### PR TITLE
MR comment Details: don't start with newline

### DIFF
--- a/logdetective/server/templates/gitlab_comment.md.j2
+++ b/logdetective/server/templates/gitlab_comment.md.j2
@@ -9,8 +9,7 @@ In this case, we are {{ certainty }}% certain of the response {{ emoji_face }}.
 <ul>
 {% for snippet in snippets %}
 <li>
-<code>
-Line {{ snippet.line_number }}: {{ snippet.text }}
+<code>Line {{ snippet.line_number }}: {{ snippet.text }}
 </code>
 {{ snippet.explanation }}
 </li>


### PR DESCRIPTION
This is an attempt to drop leading newline from Details of annotated log
lines.

Example: https://gitlab.com/TomasTomecek/redhat-internal-test-package/-/merge_requests/1#note_2441940705

![image](https://github.com/user-attachments/assets/c14ca830-76a4-450e-82a5-7e0e5447639c)
