### PR TITLE
Adding settings enabling OpenScanHub checks for our package

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -26,6 +26,11 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-all
+  - job: copr_build
+    trigger: commit
+    branch: main
+    targets:
+      - fedora-all
   - job: tests
     trigger: pull_request
     targets:

--- a/packit.yaml
+++ b/packit.yaml
@@ -26,11 +26,13 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-all
+  # Run build on commit with OpenScanHub checks
   - job: copr_build
     trigger: commit
     branch: main
     targets:
       - fedora-all
+    osh_diff_scan_after_copr_build: true
   - job: tests
     trigger: pull_request
     targets:


### PR DESCRIPTION
I've added suggested baseline settings allowing OpenScanHub to run on our code.
This would add one more layer to our code quality assurance automation. Provided that it works as intended.

If not, or if it produces too many false positives, we should disable it and return to previous setup.
And report the issues of course. 