### PR TITLE
Complete the initial Gitlab Pipeline integration

### DIFF
--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -21,7 +21,7 @@ class JobHook(BaseModel):
 
     # The identifier of the job. We only care about 'build_rpm' and
     # 'build_centos_stream_rpm' jobs.
-    build_name: str = Field(pattern=r"^build(_.*)?_rpm$")
+    build_name: str = Field(pattern=r"^build.*rpm$")
 
     # A string representing the job status. We only care about 'failed' jobs.
     build_status: str = Field(pattern=r"^failed$")

--- a/logdetective/server/server.py
+++ b/logdetective/server/server.py
@@ -318,6 +318,12 @@ async def analyze_log_staged(build_log: BuildLog):
     while lacking  result, params or query fields.
     """
     log_text = process_url(build_log.url)
+
+    return await perform_staged_analysis(log_text=log_text)
+
+
+async def perform_staged_analysis(log_text: str) -> StagedResponse:
+    """Submit the log file snippets to the LLM and retrieve their results"""
     log_summary = mine_logs(log_text)
 
     # Process snippets asynchronously

--- a/logdetective/server/server.py
+++ b/logdetective/server/server.py
@@ -1,9 +1,12 @@
 import asyncio
+import gitlab.v4
+import gitlab.v4.objects
+import jinja2
 import json
 import os
 import re
 import zipfile
-from pathlib import PurePath
+from pathlib import Path, PurePath
 from tempfile import TemporaryFile
 from typing import List, Annotated, Tuple, Dict, Any
 
@@ -425,6 +428,11 @@ async def process_gitlab_job_event(job_hook):
     # Retrieve data about the job from the GitLab API
     job = await asyncio.to_thread(project.jobs.get, job_hook.build_id)
 
+    # For easy retrieval later, we'll add project_name and project_url to the
+    # job object
+    job.project_name = project.name
+    job.project_url = project.web_url
+
     # Retrieve the pipeline that started this job
     pipeline = await asyncio.to_thread(project.pipelines.get, job_hook.pipeline_id)
 
@@ -445,7 +453,7 @@ async def process_gitlab_job_event(job_hook):
     LOG.debug("Retrieving log artifacts")
     # Retrieve the build logs from the merge request artifacts and preprocess them
     try:
-        preprocessed_log = await retrieve_and_preprocess_koji_logs(job)
+        log_url, preprocessed_log = await retrieve_and_preprocess_koji_logs(job)
     except LogsTooLargeError:
         LOG.error("Could not retrieve logs. Too large.")
         raise
@@ -456,22 +464,22 @@ async def process_gitlab_job_event(job_hook):
     preprocessed_log.close()
 
     # Add the Log Detective response as a comment to the merge request
-    await comment_on_mr(merge_request_id, staged_response)
+    await comment_on_mr(merge_request_id, job, log_url, staged_response)
 
 
 class LogsTooLargeError(RuntimeError):
     """The log archive exceeds the configured maximum size"""
 
 
-async def retrieve_and_preprocess_koji_logs(job):
+async def retrieve_and_preprocess_koji_logs(job: gitlab.v4.objects.ProjectJob):
     """Download logs from the merge request artifacts
 
     This function will retrieve the build logs and do some minimal
     preprocessing to determine which log is relevant for analysis.
 
-    returns: An open, file-like object containing the log contents to be sent
-    for processing by Log Detective. The calling function is responsible for
-    closing this object."""
+    returns: The URL pointing to the selected log file and an open, file-like
+    object containing the log contents to be sent for processing by Log
+    Detective. The calling function is responsible for closing this object."""
 
     # Make sure the file isn't too large to process.
     if not await check_artifacts_file_size(job):
@@ -554,11 +562,13 @@ async def retrieve_and_preprocess_koji_logs(job):
 
     LOG.debug("Failed architecture: %s", failed_arch)
 
-    log_path = failed_arches[failed_arch]
-    LOG.debug("Returning contents of %s", log_path)
+    log_path = failed_arches[failed_arch].as_posix()
+
+    log_url = f"{SERVER_CONFIG.gitlab.api_url}/projects/{job.project_id}/jobs/{job.id}/artifacts/{log_path}"
+    LOG.debug("Returning contents of %s", log_url)
 
     # Return the log as a file-like object with .read() function
-    return artifacts_zip.open(log_path.as_posix())
+    return log_url, artifacts_zip.open(log_path)
 
 
 async def check_artifacts_file_size(job):
@@ -585,11 +595,44 @@ async def check_artifacts_file_size(job):
     return content_length <= SERVER_CONFIG.gitlab.max_artifact_size
 
 
-async def comment_on_mr(merge_request_id: int, response: StagedResponse):
+async def comment_on_mr(
+    merge_request_id: int,
+    job: gitlab.v4.objects.ProjectJob,
+    log_url: str,
+    response: StagedResponse,
+):
     """Add the Log Detective response as a comment to the merge request"""
-    LOG.debug("Primary Explanation for MR %d: %s", merge_request_id, response.explanation.text)
+    LOG.debug(
+        "Primary Explanation for MR %d: %s", merge_request_id, response.explanation.text
+    )
 
