### PR TITLE
change the prompt to have the conclusion at the beggining

### DIFF
--- a/logdetective/constants.py
+++ b/logdetective/constants.py
@@ -9,12 +9,12 @@ DEFAULT_ADVISOR = "fedora-copr/Mistral-7B-Instruct-v0.2-GGUF"
 PROMPT_TEMPLATE = """
 Given following log snippets, and nothing else, explain what failure, if any, occured during build of this package.
 
+Please start with concise, one sentence long, summary describing the problem and recommend solution to fix it. And then follow with analysis.
+
 Analysis of the snippets must be in a format of [X] : [Y], where [X] is a log snippet, and [Y] is the explanation.
 Snippets themselves must not be altered in any way whatsoever.
 
 Snippets are delimited with '================'.
-
-Finally, drawing on information from all snippets, provide complete explanation of the issue and recommend solution.
 
 Snippets:
 


### PR DESCRIPTION
On example of `logdetective https://kojipkgs.fedoraproject.org//work/tasks/7637/130807637/root.log`

Previously:
```
 Based on the given log snippets, there are no clear indications of failure or errors during the build process. The log snippets primarily consist of debug messages and commands executed as part of the RPM build process.

The log snippets show that the script was ensuring that required directories exist, mounting necessary file systems, executing various commands, and disabling certain plugins. None of these actions resulted in any error messages or indications of issues.

The logs also contain messages that some dependencies could not be found or satisfied. However, these messages do not necessarily indicate errors or failures, as it's possible that the missing dependencies are not critical for the build to complete, or they might be available in other repositories or package sources.

In conclusion, based on the provided log snippets, there does not seem to be any significant issues or failures during the RPM build process. However, it is always a good practice to closely examine the entire build log for any potential warnings or errors, especially when dealing with critical packages or complex builds.
```

After this change:
```

Problem: The build failed to install required package 'python3-httpx' due to its unavailability in the repository.

Solution: Install the missing package manually or add its repository to the build system.

[Snippet No. 5]: No matching package to install: 'python3-httpx'
[Snippet No. 6]: Not all dependencies satisfied
[Snippet No. 7]: Error: Some packages could not be found.

The snippets indicate that the build process encountered an error while trying to install 'python3-httpx' as a dependency. The package could not be found in the repository, hence the error messages. To fix this issue, you can either install the missing package manually or add its repository to the build system.

Additionally, Snippet No. 2 shows that an attempt was made to unmount certain directories within the chroot environment. This is a normal part of the build process and does not indicate a problem. The other snippets show various commands being executed as part of the build process.
Response certainty: 95.68%
```