### PR TITLE
Relax dependencies for F40 and F41

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -850,4 +850,4 @@ server = ["fastapi", "pydantic", "pyyaml"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "ace7fbe8f8c72ba5e2c4bbd5bcc2c405a98f941069c8fa436858a539b1827612"
+content-hash = "fe8c8c1bfd6bea904a855070c34e79ec914935453cdae8bc3632bae6e05cba56"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,10 @@ huggingface-hub = ">0.23.2"
 # rawhide has numpy 2, F40 and F41 are still on 1.26
 # we need to support both versions
 numpy = ">=1.26.0"
-python-gitlab = "^5.6.0"
+python-gitlab = ">=4.4.0"
 
-pydantic = {version = "^2.10.6", optional = true }
-fastapi = {version = "^0.115.8", optional = true }
+pydantic = {version = "^2.8.2", optional = true }
+fastapi = {version = ">=0.111.1", optional = true }
 pyyaml = {version = "^6.0.1", optional = true }
 
 [tool.poetry.extras]


### PR DESCRIPTION
With these, I am able to successfully build RPM package for all currently active Fedora versions.