### PR TITLE
add link to logdetective-website project

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Log Detective
 
 A Python tool to analyze logs using a Language Model (LLM) and Drain template miner.
 
+Note: if you are looking for code of website logdetective.com it is in [github.com/fedora-copr/logdetective-website](https://github.com/fedora-copr/logdetective-website).
+
 Installation
 ------------
 


### PR DESCRIPTION
After
https://github.com/fedora-copr/logdetective-website/pull/223 the link from logdetective.com goes here, so we should have a good hint for users that are looking for source code of website itself.