### PR TITLE
ci: fix the vcs-diff-lint integration

### DIFF
--- a/.github/workflows/python-diff-lint.yml
+++ b/.github/workflows/python-diff-lint.yml
@@ -16,7 +16,9 @@ jobs:
       - name: VCS Diff Lint
         uses: fedora-copr/vcs-diff-lint-action@v1
         id: VCS_Diff_Lint
-        install_rpm_packages: ["python3-numpy"]
+        with:
+          install_rpm_packages: |
+            python3-numpy
 
       - name: Upload artifact with detected defects in SARIF format
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The action option "install_rpm_packages" accepts a space-separated string.