### PR TITLE
Minimize differences between devel and production composes

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,6 @@
 # compose sources this file
 # docs: https://docs.docker.com/compose/environment-variables/set-environment-variables/
+ENV="devel"
 LLAMA_CPP_SERVER_PORT=8000
 LLAMA_CPP_HOST=llama-cpp-server
 LOGDETECTIVE_SERVER_PORT=8080

--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -1,50 +1,19 @@
 services:
   llama-cpp:
-    image: quay.io/logdetective/runtime:0.3.3-cuda
-    build:
-      context: .
-      dockerfile: ./Containerfile.cuda
-    hostname: "${LLAMA_CPP_HOST}"
-    command: "llama-server --host 0.0.0.0 --port ${LLAMA_CPP_SERVER_PORT}"
-    stdin_open: true
-    tty: true
-    env_file: .env
-    ports:
-      - "${LLAMA_CPP_SERVER_PORT:-8000}:${LLAMA_CPP_SERVER_PORT:-8000}"
-    volumes:
-      - ${MODELS_PATH-./models}:/models:Z
+    extends:
+      file: docker-compose.yaml
+      service: llama-cpp
     # these lines are needed for CUDA acceleration
     devices:
       - nvidia.com/gpu=all
   server:
-    image: quay.io/logdetective/runtime:0.3.3
-    build:
-      context: .
-      dockerfile: ./Containerfile
-    depends_on:
-      - postgres
-    hostname: logdetective-server
-    stdin_open: true
-    tty: true
-    volumes:
-      - .:/src/:z
-      - ./server/config.yml:/config.yml:z
-      - ./files/run_server.sh:/run_server.sh:z
-    ports:
-      - "${LOGDETECTIVE_SERVER_PORT:-8080}:${LOGDETECTIVE_SERVER_PORT:-8080}"
-    env_file: .env
-    # so gunicorn can find logdetective python module
-    # and alembic can find alembic.ini
-    working_dir: /src
-    entrypoint: ["/run_server.sh"]
-
+    extends:
+      file: docker-compose.yaml
+      service: server
   postgres:
-    image: quay.io/sclorg/postgresql-15-c9s
-    volumes:
-      - database_data:/var/lib/postgresql/data
-    ports:
-      - "${POSTGRESQL_PORT:-5432}:${POSTGRESQL_PORT:-5432}"
-    env_file: .env
+    extends:
+      file: docker-compose.yaml
+      service: postgres
 
 volumes:
   database_data:

--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   llama-cpp:
-    image: quay.io/logdetective/runtime:0.2.14-cuda
+    image: quay.io/logdetective/runtime:0.3.3-cuda
     build:
       context: .
       dockerfile: ./Containerfile.cuda
@@ -18,7 +18,7 @@ services:
     devices:
       - nvidia.com/gpu=all
   server:
-    image: quay.io/logdetective/runtime:0.2.14
+    image: quay.io/logdetective/runtime:0.3.3
     build:
       context: .
       dockerfile: ./Containerfile
@@ -28,9 +28,9 @@ services:
     stdin_open: true
     tty: true
     volumes:
-      - .:/src/:Z
-      - ./server/config.yml:/config.yml:Z
-      - ./files/run_server.sh:/run_server.sh:Z
+      - .:/src/:z
+      - ./server/config.yml:/config.yml:z
+      - ./files/run_server.sh:/run_server.sh:z
     ports:
       - "${LOGDETECTIVE_SERVER_PORT:-8080}:${LOGDETECTIVE_SERVER_PORT:-8080}"
     env_file: .env

--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   llama-cpp:
     image: quay.io/logdetective/runtime:0.3.3-cuda

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   llama-cpp:
-    image: logdetective/runtime:latest-cuda
+    image: quay.io/logdetective/runtime:0.3.3-cuda
     build:
       context: .
       dockerfile: ./Containerfile.cuda
@@ -20,7 +20,7 @@ services:
     # security_opt:
     #   - "label=disable"
   server:
-    image: logdetective/runtime:latest
+    image: quay.io/logdetective/runtime:0.3.3
     depends_on:
       - postgres
     build:
@@ -31,8 +31,8 @@ services:
     tty: true
     volumes:
       - .:/src/:z
-      - ./server/config.yml:/config.yml:Z
-      - ./files/run_server.sh:/run_server.sh:Z
+      - ./server/config.yml:/config.yml:z
+      - ./files/run_server.sh:/run_server.sh:z
     ports:
       - "${LOGDETECTIVE_SERVER_PORT:-8080}:${LOGDETECTIVE_SERVER_PORT:-8080}"
     env_file: .env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   llama-cpp:
     image: quay.io/logdetective/runtime:0.3.3-cuda

--- a/files/run_server.sh
+++ b/files/run_server.sh
@@ -19,8 +19,11 @@ if [[ $n -eq $ATTEMPTS ]]; then
     exit 1
 fi
 
+if [ "$ENV" == "production" ]; then
+    conf="/src/server/gunicorn-prod.config.py"
+else
+    conf="/src/server/gunicorn-dev.config.py"
+fi
+
 echo "Starting application server..."
-# --no-reload: doesn't work in a container - `PermissionError: Permission denied (os error 13) about ["/proc"]`
-# command: fastapi dev /src/logdetective/server.py --host 0.0.0.0 --port $LOGDETECTIVE_SERVER_PORT --no-reload
-# timeout set to 240 - 4 minutes should be enough for one LLM execution locally on a CPU
-gunicorn -k uvicorn.workers.UvicornWorker --timeout 240 logdetective.server.server:app -b 0.0.0.0:${LOGDETECTIVE_SERVER_PORT}
+exec gunicorn -c "$conf" logdetective.server.server:app

--- a/server/gunicorn-dev.config.py
+++ b/server/gunicorn-dev.config.py
@@ -1,0 +1,13 @@
+import os
+
+bind = f"0.0.0.0:{os.environ['LOGDETECTIVE_SERVER_PORT']}"
+worker_class = "uvicorn.workers.UvicornWorker"
+workers = 1
+# timeout set to 240 - 4 minutes should be enough for one LLM execution locally
+# on a CPU
+timeout = 600
+# write to stdout
+accesslog = "-"
+# certfile = "/src/server/cert.pem"
+# keyfile = "/src/server/privkey.pem"
+# ca_certs = "/src/server/fullchain.pem"


### PR DESCRIPTION
My goal is to eventually remove the `docker-compose-prod.yaml` completely and keep just `docker-compose.yaml` but this is IMHO a good first step.

I tested this in production and it works fine.