### PR TITLE
Production overrides for environment variables

### DIFF
--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -10,6 +10,11 @@ services:
     extends:
       file: docker-compose.yaml
       service: server
+    environment:
+      ENV: production
+      LOGDETECTIVE_SERVER_PORT: 443
+    ports:
+      - 443:443
   postgres:
     extends:
       file: docker-compose.yaml


### PR DESCRIPTION
My original idea was to move all defaults out of the .env file and then removing it from git repository, allowing everybody to create only a minimal .env file with changed variables for their system. It's not that easy because many of the variables are used by the inference container.

For the time being, let's just override production variables like this, so that we can avoid modifying and having changes in the .env file directly in production.

Once we get rid of the inference container, it may be easier to revisit this topic.