### PR TITLE
Improve server part of the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ $ ll $MODELS_PATH
 
 If the variable is not set, `./models` is mounted inside by default.
 
+Model can be downloaded by:
+```
+$ curl -L -o models/mistral-7b-instruct-v0.2.Q4_K_S.gguf https://huggingface.co/fedora-copr/Mistral-7B-Instruct-v0.2-GGUF/resolve/main/ggml-model-Q4_K_S.gguf
+```
+
 
 License
 -------


### PR DESCRIPTION
For easy setup of the server users have to have model locally downloaded, however, we are missing easy guide to know which model should be used or how to download it.

Let's make things a bit more accessible.