### PR TITLE
Webhook: submit build failure to LLM and log the response

### DIFF
--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -21,7 +21,7 @@ class JobHook(BaseModel):
 
     # The identifier of the job. We only care about 'build_rpm' and
     # 'build_centos_stream_rpm' jobs.
-    build_name: str = Field(pattern=r"^build(_.*)?_rpm$")
+    build_name: str = Field(pattern=r"^build.*rpm$")
 
     # A string representing the job status. We only care about 'failed' jobs.
     build_status: str = Field(pattern=r"^failed$")

--- a/logdetective/server/server.py
+++ b/logdetective/server/server.py
@@ -322,6 +322,12 @@ async def analyze_log_staged(build_log: BuildLog):
     while lacking  result, params or query fields.
     """
     log_text = process_url(build_log.url)
+
+    return await perform_staged_analysis(log_text=log_text)
+
+
+async def perform_staged_analysis(log_text: str) -> StagedResponse:
+    """Submit the log file snippets to the LLM and retrieve their results"""
     log_summary = mine_logs(log_text)
 
     # Process snippets asynchronously

--- a/logdetective/server/server.py
+++ b/logdetective/server/server.py
@@ -455,11 +455,12 @@ async def process_gitlab_job_event(job_hook):
         raise
 
     # Submit log to Log Detective and await the results.
-    response = await submit_log_to_llm(preprocessed_log)
+    log_text = preprocessed_log.read().decode(encoding="utf-8")
+    staged_response = await perform_staged_analysis(log_text=log_text)
     preprocessed_log.close()
 
     # Add the Log Detective response as a comment to the merge request
-    await comment_on_mr(merge_request_id, response)
+    await comment_on_mr(merge_request_id, staged_response)
 
 
 class LogsTooLargeError(RuntimeError):
@@ -588,15 +589,11 @@ async def check_artifacts_file_size(job):
     return content_length <= SERVER_CONFIG.gitlab.max_artifact_size
 
 
-async def submit_log_to_llm(log):
-    """Stream the log to the LLM for processing"""
-    # TODO: query the LLM with the log contents  # pylint: disable=fixme
-    # This function will be implemented later; right now it does nothing.
-    LOG.debug("Log contents:\n%s", log.read())
-    return ""
-
-
-async def comment_on_mr(merge_request_id: int, response: str):  # pylint: disable=unused-argument
+async def comment_on_mr(merge_request_id: int, response: StagedResponse):
     """Add the Log Detective response as a comment to the merge request"""
-    # TODO: Implement this  # pylint: disable=fixme
-    pass  # pylint: disable=unnecessary-pass
+    LOG.debug("Primary Explanation for MR %d: %s", merge_request_id, response.explanation.text)
+
+    for snippet in response.snippets:
+        LOG.debug("")
+        LOG.debug("%d: %s", snippet.line_number, snippet.text)
+        LOG.debug("%s", snippet.explanation)


### PR DESCRIPTION
## webhook: Submit the log text to the LLM

This will perform staged analysis. As a temporary placeholder, it also
logs the response in human-readable format. This will be replaced by a
jinja2 template in a future patch.

Fixes: https://issues.redhat.com/browse/LD-16

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>

## Make /analyze/staged body a separate function

This will allow it to be reused by the webhook handler without needing a
URL for the log text.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>


Depends-on: #139 
This takes advantage of the new, much more understandable `Explanation` model.