### PR TITLE
Listen for GitLab job_event webhooks

### DIFF
--- a/.github/workflows/python-diff-lint.yml
+++ b/.github/workflows/python-diff-lint.yml
@@ -25,6 +25,8 @@ jobs:
           install_rpm_packages: |
             python3-numpy
             python3-pytest
+            python3-fastapi
+            python3-gitlab
           linter_tags: |
             pylint
             ruff

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -101,7 +101,11 @@ class GitLabConfig(BaseModel):
     """Model for GitLab configuration of logdetective server."""
 
     url: str = None
+    api_url: str = None
     api_token: str = None
+
+    # Maximum size of artifacts.zip in MiB. (default: 300 MiB)
+    max_artifact_size: int = 300
 
     def __init__(self, data: Optional[dict] = None):
         super().__init__()
@@ -109,7 +113,9 @@ class GitLabConfig(BaseModel):
             return
 
         self.url = data.get("url", "https://gitlab.com")
+        self.api_url = f"{self.url}/api/v4"
         self.api_token = data.get("api_token", None)
+        self.max_artifact_size = int(data.get("max_artifact_size")) * 1024 * 1024
 
 
 class GeneralConfig(BaseModel):

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -69,11 +69,27 @@ class ExtractorConfig(BaseModel):
         self.verbose = data.get("verbose", False)
 
 
+class GitLabConfig(BaseModel):
+    """Model for GitLab configuration of logdetective server."""
+
+    url: str = None
+    api_token: str = None
+
+    def __init__(self, data: Optional[dict] = None):
+        super().__init__()
+        if data is None:
+            return
+
+        self.url = data.get("url", "https://gitlab.com")
+        self.api_token = data.get("api_token", None)
+
+
 class Config(BaseModel):
     """Model for configuration of logdetective server."""
 
     inference: InferenceConfig = InferenceConfig()
     extractor: ExtractorConfig = ExtractorConfig()
+    gitlab: GitLabConfig = GitLabConfig()
 
     def __init__(self, data: Optional[dict] = None):
         super().__init__()
@@ -83,3 +99,4 @@ class Config(BaseModel):
 
         self.inference = InferenceConfig(data.get("inference"))
         self.extractor = ExtractorConfig(data.get("extractor"))
+        self.gitlab = GitLabConfig(data.get("gitlab"))

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -83,6 +83,17 @@ class GitLabConfig(BaseModel):
         self.url = data.get("url", "https://gitlab.com")
         self.api_token = data.get("api_token", None)
 
+class GeneralConfig(BaseModel):
+    """General config options for Log Detective"""
+
+    packages: List[str] = None
+
+    def __init__(self, data: Optional[dict] = None):
+        super().__init__()
+        if data is None:
+            return
+
+        self.packages = data.get("packages", list())
 
 class Config(BaseModel):
     """Model for configuration of logdetective server."""
@@ -90,6 +101,7 @@ class Config(BaseModel):
     inference: InferenceConfig = InferenceConfig()
     extractor: ExtractorConfig = ExtractorConfig()
     gitlab: GitLabConfig = GitLabConfig()
+    general: GeneralConfig = GeneralConfig()
 
     def __init__(self, data: Optional[dict] = None):
         super().__init__()
@@ -100,3 +112,4 @@ class Config(BaseModel):
         self.inference = InferenceConfig(data.get("inference"))
         self.extractor = ExtractorConfig(data.get("extractor"))
         self.gitlab = GitLabConfig(data.get("gitlab"))
+        self.general = GeneralConfig(data.get("general"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ huggingface-hub = ">0.23.2"
 # rawhide has numpy 2, F40 and F41 are still on 1.26
 # we need to support both versions
 numpy = ">=1.26.0"
+python-gitlab = "^5.6.0"
 
 [tool.poetry.group.server.dependencies]
 fastapi = "^0.115.8"

--- a/server/config.yml
+++ b/server/config.yml
@@ -5,3 +5,6 @@ extractor:
   context: true
   max_clusters: 32
   verbose: false
+gitlab:
+  url: https://gitlab.com
+  api_token: glpat-XXXXXX

--- a/server/config.yml
+++ b/server/config.yml
@@ -8,6 +8,7 @@ extractor:
 gitlab:
   url: https://gitlab.com
   api_token: glpat-XXXXXX
+  max_artifact_size: 300
 general:
   packages:
     - osci-internal-test-package

--- a/server/config.yml
+++ b/server/config.yml
@@ -8,3 +8,6 @@ extractor:
 gitlab:
   url: https://gitlab.com
   api_token: glpat-XXXXXX
+general:
+  packages:
+    - osci-internal-test-package


### PR DESCRIPTION
Listens for the events and queries the GitLab API for additional
information leading to the logs of failed builds.

Retrieves the logs and analyzes them to determine the correct log to
submit to the Log Detective processing.

Fixes: https://issues.redhat.com/browse/LD-8

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>
