### PR TITLE
Copy run_server.sh and gunicorn configs to the image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -31,5 +31,7 @@ RUN pip3 install llama_cpp_python==0.2.85 sse-starlette starlette-context \
 COPY ./logdetective/ /src/logdetective/
 COPY ./alembic.ini /src/alembic.ini
 COPY ./alembic /src/alembic
+COPY ./files /src/files
+COPY ./server /src/server
 
 WORKDIR /src


### PR DESCRIPTION
Otherwise, the image refuses to start outside our docker-compose setup that bindmounts the files in.