### PR TITLE
Moving to metadata action v5.7.0, fixing suffix for latest tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,25 +61,28 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
             type=sha
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       # Extract metadata (tags, labels) for Docker cuda image
       # https://github.com/docker/metadata-action
       - name: Extract metadata for cuda image
         id: meta-cuda
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+            suffix=-cuda
           tags: |
-            type=semver,pattern={{version}},suffix=-cuda
-            type=sha,suffix=-cuda
-            type=raw,value=latest,suffix=-cuda
+            type=semver,pattern={{version}}
+            type=sha
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       # Build Docker image with Buildx
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
This PR update metadat action to v5.7.0 while also changing how the `latest` tag is applied.