### PR TITLE
Add support for OIDC publishing to PyPi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,11 @@ on:
 jobs:
   pypi_release:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/logdetective
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v2
@@ -18,7 +23,7 @@ jobs:
       - name: Add Poetry to path
         run: echo "${HOME}/.poetry/bin" >> $GITHUB_PATH
       - run: poetry install
-      - name: Set token for pypi
-        run: poetry config pypi-token.pypi "${{ secrets.PYPI_TOKEN_CI }}"
-      - name: Build and publish package
-        run: poetry publish --build
+      - name: Build package
+        run: poetry build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This is recommended way for publishing packages.
https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect

I've added this workflow as trusted into pypi.org configuration so everything should be prepared. After this is merged we can remove `PYPI_TOKEN_CI` from secrets.

Tested here: https://github.com/jkonecny12/logdetective/actions/runs/10008644803