### PR TITLE
sync production configuration to git (registry namespace, gunicorn timeout)

### DIFF
--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   llama-cpp:
-    image: logdetective/runtime:latest-cuda
+    image: quay.io/logdetective/runtime:latest-cuda
     build:
       context: .
       dockerfile: ./Containerfile.cuda
@@ -18,7 +18,7 @@ services:
     devices:
       - nvidia.com/gpu=all
   server:
-    image: logdetective/runtime:latest
+    image: quay.io/logdetective/runtime:latest
     build:
       context: .
       dockerfile: ./Containerfile

--- a/server/gunicorn-prod.config.py
+++ b/server/gunicorn-prod.config.py
@@ -2,8 +2,9 @@ import os
 bind = f"0.0.0.0:{os.environ['LOGDETECTIVE_SERVER_PORT']}"
 worker_class = "uvicorn.workers.UvicornWorker"
 workers = 2
-# timeout set to 120 - 2 minutes should be enough for one LLM execution in production on a GPU
-timeout = 120
+# timeout set to 600 seconds; with 32 clusters and several runs in parallel, it
+# can take even 10 minutes for a query to complete
+timeout = 600
 # write to stdout
 accesslog = '-'
 # certfile = "/src/server/cert.pem"


### PR DESCRIPTION
```
increase backend API timeout to 10 minutes

2 minutes is not enough sadly, especially now that we make much more
snippets
```


```
prod compose: point to quay.io images

we need to point to our officially built quay.io images, otherwise
podman treats it as localhost
```