### PR TITLE
Specify model and max_tokens when querying models

### DIFF
--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -95,6 +95,7 @@ class InferenceConfig(BaseModel):
     )
     url: str = ""
     api_token: str = ""
+    model: str = ""
 
     def __init__(self, data: Optional[dict] = None):
         super().__init__()
@@ -106,6 +107,7 @@ class InferenceConfig(BaseModel):
         self.api_endpoint = data.get("api_endpoint", "/chat/completions")
         self.url = data.get("url", "")
         self.api_token = data.get("api_token", "")
+        self.model = data.get("model", "default-model")
 
 
 class ExtractorConfig(BaseModel):

--- a/logdetective/server/server.py
+++ b/logdetective/server/server.py
@@ -301,6 +301,8 @@ async def analyze_log(build_log: BuildLog):
     response = await submit_text(
         PROMPT_CONFIG.prompt_template.format(log_summary),
         api_endpoint=SERVER_CONFIG.inference.api_endpoint,
+        model=SERVER_CONFIG.inference.model,
+        max_tokens=SERVER_CONFIG.inference.max_tokens,
     )
     certainty = 0
 
@@ -341,6 +343,8 @@ async def perform_staged_analysis(log_text: str) -> StagedResponse:
             submit_text(
                 PROMPT_CONFIG.snippet_prompt_template.format(s),
                 api_endpoint=SERVER_CONFIG.inference.api_endpoint,
+                model=SERVER_CONFIG.inference.model,
+                max_tokens=SERVER_CONFIG.inference.max_tokens,
             )
             for s in log_summary
         ]
@@ -355,7 +359,10 @@ async def perform_staged_analysis(log_text: str) -> StagedResponse:
     )
 
     final_analysis = await submit_text(
-        final_prompt, api_endpoint=SERVER_CONFIG.inference.api_endpoint
+        final_prompt,
+        api_endpoint=SERVER_CONFIG.inference.api_endpoint,
+        model=SERVER_CONFIG.inference.model,
+        max_tokens=SERVER_CONFIG.inference.max_tokens,
     )
 
     certainty = 0
@@ -396,7 +403,9 @@ async def analyze_log_stream(build_log: BuildLog):
         headers["Authorization"] = f"Bearer {SERVER_CONFIG.inference.api_token}"
 
     stream = await submit_text_chat_completions(
-        PROMPT_CONFIG.prompt_template.format(log_summary), stream=True, headers=headers
+        PROMPT_CONFIG.prompt_template.format(log_summary), stream=True, headers=headers,
+        model=SERVER_CONFIG.inference.model,
+        max_tokens=SERVER_CONFIG.inference.model,
     )
 
     return StreamingResponse(stream)


### PR DESCRIPTION
When using docker-compose, our inference container gets these from our `.env` file (see `LLAMA_ARG_MODEL`). However, in production we use models.corp, so these are not being set anymore. We need to specify them in our request.