### PR TITLE
Track metrics for Gitlab-triggered requests

### DIFF
--- a/logdetective/server/metric.py
+++ b/logdetective/server/metric.py
@@ -50,7 +50,7 @@ def update_metrics(
     )
 
 
-def track_request():
+def track_request(name=None):
     """
     Decorator to track requests metrics
     """
@@ -58,14 +58,14 @@ def track_request():
     def decorator(f):
         @wraps(f)
         async def async_decorated_function(*args, **kwargs):
-            metrics_id = add_new_metrics(f.__name__)
+            metrics_id = add_new_metrics(name if name else f.__name__)
             response = await f(*args, **kwargs)
             update_metrics(metrics_id, response)
             return response
 
         @wraps(f)
         def sync_decorated_function(*args, **kwargs):
-            metrics_id = add_new_metrics(f.__name__)
+            metrics_id = add_new_metrics(name if name else f.__name__)
             response = f(*args, **kwargs)
             update_metrics(metrics_id, response)
             return response

--- a/logdetective/server/server.py
+++ b/logdetective/server/server.py
@@ -370,7 +370,6 @@ async def analyze_log(
 
 
 @app.post("/analyze/staged", response_model=StagedResponse)
-@track_request()
 async def analyze_log_staged(
     build_log: BuildLog, http: aiohttp.ClientSession = Depends(get_http_session)
 ):
@@ -385,6 +384,7 @@ async def analyze_log_staged(
     return await perform_staged_analysis(http, log_text=log_text)
 
 
+@track_request(name="analyze_log_staged")
 async def perform_staged_analysis(
     http: aiohttp.ClientSession, log_text: str
 ) -> StagedResponse:

--- a/tests/test_server_gitlab.py
+++ b/tests/test_server_gitlab.py
@@ -7,6 +7,10 @@ import aioresponses
 
 from flexmock import flexmock
 
+from test_helpers import (
+    DatabaseFactory,
+)
+
 from logdetective.server.server import process_gitlab_job_event
 from logdetective.server.models import JobHook
 from logdetective.server import server
@@ -169,7 +173,8 @@ def mock_job_hook():
 
 @pytest.mark.asyncio
 async def test_process_gitlab_job_event(mock_config, mock_job_hook):
-    _, _, job_hook = mock_job_hook
-    await process_gitlab_job_event(
-        http=aiohttp.ClientSession(), forge=Forge.gitlab_com, job_hook=job_hook
-    )
+    with DatabaseFactory().make_new_db() as _:
+        _, _, job_hook = mock_job_hook
+        await process_gitlab_job_event(
+            http=aiohttp.ClientSession(), forge=Forge.gitlab_com, job_hook=job_hook
+        )


### PR DESCRIPTION
Gitlab uses the underlying code for staged analysis, but it doesn't call the endpoint directly, meaning it wasn't being saved to the database. This patch adds an argument to the decorator allowing us to override the function name it uses to save to the DB (for backwards compatibility) and moves the decorator to the inner function perform_staged_analysis().

Note: this patch does _not_ implement the linking of the metrics with the Gitlab merge request yet. At the moment, it's only treating it as if it was another external request. I'm still trying to figure out how to populate that relationship.