### PR TITLE
ci: allow external contributors to write security events

### DIFF
--- a/.github/workflows/python-diff-lint.yml
+++ b/.github/workflows/python-diff-lint.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   python-lint-job:
     runs-on: ubuntu-latest
+
+    permissions:
+      # required for all workflows
+      security-events: write
+
     steps:
       - name: Repository checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Per upstream howto:
https://github.com/fedora-copr/vcs-diff-lint-action

Relates: #97