### PR TITLE
Removing push trigger as per recommendations

### DIFF
--- a/.github/workflows/python-diff-lint.yml
+++ b/.github/workflows/python-diff-lint.yml
@@ -2,7 +2,6 @@
 name: Lint Python issues
 
 on:
-  push:
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
The lint job was failing due to insufficient access rights. [1] This should clear things up.

[1] https://github.com/fedora-copr/logdetective/actions/runs/12474784958/job/34817297269?pr=96 