### PR TITLE
Refactor prompts into YAML

### DIFF
--- a/logdetective/constants.py
+++ b/logdetective/constants.py
@@ -1,61 +1,21 @@
-# pylint: disable=line-too-long
-DEFAULT_ADVISOR = "fedora-copr/Mistral-7B-Instruct-v0.2-GGUF"
+import os
+import yaml
+from functools import lru_cache
 
-PROMPT_TEMPLATE = """
-Given following log snippets, and nothing else, explain what failure, if any, occured during build of this package.
+PROMPTS_YAML_PATH = os.path.join(os.path.dirname(__file__), "prompts.yaml")
 
-Analysis of the snippets must be in a format of [X] : [Y], where [X] is a log snippet, and [Y] is the explanation.
-Snippets themselves must not be altered in any way whatsoever.
+@lru_cache()
+def _load_yaml(path: str = PROMPTS_YAML_PATH) -> dict:
+    """Load YAML content from the given file path."""
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
 
-Snippets are delimited with '================'.
+_yaml_data = _load_yaml()
 
-Finally, drawing on information from all snippets, provide complete explanation of the issue and recommend solution.
+DEFAULT_ADVISOR = _yaml_data.get("default_advisor", "fedora-copr/Mistral-7B-Instruct-v0.2-GGUF")
+SNIPPET_DELIMITER = _yaml_data.get("constants", {}).get("snippet_delimiter", "================")
 
-Snippets:
-
-{}
-
-Analysis:
-
-"""
-
-SUMMARIZE_PROMPT_TEMPLATE = """
-Does following log contain error or issue?
-
-Log:
-
-{}
-
-Answer:
-
-"""
-
-SNIPPET_PROMPT_TEMPLATE = """
-Analyse following RPM build log snippet. Describe contents accurately, without speculation or suggestions for resolution.
-
-Snippet:
-
-{}
-
-Analysis:
-
-"""
-
-PROMPT_TEMPLATE_STAGED = """
-Given following log snippets, their explanation, and nothing else, explain what failure, if any, occured during build of this package.
-
-Snippets are in a format of [X] : [Y], where [X] is a log snippet, and [Y] is the explanation.
-
-Snippets are delimited with '================'.
-
-Drawing on information from all snippets, provide complete explanation of the issue and recommend solution.
-
-Snippets:
-
-{}
-
-Analysis:
-
-"""
-
-SNIPPET_DELIMITER = "================"
+PROMPT_TEMPLATE = _yaml_data["prompts"]["analyze_snippets"]["template"]
+PROMPT_TEMPLATE_STAGED = _yaml_data["prompts"]["staged_analysis"]["template"]
+SUMMARIZE_PROMPT_TEMPLATE = _yaml_data["prompts"]["summarize_log"]["template"]
+SNIPPET_PROMPT_TEMPLATE = _yaml_data["prompts"]["analyze_snippet_only"]["template"]

--- a/logdetective/prompts.yaml
+++ b/logdetective/prompts.yaml
@@ -1,0 +1,58 @@
+default_advisor: fedora-copr/Mistral-7B-Instruct-v0.2-GGUF
+
+prompts:
+  analyze_snippets:
+    template: |
+      Given following log snippets, and nothing else, explain what failure, if any, occured during build of this package.
+
+      Analysis of the snippets must be in a format of [X] : [Y], where [X] is a log snippet, and [Y] is the explanation.
+      Snippets themselves must not be altered in any way whatsoever.
+
+      Snippets are delimited with '================'.
+
+      Finally, drawing on information from all snippets, provide complete explanation of the issue and recommend solution.
+
+      Snippets:
+
+      {}
+
+      Analysis:
+
+  summarize_log:
+    template: |
+      Does following log contain error or issue?
+
+      Log:
+
+      {}
+
+      Answer:
+
+  analyze_snippet_only:
+    template: |
+      Analyse following RPM build log snippet. Describe contents accurately, without speculation or suggestions for resolution.
+
+      Snippet:
+
+      {}
+
+      Analysis:
+
+  staged_analysis:
+    template: |
+      Given following log snippets, their explanation, and nothing else, explain what failure, if any, occured during build of this package.
+
+      Snippets are in a format of [X] : [Y], where [X] is a log snippet, and [Y] is the explanation.
+
+      Snippets are delimited with '================'.
+
+      Drawing on information from all snippets, provide complete explanation of the issue and recommend solution.
+
+      Snippets:
+
+      {}
+
+      Analysis:
+
+constants:
+  snippet_delimiter: "================"


### PR DESCRIPTION
This PR addresses issue #93 by moving all prompt templates to a YAML configuration file (prompts.yaml). Prompts are now loaded using constants.py by cached YAML parsing. This makes prompts easier to maintain, edit, and experiment without modifying code directly.

- Prompts now live in prompts.yaml .
- All prompt usage updated to import from constants.py
- Clean separation of config and logic
- No changes needed in utils.py or other processing code

Tested locally and existing functionality works as expected.
