### PR TITLE
prod deployment: point to latest version

### DIFF
--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   llama-cpp:
-    image: quay.io/logdetective/runtime:latest-cuda
+    image: quay.io/logdetective/runtime:0.2.14-cuda
     build:
       context: .
       dockerfile: ./Containerfile.cuda
@@ -18,7 +18,7 @@ services:
     devices:
       - nvidia.com/gpu=all
   server:
-    image: quay.io/logdetective/runtime:latest
+    image: quay.io/logdetective/runtime:0.2.14
     build:
       context: .
       dockerfile: ./Containerfile


### PR DESCRIPTION
In 78e1db0c27381aaa9f48955870eda21ea4896f20 we have changed the way we
tag our release container images - we no longer have `latest-cuda`.

There we need to pin to specific version for the production deployment.

![image](https://github.com/user-attachments/assets/6b226451-3ec5-461f-b1cd-4e57a2097644)
