### PR TITLE
Adding option to provide authentication token for LLM

### DIFF
--- a/.env
+++ b/.env
@@ -19,3 +19,5 @@ LLAMA_ARG_CTX_SIZE=32768
 LLAMA_ARG_N_PARALLEL=4
 # Path to Logdetective server configuration file
 LOGDETECTIVE_SERVER_CONF="/config.yml"
+# Authorization token for remote LLM API
+# LLM_API_TOKEN="$API_SECRET"

--- a/logdetective/server/server.py
+++ b/logdetective/server/server.py
@@ -29,7 +29,7 @@ LLM_CPP_SERVER_TIMEOUT = os.environ.get("LLAMA_CPP_SERVER_TIMEOUT", 600)
 LOG_SOURCE_REQUEST_TIMEOUT = os.environ.get("LOG_SOURCE_REQUEST_TIMEOUT", 60)
 API_TOKEN = os.environ.get("LOGDETECTIVE_TOKEN", None)
 SERVER_CONFIG_PATH = os.environ.get("LOGDETECTIVE_SERVER_CONF", None)
-
+LLM_API_TOKEN = os.environ.get("LLM_API_TOKEN", None)
 
 SERVER_CONFIG = load_server_config(SERVER_CONFIG_PATH)
 
@@ -126,11 +126,16 @@ async def submit_text(
         "model": model,
     }
 
+    headers = {"Content-Type": "application/json"}
+
+    if LLM_API_TOKEN:
+        headers["Authorization"] = f"Bearer {LLM_API_TOKEN}"
+
     try:
         # Expects llama-cpp server to run on LLM_CPP_SERVER_ADDRESS:LLM_CPP_SERVER_PORT
         response = requests.post(
             f"{LLM_CPP_SERVER_ADDRESS}:{LLM_CPP_SERVER_PORT}/v1/completions",
-            headers={"Content-Type": "application/json"},
+            headers=headers,
             data=json.dumps(data),
             timeout=int(LLM_CPP_SERVER_TIMEOUT),
             stream=stream,


### PR DESCRIPTION
If we want to use LLMs from third party providers we need to supply authentication tokens.
OpenAI APIs [1][2] expect this as part of the request header, the same approach was adopted by perplexity [3] and others so it makes sense to support it.

[1]https://platform.openai.com/docs/api-reference/completions
[2]https://platform.openai.com/docs/api-reference/chat/create
[3]https://docs.perplexity.ai/api-reference/chat-completions
[4]https://huggingface.co/docs/api-inference/en/tasks/chat-completion?code=curl#code-snippet-example-for-conversational-llms