### PR TITLE
Add a graph for responses avarage time and length

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,10 +310,22 @@ certbot certonly --standalone -d logdetective01.fedorainfracloud.org
 Querying statistics
 -------------------
 
-You can retrieve statistics about server requests over a specified time period
-using either the `curl` command or the `http` command (provided by the `httpie` package).
+You can retrieve statistics about server requests and responses over a specified time period
+using either a browser, the `curl` or the `http` command (provided by the `httpie` package).
 
 When no time period is specified, the query defaults to the last 2 days:
+
+You can view requests and responses statistics
+ - for the `/analyze` endpoint at http://localhost:8080/metrics/analyze
+ - for the `/analyze/staged` endpoint at http://localhost:8080/metrics/analyze/staged.
+
+You can retrieve single svg images at the following endpoints:
+ - `/metrics/analyze/requests`
+ - `/metrics/analyze/responses`
+ - `/metrics/analyze/staged/requests`
+ - `/metrics/analyze/stages/responses`
+
+Examples:
 
 ```
 http GET "localhost:8080/metrics/analyze/requests" > /tmp/plot.svg
@@ -322,7 +334,6 @@ curl "localhost:8080/metrics/analyze/staged/requests" > /tmp/plot.svg
 
 You can specify the time period in hours, days, or weeks.
 The time period:
-
  - cannot be less than one hour
  - cannot be negative
  - ends at the current time (when the query is made)

--- a/logdetective/server/metric.py
+++ b/logdetective/server/metric.py
@@ -41,12 +41,10 @@ def update_metrics(
         sent_at if sent_at else datetime.datetime.now(datetime.timezone.utc)
     )
     response_length = None
-    if hasattr(response, "explanation") and "choices" in response.explanation:
-        response_length = sum(
-            len(choice["text"])
-            for choice in response.explanation["choices"]
-            if "text" in choice
-        )
+    if hasattr(response, "explanation") and isinstance(
+        response.explanation, models.Explanation
+    ):
+        response_length = len(response.explanation.text)
     response_certainty = (
         response.response_certainty if hasattr(response, "response_certainty") else None
     )

--- a/logdetective/server/plot.py
+++ b/logdetective/server/plot.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Optional
+from typing import Optional, Union
 
 import numpy
 import matplotlib
@@ -62,24 +62,24 @@ class Definition:
 
 
 def create_time_series_arrays(
-    counts_dict: dict[datetime.datetime, int],
+    values_dict: dict[datetime.datetime, int],
+    plot_def: Definition,
     start_time: datetime.datetime,
     end_time: datetime.datetime,
-    time_delta: datetime.timedelta,
-    time_format: str,
+    value_type: Optional[Union[int, float]] = int,
 ) -> tuple[numpy.ndarray, numpy.ndarray]:
-    """Create time series arrays from a dictionary of counts.
+    """Create time series arrays from a dictionary of values.
 
     This function generates two aligned numpy arrays:
     1. An array of timestamps from start_time to end_time
-    2. A corresponding array of counts for each timestamp
+    2. A corresponding array of valuesfor each timestamp
 
     The timestamps are truncated to the precision specified by time_format.
-    If a timestamp in counts_dict matches a generated timestamp, its count is used;
-    otherwise, the count defaults to zero.
+    If a timestamp in values_dict matches a generated timestamp, its values is used;
+    otherwise, the value defaults to zero.
 
     Args:
-        counts_dict: Dictionary mapping timestamps to their respective counts
+        values_dict: Dictionary mapping timestamps to their respective values
         start_time: The starting timestamp of the time series
         end_time: The ending timestamp of the time series
         time_delta: The time interval between consecutive timestamps
@@ -88,67 +88,70 @@ def create_time_series_arrays(
     Returns:
         A tuple containing:
             - numpy.ndarray: Array of timestamps
-            - numpy.ndarray: Array of corresponding counts
+            - numpy.ndarray: Array of corresponding values
     """
-    num_intervals = int((end_time - start_time) / time_delta) + 1
+    num_intervals = int((end_time - start_time) / plot_def.time_delta) + 1
 
     timestamps = numpy.array(
         [
             datetime.datetime.strptime(
-                (start_time + i * time_delta).strftime(format=time_format), time_format
+                (start_time + i * plot_def.time_delta).strftime(
+                    format=plot_def.time_format
+                ),
+                plot_def.time_format,
             )
             for i in range(num_intervals)
         ]
     )
-    counts = numpy.zeros(num_intervals, dtype=int)
+    values = numpy.zeros(num_intervals, dtype=value_type)
 
     timestamp_to_index = {timestamp: i for i, timestamp in enumerate(timestamps)}
 
-    for timestamp, count in counts_dict.items():
+    for timestamp, count in values_dict.items():
         if timestamp in timestamp_to_index:
-            counts[timestamp_to_index[timestamp]] = count
+            values[timestamp_to_index[timestamp]] = count
 
-    return timestamps, counts
+    return timestamps, values
 
 
-def _add_bar_chart_for_requests_count(
-    ax1: matplotlib.figure.Axes,
+def _add_bar_chart(
+    ax: matplotlib.figure.Axes,
     plot_def: Definition,
     timestamps: numpy.array,
-    counts: numpy.array,
+    values: numpy.array,
+    label: str,
 ) -> None:
-    """Add a bar chart for requests count (axes 1)"""
+    """Add a blue bar chart"""
     bar_width = (
         0.8 * plot_def.time_delta.total_seconds() / 86400
     )  # Convert to days for matplotlib
-    ax1.bar(
+    ax.bar(
         timestamps,
-        counts,
+        values,
         width=bar_width,
         alpha=0.7,
         color="skyblue",
-        label="Requests",
+        label=label,
     )
-    ax1.set_xlabel("Time")
-    ax1.set_ylabel("Requests", color="blue")
-    ax1.tick_params(axis="y", labelcolor="blue")
+    ax.set_xlabel("Time")
+    ax.set_ylabel(label, color="blue")
+    ax.tick_params(axis="y", labelcolor="blue")
 
-    ax1.xaxis.set_major_formatter(matplotlib.dates.DateFormatter(plot_def.time_format))
-    ax1.xaxis.set_major_locator(plot_def.locator)
+    ax.xaxis.set_major_formatter(matplotlib.dates.DateFormatter(plot_def.time_format))
+    ax.xaxis.set_major_locator(plot_def.locator)
 
     matplotlib.pyplot.xticks(rotation=45)
 
-    ax1.grid(True, alpha=0.3)
+    ax.grid(True, alpha=0.3)
 
 
-def _add_cumulative_line_for_requests_count(
-    ax2: matplotlib.figure.Axes, timestamps: numpy.array, counts: numpy.array
+def _add_line_chart(
+    ax: matplotlib.figure.Axes, timestamps: numpy.array, values: numpy.array, label: str
 ) -> None:
-    """Add cumulative line on secondary y-axis"""
-    cumulative = numpy.cumsum(counts)
-    ax2.plot(timestamps, cumulative, "r-", linewidth=2, label="Cumulative")
-    ax2.set_ylabel("Cumulative Requests", color="red")
-    ax2.tick_params(axis="y", labelcolor="red")
+    """Add a red line chart"""
+    ax.plot(timestamps, values, "r-", linewidth=2, label=label)
+    ax.set_ylabel(label, color="red")
+    ax.tick_params(axis="y", labelcolor="red")
 
 
 def requests_per_time(
@@ -183,17 +186,89 @@ def requests_per_time(
         start_time, end_time, plot_def.time_format, endpoint
     )
     timestamps, counts = create_time_series_arrays(
-        requests_counts, start_time, end_time, plot_def.time_delta, plot_def.time_format
+        requests_counts, plot_def, start_time, end_time
     )
 
     fig, ax1 = matplotlib.pyplot.subplots(figsize=(12, 6))
-    _add_bar_chart_for_requests_count(ax1, plot_def, timestamps, counts)
+    _add_bar_chart(ax1, plot_def, timestamps, counts, "Requests")
 
     ax2 = ax1.twinx()
-    _add_cumulative_line_for_requests_count(ax2, timestamps, counts)
+    _add_line_chart(ax2, timestamps, numpy.cumsum(counts), "Cumulative Requests")
 
     matplotlib.pyplot.title(
         f"Requests received for API {endpoint} ({start_time.strftime(plot_def.time_format)} "
+        f"to {end_time.strftime(plot_def.time_format)})"
+    )
+
+    lines1, labels1 = ax1.get_legend_handles_labels()
+    lines2, labels2 = ax2.get_legend_handles_labels()
+    ax1.legend(lines1 + lines2, labels1 + labels2, loc="center")
+
+    matplotlib.pyplot.tight_layout()
+
+    return fig
+
+
+def average_time_per_responses(  # pylint: disable=too-many-locals
+    period_of_time: models.TimePeriod,
+    endpoint: EndpointType = EndpointType.ANALYZE,
+    end_time: Optional[datetime.datetime] = None,
+) -> matplotlib.figure.Figure:
+    """
+    Generate a visualization of average response time and length over a specified time period.
+
+    This function creates a dual-axis plot showing:
+    1. A bar chart of average response time per time interval
+    1. A line chart of average response length per time interval
+
+    The time intervals are determined by the provided TimePeriod object, which defines
+    the granularity and formatting of the time axis.
+
+    Args:
+        period_of_time: A TimePeriod object that defines the time period and interval
+                        for the analysis (e.g., hourly, daily, weekly)
+        endpoint: One of the API endpoints
+        end_time: The end time for the analysis period. If None, defaults to the current
+                  UTC time
+
+    Returns:
+        A matplotlib Figure object containing the generated visualization
+    """
+    end_time = end_time or datetime.datetime.now(datetime.timezone.utc)
+    start_time = period_of_time.get_period_start_time(end_time)
+    plot_def = Definition(period_of_time)
+    responses_average_time = AnalyzeRequestMetrics.get_responses_average_time_in_period(
+        start_time, end_time, plot_def.time_format, endpoint
+    )
+    timestamps, average_time = create_time_series_arrays(
+        responses_average_time,
+        plot_def,
+        start_time,
+        end_time,
+        float,
+    )
+
+    fig, ax1 = matplotlib.pyplot.subplots(figsize=(12, 6))
+    _add_bar_chart(ax1, plot_def, timestamps, average_time, "average response time (seconds)")
+
+    responses_average_length = (
+        AnalyzeRequestMetrics.get_responses_average_length_in_period(
+            start_time, end_time, plot_def.time_format, endpoint
+        )
+    )
+    timestamps, average_length = create_time_series_arrays(
+        responses_average_length,
+        plot_def,
+        start_time,
+        end_time,
+        float,
+    )
+
+    ax2 = ax1.twinx()
+    _add_line_chart(ax2, timestamps, average_length, "average response length (chars)")
+
+    matplotlib.pyplot.title(
+        f"average response time for API {endpoint} ({start_time.strftime(plot_def.time_format)} "
         f"to {end_time.strftime(plot_def.time_format)})"
     )
 

--- a/tests/test_database_models.py
+++ b/tests/test_database_models.py
@@ -54,3 +54,45 @@ def test_AnalyzeRequestMetrics_ger_request_in_period(endpoint):
             start_time, end_time, time_format, endpoint
         )
         assert len(counts_dict) == 10 or len(counts_dict) == 11
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [EndpointType.ANALYZE, EndpointType.ANALYZE_STAGED],
+)
+def test_AnalyzeRequestMetrics_ger_responses_average_time(endpoint):
+    duration = datetime.timedelta(hours=13)
+    with PopulateDatabase.populate_db_and_mock_postgres(
+        duration=duration,
+        endpoint=endpoint,
+    ) as _:
+        end_time = datetime.datetime.now(datetime.timezone.utc)
+        start_time = end_time - datetime.timedelta(hours=10)
+        time_format = "%Y-%m-%d %H"
+        average_times_dict = AnalyzeRequestMetrics.get_responses_average_time_in_period(
+            start_time, end_time, time_format, endpoint
+        )
+        assert len(average_times_dict) == 10 or len(average_times_dict) == 11
+        values = list(average_times_dict.values())
+        # responses times always increase in the same way inside the hour
+        assert values[2] == pytest.approx(values[3], abs=1e-3)
+        assert values[4] == pytest.approx(values[5], abs=1e-3)
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [EndpointType.ANALYZE, EndpointType.ANALYZE_STAGED],
+)
+def test_AnalyzeRequestMetrics_ger_responses_average_length(endpoint):
+    duration = datetime.timedelta(hours=13)
+    with PopulateDatabase.populate_db_and_mock_postgres(
+        duration=duration,
+        endpoint=endpoint,
+    ) as _:
+        end_time = datetime.datetime.now(datetime.timezone.utc)
+        start_time = end_time - datetime.timedelta(hours=10)
+        time_format = "%Y-%m-%d %H"
+        average_lengths_dict = AnalyzeRequestMetrics.get_responses_average_length_in_period(
+            start_time, end_time, time_format, endpoint
+        )
+        assert len(average_lengths_dict) == 10 or len(average_lengths_dict) == 11

--- a/tests/test_server_plot.py
+++ b/tests/test_server_plot.py
@@ -7,7 +7,11 @@ from test_helpers import PopulateDatabase
 
 from logdetective.server import plot, models
 from logdetective.server.database.models import AnalyzeRequestMetrics, EndpointType
-from logdetective.server.plot import create_time_series_arrays, requests_per_time
+from logdetective.server.plot import (
+    create_time_series_arrays,
+    requests_per_time,
+    average_time_per_responses,
+)
 
 
 def test_week_Definition():
@@ -43,10 +47,9 @@ def test_create_time_series_arrays(endpoint):
         )
         timestamps, counts = create_time_series_arrays(
             counts_dict,
+            plot_details,
             start_time,
             end_time,
-            plot_details.time_delta,
-            plot_details.time_format,
         )
         assert len(timestamps) == len(counts) == 22 + 1
         assert (
@@ -61,48 +64,111 @@ def _save_fig(fig):
 
 
 @pytest.mark.parametrize(
-    "endpoint",
-    [EndpointType.ANALYZE, EndpointType.ANALYZE_STAGED],
+    "endpoint,plot",
+    [
+        pytest.param(
+            EndpointType.ANALYZE,
+            requests_per_time,
+            id="Requests per time for ANALYZE endpoint",
+        ),
+        pytest.param(
+            EndpointType.ANALYZE_STAGED,
+            requests_per_time,
+            id="Requests per time for ANALYZE_STAGED endpoint",
+        ),
+        pytest.param(
+            EndpointType.ANALYZE,
+            average_time_per_responses,
+            id="average time and length for ANALYZE endpoint",
+        ),
+        pytest.param(
+            EndpointType.ANALYZE_STAGED,
+            average_time_per_responses,
+            id="average time and length for ANALYZE_STAGED endpoint",
+        ),
+    ],
 )
-def test_requests_per_time_hourly(endpoint):
+def test_hourly_plots(endpoint, plot):
     duration = datetime.timedelta(hours=14)
     with PopulateDatabase.populate_db_and_mock_postgres(
         duration=duration,
         endpoint=endpoint,
     ) as _:
         period = models.TimePeriod(hours=22)
-        fig = requests_per_time(period, endpoint)
+        fig = plot(period, endpoint)
         assert fig
         _save_fig(fig)
 
 
 @pytest.mark.parametrize(
-    "endpoint",
-    [EndpointType.ANALYZE, EndpointType.ANALYZE_STAGED],
+    "endpoint,plot",
+    [
+        pytest.param(
+            EndpointType.ANALYZE,
+            requests_per_time,
+            id="Requests per time for ANALYZE endpoint",
+        ),
+        pytest.param(
+            EndpointType.ANALYZE_STAGED,
+            requests_per_time,
+            id="Requests per time for ANALYZE_STAGED endpoint",
+        ),
+        pytest.param(
+            EndpointType.ANALYZE,
+            average_time_per_responses,
+            id="average time and length for ANALYZE endpoint",
+        ),
+        pytest.param(
+            EndpointType.ANALYZE_STAGED,
+            average_time_per_responses,
+            id="average time and length for ANALYZE_STAGED endpoint",
+        ),
+    ],
 )
-def test_requests_per_time_daily(endpoint):
+def test_daily_plots(endpoint, plot):
     duration = datetime.timedelta(days=9)
     with PopulateDatabase.populate_db_and_mock_postgres(
         duration=duration,
         endpoint=endpoint,
     ) as _:
         period = models.TimePeriod(days=15)
-        fig = requests_per_time(period, endpoint)
+        fig = plot(period, endpoint)
         assert fig
         _save_fig(fig)
 
 
 @pytest.mark.parametrize(
-    "endpoint",
-    [EndpointType.ANALYZE, EndpointType.ANALYZE_STAGED],
+    "endpoint,plot",
+    [
+        pytest.param(
+            EndpointType.ANALYZE,
+            requests_per_time,
+            id="Requests per time for ANALYZE endpoint",
+        ),
+        pytest.param(
+            EndpointType.ANALYZE_STAGED,
+            requests_per_time,
+            id="Requests per time for ANALYZE_STAGED endpoint",
+        ),
+        pytest.param(
+            EndpointType.ANALYZE,
+            average_time_per_responses,
+            id="average time and length for ANALYZE endpoint",
+        ),
+        pytest.param(
+            EndpointType.ANALYZE_STAGED,
+            average_time_per_responses,
+            id="average time and length for ANALYZE_STAGED endpoint",
+        ),
+    ],
 )
-def test_requests_per_time_weekly(endpoint):
+def test_weekly_plots(endpoint, plot):
     duration = datetime.timedelta(weeks=3)
     with PopulateDatabase.populate_db_and_mock_postgres(
         duration=duration,
         endpoint=endpoint,
     ) as _:
         period = models.TimePeriod(weeks=5)
-        fig = requests_per_time(period, endpoint)
+        fig = plot(period, endpoint)
         assert fig
         _save_fig(fig)


### PR DESCRIPTION
Example for http://localhost:8080/metrics/analyze?hours=5

![Screenshot From 2025-04-07 11-11-44](https://github.com/user-attachments/assets/fce7d3c8-2b01-4847-b80a-f25b6a110fc3)