-    for snippet in response.snippets:
-        LOG.debug("")
-        LOG.debug("%d: %s", snippet.line_number, snippet.text)
-        LOG.debug("%s", snippet.explanation)
+    # Get the formatted comment.
+    comment = await generate_mr_comment(job, log_url, response)
+
+    # Submit a new comment to the Merge Request using the Gitlab API
+
+
+async def generate_mr_comment(
+    job: gitlab.v4.objects.ProjectJob, log_url: str, response: StagedResponse
+) -> str:
+    """Use a template to generate a comment string to submit to Gitlab"""
+
+    # Locate and load the comment template
+    script_path = Path(__file__).resolve().parent
+    template_path = Path(script_path, "templates")
+    jinja_env = jinja2.Environment(loader=jinja2.FileSystemLoader(template_path))
+    tpl = jinja_env.get_template("gitlab_comment.md.j2")
+
+    artifacts_url = f"{job.project_url}/-/jobs/{job.id}/artifacts/download"
+
+    # Generate the comment from the template
+    content = tpl.render(
+        package=job.project_name,
+        explanation=response.explanation.text,
+        certainty=f"{response.response_certainty:.2f}",
+        snippets=response.snippets,
+        log_url=log_url,
+        artifacts_url=artifacts_url,
+    )
+
+    return content

--- a/logdetective/server/server.py
+++ b/logdetective/server/server.py
@@ -634,11 +634,19 @@ async def generate_mr_comment(
 
     artifacts_url = f"{job.project_url}/-/jobs/{job.id}/artifacts/download"
 
+    if response.response_certainty >= 90:
+        emoji_face = ":slight_smile:"
+    elif response.response_certainty >= 70:
+        emoji_face = ":neutral_face:"
+    else:
+        emoji_face = ":frowning2:"
+
     # Generate the comment from the template
     content = tpl.render(
         package=job.project_name,
         explanation=response.explanation.text,
         certainty=f"{response.response_certainty:.2f}",
+        emoji_face=emoji_face,
         snippets=response.snippets,
         log_url=log_url,
         artifacts_url=artifacts_url,

--- a/logdetective/server/templates/gitlab_comment.md.j2
+++ b/logdetective/server/templates/gitlab_comment.md.j2
@@ -1,0 +1,66 @@
+The package {{ package }} failed to build, here is a possible explanation why.
+
+Please know that the explanation was provided by AI and may be incorrect.
+In this case, we are {{ certainty }}% certain of the response :neutral_face:.
+
+{{ explanation }}
+
+<details>
+<ul>
+{% for snippet in snippets %}
+<li>
+<code>
+Line {{ snippet.line_number }}: {{ snippet.text }}
+</code>
+{{ snippet.explanation }}
+</li>
+{% endfor %}
+</ul>
+</details>
+
+<details>
+  <summary>Logs</summary>
+  <p>
+    Log Detective analyzed the following logs files to provide an explanation:
+  </p>
+
+  <ul>
+    <li><a href="{{ log_url }}">{{ log_url }}</a></li>
+  </ul>
+
+  <p>
+    Additional logs are available from:
+    <ul>
+    <li><a href="{{ artifacts_url }}">artifacts.zip</a></li>
+  </ul>
+  </p>
+
+  <p>
+    Please know that these log files are automatically removed after some
+    time, so you might need a backup.
+  </p>
+</details>
+
+<details>
+  <summary>Help</summary>
+  <p>Don't hesitate to reach out.</p>
+
+  <ul>
+    <li><a href="https://github.com/fedora-copr/logdetective">Upstream</a></li>
+    <li><a href="https://github.com/fedora-copr/logdetective/issues">Issue tracker</a></li>
+    <li><a href="https://redhat.enterprise.slack.com/archives/C06DWNVKKDE">Slack</a></li>
+    <li><a href="https://log-detective.com/documentation">Documentation</a></li>
+  </ul>
+</details>
+
+
+---
+This comment was created by [Log Detective][log-detective].
+
+Was the provided feedback accurate and helpful? <br>Please vote with :thumbsup:
+or :thumbsdown: to help us improve.<br>
+
+
+
+[log-detective]: https://log-detective.com/
+[contact]: https://github.com/fedora-copr

--- a/logdetective/server/templates/gitlab_comment.md.j2
+++ b/logdetective/server/templates/gitlab_comment.md.j2
@@ -1,7 +1,7 @@
 The package {{ package }} failed to build, here is a possible explanation why.
 
 Please know that the explanation was provided by AI and may be incorrect.
-In this case, we are {{ certainty }}% certain of the response :neutral_face:.
+In this case, we are {{ certainty }}% certain of the response {{ emoji_face }}.
 
 {{ explanation }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,10 @@ description = "Log using LLM AI to search for build/test failures and provide id
 authors = ["Jiri Podivin <jpodivin@gmail.com>"]
 license = "Apache-2.0"
 readme = "README.md"
-include = ["logdetective/drain3.ini"]
+include = [
+    "logdetective/drain3.ini",
+    "logdetective/server/templates/gitlab_comment.md.j2",
+]
 packages = [
     { include = "logdetective" }
 ]


### PR DESCRIPTION
This merge request now includes and supersedes both #161 and #163 

After this patch-set, the Gitlab integration will meet its initial MVP (minimum viable project) status by:

* Receiving notification from the pipeline of failures in CentOS Stream or RHEL RPM builds in the RHEL-on-Gitlab pipeline.
* Will interrogate the contents of the Koji build logs to determine the most likely log to contain the failure information.
* Will then submit that log to the LLM for analysis using the "staged" mechanism.
* Will retrieve the resulting analysis, both general and with individual snippets and construct a Markdown comment.
* Will attach that markdown comment as a new discussion thread on the merge request that spawned the failed pipeline.

Fixes: https://issues.redhat.com/browse/LD-16
Fixes: https://issues.redhat.com/browse/LD-17