### PR TITLE
Implementing interface with /chat/completions endpoint

### DIFF
--- a/logdetective/utils.py
+++ b/logdetective/utils.py
@@ -7,7 +7,7 @@ import requests
 
 from llama_cpp import Llama, CreateCompletionResponse, CreateCompletionStreamResponse
 from logdetective.constants import PROMPT_TEMPLATE, SNIPPET_DELIMITER
-
+from logdetective.server.models import AnalyzedSnippet
 
 LOG = logging.getLogger("logdetective")
 
@@ -175,11 +175,11 @@ def format_snippets(snippets: list[str] | list[Tuple[int, str]]) -> str:
     return summary
 
 
-def format_analyzed_snippets(snippets: list[Dict]) -> str:
+def format_analyzed_snippets(snippets: list[AnalyzedSnippet]) -> str:
     """Format snippets for submission into staged prompt."""
     summary = f"\n{SNIPPET_DELIMITER}\n".join(
         [
-            f"[{e['snippet']}] at line [{e["line_number"]}]: [{e['comment']['choices'][0]['text']}]"
+            f"[{e.text}] at line [{e.line_number}]: [{e.explanation.text}]"
             for e in snippets
         ]
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ from logdetective.utils import (
     format_snippets,
     format_analyzed_snippets,
 )
+from logdetective.server.models import AnalyzedSnippet, Explanation
 
 test_snippets = [
     # Simple
@@ -12,16 +13,15 @@ test_snippets = [
     [(10, "Snippet 1"), (120, "Snippet 1"), (240, "Snippet 1")],
 ]
 
-# Contents of "comment" follow structure of OpenAI API completions
-# response format https://platform.openai.com/docs/api-reference/completions
 test_analyzed_snippets = [
     [
-        {
-            "snippet": e[1],
-            "line_number": e[0],
-            "comment": {"choices": [{"text": f"Comment for snippet on line {e[0]}"}]},
-        }
-        for e in test_snippets[0]
+        AnalyzedSnippet(
+            text=e[1],
+            line_number=e[0],
+            explanation=Explanation(
+                text=f"Comment for snippet on line {e[0]}",
+                logprobs=[{"logprob": 66.6}, {"logprob": 99.9}, {"logprob": 1.0}]))
+        for e in test_snippets[1]
     ]
 ]
 


### PR DESCRIPTION
* New response model for Log Detective API
* Configuration option for choosing alternative endpoints
* Removed dependence on llama-cpp response models
* Disabled R0913,R0917 pylint rules in several key places, as I consider passing all of these in struct an overkill