### PR TITLE
Load balance LLM queries to different endpoints

### DIFF
--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -190,7 +190,7 @@ class Config(BaseModel):
     """Model for configuration of logdetective server."""
 
     log: LogConfig = LogConfig()
-    inference: InferenceConfig = InferenceConfig()
+    inference: list[InferenceConfig] = [InferenceConfig()]
     extractor: ExtractorConfig = ExtractorConfig()
     gitlab: GitLabConfig = GitLabConfig()
     general: GeneralConfig = GeneralConfig()
@@ -202,7 +202,7 @@ class Config(BaseModel):
             return
 
         self.log = LogConfig(data.get("log"))
-        self.inference = InferenceConfig(data.get("inference"))
+        self.inference = [InferenceConfig(x) for x in data.get("inference")]
         self.extractor = ExtractorConfig(data.get("extractor"))
         self.gitlab = GitLabConfig(data.get("gitlab"))
         self.general = GeneralConfig(data.get("general"))

--- a/server/config.yml
+++ b/server/config.yml
@@ -3,11 +3,11 @@ log:
   level_file: "DEBUG"
   path: "log/logdetective.log"
 inference:
-  max_tokens: -1
-  log_probs: 1
-  url: http://llama-cpp-server:8000
-  # url: https://mistral-7b-instruct-v0-3--apicast-production.apps.int.stc.ai.prod.us-east-1.aws.paas.redhat.com/
-  api_token: ""
+  - max_tokens: -1
+    log_probs: 1
+    url: http://llama-cpp-server:8000
+    # url: https://mistral-7b-instruct-v0-3--apicast-production.apps.int.stc.ai.prod.us-east-1.aws.paas.redhat.com/
+    api_token: ""
 extractor:
   context: true
   max_clusters: 25

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -89,7 +89,7 @@ async def test_process_url():
 @pytest.mark.asyncio
 async def test_submit_text_chat_completions():
     mock_response = b"123"
-    SERVER_CONFIG.inference.url = "http://localhost:8080"
+    SERVER_CONFIG.inference[0].url = "http://localhost:8080"
     with aioresponses.aioresponses() as mock:
         mock.post('http://localhost:8080/v1/chat/completions', status=200, body=mock_response)
         async with aiohttp.ClientSession() as http:


### PR DESCRIPTION
Fix LD-64

This breaks a backward compatibility of the config file (the `inference` field now expect a list of configurations) but shouldn't break a previous behavior in a case when the list contains just one inference configuration.

When there are multiple configurations, we randomly shuffle them for every request to achieve a pseudo load balancing. We also improve our fault tolerance because if the inference request fails, we try next inference configuration, and then the next one, etc.