### PR TITLE
Generate Gitlab merge request comments

### DIFF
--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -21,7 +21,7 @@ class JobHook(BaseModel):
 
     # The identifier of the job. We only care about 'build_rpm' and
     # 'build_centos_stream_rpm' jobs.
-    build_name: str = Field(pattern=r"^build(_.*)?_rpm$")
+    build_name: str = Field(pattern=r"^build.*rpm$")
 
     # A string representing the job status. We only care about 'failed' jobs.
     build_status: str = Field(pattern=r"^failed$")

--- a/logdetective/server/server.py
+++ b/logdetective/server/server.py
@@ -322,6 +322,12 @@ async def analyze_log_staged(build_log: BuildLog):
     while lacking  result, params or query fields.
     """
     log_text = process_url(build_log.url)
+
+    return await perform_staged_analysis(log_text=log_text)
+
+
+async def perform_staged_analysis(log_text: str) -> StagedResponse:
+    """Submit the log file snippets to the LLM and retrieve their results"""
     log_summary = mine_logs(log_text)
 
     # Process snippets asynchronously

--- a/logdetective/server/server.py
+++ b/logdetective/server/server.py
@@ -455,11 +455,12 @@ async def process_gitlab_job_event(job_hook):
         raise
 
     # Submit log to Log Detective and await the results.
-    response = await submit_log_to_llm(preprocessed_log)
+    log_text = preprocessed_log.read().decode(encoding="utf-8")
+    staged_response = await perform_staged_analysis(log_text=log_text)
     preprocessed_log.close()
 
     # Add the Log Detective response as a comment to the merge request
-    await comment_on_mr(merge_request_id, response)
+    await comment_on_mr(merge_request_id, staged_response)
 
 
 class LogsTooLargeError(RuntimeError):
@@ -588,15 +589,11 @@ async def check_artifacts_file_size(job):
     return content_length <= SERVER_CONFIG.gitlab.max_artifact_size
 
 
-async def submit_log_to_llm(log):
-    """Stream the log to the LLM for processing"""
-    # TODO: query the LLM with the log contents  # pylint: disable=fixme
-    # This function will be implemented later; right now it does nothing.
-    LOG.debug("Log contents:\n%s", log.read())
-    return ""
-
-
-async def comment_on_mr(merge_request_id: int, response: str):  # pylint: disable=unused-argument
+async def comment_on_mr(merge_request_id: int, response: StagedResponse):
     """Add the Log Detective response as a comment to the merge request"""
-    # TODO: Implement this  # pylint: disable=fixme
-    pass  # pylint: disable=unnecessary-pass
+    LOG.debug("Primary Explanation for MR %d: %s", merge_request_id, response.explanation.text)
+
+    for snippet in response.snippets:
+        LOG.debug("")
+        LOG.debug("%d: %s", snippet.line_number, snippet.text)
+        LOG.debug("%s", snippet.explanation)

--- a/logdetective/server/templates/gitlab_comment.md.j2
+++ b/logdetective/server/templates/gitlab_comment.md.j2
@@ -1,0 +1,66 @@
+The package {{ package }} failed to build, here is a possible explanation why.
+
+Please know that the explanation was provided by AI and may be incorrect.
+In this case, we are {{ certainty }}% certain of the response :neutral_face:.
+
+{{ explanation }}
+
+<details>
+<ul>
+{% for snippet in snippets %}
+<li>
+<code>
+Line {{ snippet.line_number }}: {{ snippet.text }}
+</code>
+{{ snippet.explanation }}
+</li>
+{% endfor %}
+</ul>
+</details>
+
+<details>
+  <summary>Logs</summary>
+  <p>
+    Log Detective analyzed the following logs files to provide an explanation:
+  </p>
+
+  <ul>
+    <li><a href="{{ log_url }}">{{ log_url }}</a></li>
+  </ul>
+
+  <p>
+    Additional logs are available from:
+    <ul>
+    <li><a href="{{ artifacts_url }}">artifacts.zip</a></li>
+  </ul>
+  </p>
+
+  <p>
+    Please know that these log files are automatically removed after some
+    time, so you might need a backup.
+  </p>
+</details>
+
+<details>
+  <summary>Help</summary>
+  <p>Don't hesitate to reach out.</p>
+
+  <ul>
+    <li><a href="https://github.com/fedora-copr/logdetective">Upstream</a></li>
+    <li><a href="https://github.com/fedora-copr/logdetective/issues">Issue tracker</a></li>
+    <li><a href="https://redhat.enterprise.slack.com/archives/C06DWNVKKDE">Slack</a></li>
+    <li><a href="https://log-detective.com/documentation">Documentation</a></li>
+  </ul>
+</details>
+
+
+---
+This comment was created by [Log Detective][log-detective].
+
+Was the provided feedback accurate and helpful? <br>Please vote with :thumbsup:
+or :thumbsdown: to help us improve.<br>
+
+
+
+[log-detective]: https://log-detective.com/
+[contact]: https://github.com/fedora-copr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,10 @@ description = "Log using LLM AI to search for build/test failures and provide id
 authors = ["Jiri Podivin <jpodivin@gmail.com>"]
 license = "Apache-2.0"
 readme = "README.md"
-include = ["logdetective/drain3.ini"]
+include = [
+    "logdetective/drain3.ini",
+    "logdetective/server/templates/gitlab_comment.md.j2",
+]
 packages = [
     { include = "logdetective" }
 ]


### PR DESCRIPTION
This patch adds support for converting the results of the staged
analysis into a comment to be submitted against the original merge
request that triggered the analysis.

It takes advantage of Jinja 2 templating to generate the content in
Markdown format.

This patch also modifies the return values of the log preprocessing
function to return the URL of the detected log so that it can be linked
in the comment.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>


It depends on (and therefore includes in this stack of patches) #161 