### PR TITLE
move format_analyzed_snippets to server.utils

### DIFF
--- a/logdetective/server/server.py
+++ b/logdetective/server/server.py
@@ -26,10 +26,13 @@ from logdetective.utils import (
     validate_url,
     compute_certainty,
     format_snippets,
-    format_analyzed_snippets,
     load_prompts,
 )
-from logdetective.server.utils import load_server_config, get_log
+from logdetective.server.utils import (
+    load_server_config,
+    get_log,
+    format_analyzed_snippets,
+)
 from logdetective.server.metric import track_request
 from logdetective.server.models import (
     BuildLog,

--- a/logdetective/server/utils.py
+++ b/logdetective/server/utils.py
@@ -1,6 +1,18 @@
 import logging
 import yaml
-from logdetective.server.models import Config
+from logdetective.constants import SNIPPET_DELIMITER
+from logdetective.server.models import Config, AnalyzedSnippet
+
+
+def format_analyzed_snippets(snippets: list[AnalyzedSnippet]) -> str:
+    """Format snippets for submission into staged prompt."""
+    summary = f"\n{SNIPPET_DELIMITER}\n".join(
+        [
+            f"[{e.text}] at line [{e.line_number}]: [{e.explanation.text}]"
+            for e in snippets
+        ]
+    )
+    return summary
 
 
 def load_server_config(path: str | None) -> Config:

--- a/logdetective/utils.py
+++ b/logdetective/utils.py
@@ -7,8 +7,6 @@ import requests
 import yaml
 
 from llama_cpp import Llama, CreateCompletionResponse, CreateCompletionStreamResponse
-from logdetective.constants import SNIPPET_DELIMITER
-from logdetective.server.models import AnalyzedSnippet
 from logdetective.models import PromptConfig
 
 
@@ -175,17 +173,6 @@ def format_snippets(snippets: list[str] | list[Tuple[int, str]]) -> str:
             {s[1]}
             ================
             """
-    return summary
-
-
-def format_analyzed_snippets(snippets: list[AnalyzedSnippet]) -> str:
-    """Format snippets for submission into staged prompt."""
-    summary = f"\n{SNIPPET_DELIMITER}\n".join(
-        [
-            f"[{e.text}] at line [{e.line_number}]: [{e.explanation.text}]"
-            for e in snippets
-        ]
-    )
     return summary
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,9 +3,9 @@ import pytest
 from logdetective.utils import (
     compute_certainty,
     format_snippets,
-    format_analyzed_snippets,
     load_prompts,
 )
+from logdetective.server.utils import format_analyzed_snippets
 from logdetective.server.models import AnalyzedSnippet, Explanation
 from logdetective.models import PromptConfig
 from logdetective import constants


### PR DESCRIPTION
Fixes: #192

Addressing:
```
Traceback (most recent call last):
  File "/usr/bin/logdetective", line 5, in <module>
    from logdetective.logdetective import main
  File "/usr/lib/python3.13/site-packages/logdetective/logdetective.py", line 6, in <module>
    from logdetective.utils import (
    ...<6 lines>...
    )
  File "/usr/lib/python3.13/site-packages/logdetective/utils.py", line 11, in <module>
    from logdetective.server.models import AnalyzedSnippet
ModuleNotFoundError: No module named 'logdetective.server.models'
```