### PR TITLE
fix cuda image build

### DIFF
--- a/Containerfile.cuda
+++ b/Containerfile.cuda
@@ -8,20 +8,15 @@ RUN dnf install -y python3-requests python3-pip gcc gcc-c++ python3-scikit-build
     && echo "gpgcheck=1" >> /etc/yum.repos.d/cuda.repo \
     && echo "gpgkey=https://developer.download.nvidia.com/compute/cuda/repos/fedora39/x86_64/D42D0685.pub" >> /etc/yum.repos.d/cuda.repo \
     && dnf module enable -y nvidia-driver:555-dkms \
-    && dnf install -y cuda-compiler-12-5 cuda-toolkit-12-5 nvidia-driver-cuda-libs cmake \
+    && dnf install -y cuda-compiler-12-6 cuda-toolkit-12-6 nvidia-driver-cuda-libs cmake \
     && dnf clean all
-ENV CMAKE_ARGS="-DGGML_CUDA=on"
 ENV LLAMACPP_VER="b4501"
-ENV PATH=${PATH}:/usr/local/cuda-12.5/bin/
-# some of these are either not in F39 or have old version
-# RUN pip3 install llama_cpp_python==0.2.85 starlette drain3 sse-starlette starlette-context \
-#     pydantic-settings fastapi[standard] \
-#     && mkdir /src
+ENV PATH=${PATH}:/usr/local/cuda-12.6/bin/
 
 # Clone, checkout, build and move llama.cpp server to path
 RUN git clone https://github.com/ggerganov/llama.cpp.git && \
     cd llama.cpp && \
     git checkout $LLAMACPP_VER && \
-    cmake -B build && \
+    cmake -B build -DGGML_CUDA=ON && \
     cmake --build build --config Release -j 4 -t llama-server && \
     mv ./build/bin/llama-server /bin/llama-server


### PR DESCRIPTION
* bump cuda to 12.6 - that's what we have on the host
* enable cuda build directly via cmake CLI arg: it wasn't picking up the
  env var
* drop logdetective installation, not needed for llama-server