### PR TITLE
Adding log line number information to the snippet

### DIFF
--- a/logdetective/constants.py
+++ b/logdetective/constants.py
@@ -31,7 +31,7 @@ Answer:
 """
 
 SNIPPET_PROMPT_TEMPLATE = """
-Analyse following RPM build log snippet. Decribe contents accurately, without speculation or suggestions for resolution.
+Analyse following RPM build log snippet. Describe contents accurately, without speculation or suggestions for resolution.
 
 Snippet:
 

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -28,10 +28,13 @@ class StagedResponse(Response):
         https://llama-cpp-python.readthedocs.io/en/latest/api-reference/#llama_cpp.llama_types.CreateCompletionResponse
     response_certainty: float
     snippets:
-        list of dictionaries { 'snippet' : '<original_text>, 'comment': CreateCompletionResponse }
+        list of dictionaries {
+        'snippet' : '<original_text>,
+        'comment': CreateCompletionResponse,
+        'line_number': '<location_in_log>' }
     """
 
-    snippets: List[Dict[str, str | Dict]]
+    snippets: List[Dict[str, str | Dict | int]]
 
 
 class InferenceConfig(BaseModel):


### PR DESCRIPTION
Location of representative cluster sample, meaning the first log chunk matching created cluster, is now stored and used as part of prompt when using the Drain extractor.

Further changes:

* Fixing typo in SNIPPET_PROMPT_TEMPLATE
* Ammending StagedResponse model docstring
* Return type annotations for get_chunks utility function
* Refactoring snippet joining into format_analyzed_snippets function