### PR TITLE
Added example of how to use a different model to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Usage
 
 To analyze a log file, run the script with the following command line arguments:
 - `url` (required): The URL of the log file to be analyzed.
-- `--model` (optional, default: "Mistral-7B-Instruct-v0.2-GGUF"): The path or URL of the language model for analysis.
+- `--model` (optional, default: "Mistral-7B-Instruct-v0.2-GGUF"): The path or URL of the language model for analysis. As we are using LLama.cpp we want this to be in the `gguf` format. You can include the download link to the model here. If the model is already on your machine it will skip the download.
 - `--summarizer` (optional, default: "drain"): Choose between LLM and Drain template miner as the log summarizer. You can also provide the path to an existing language model file instead of using a URL.
 - `--n_lines` (optional, default: 5): The number of lines per chunk for LLM analysis. This only makes sense when you are summarizing with LLM.
 
@@ -40,6 +40,10 @@ Example usage:
 Or if the log file is stored locally:
 
     logdetective ./data/logs.txt
+
+Example you want to use a different model:
+
+    logdetective https://example.com/logs.txt --model https://huggingface.co/QuantFactory/Meta-Llama-3-8B-Instruct-GGUF/resolve/main/Meta-Llama-3-8B-Instruct.Q5_K_S.gguf?download=true
 
 
 Real Example


### PR DESCRIPTION
I was a bit confused when trying to run logdetective with different models as I did not realize that the download URL had to be passed into the --model argument. I added a bit of text to explain this as well as provided a quick example.