### PR TITLE
Make the docker-compose.yaml file compatible with docker

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,8 +53,3 @@ volumes:
   database_data:
     driver: local
   matplotlib-config:
-    emptyDir: {}
-
-volumeMounts:
-  - name: matplotlib-config
-    mountPath: "${MPLCONFIGDIR}"


### PR DESCRIPTION
These constructs work with podman-compose but docker-compose fails with:

    volumes.matplotlib-config Additional property emptyDir is not allowed
    (root) Additional property volumeMounts is not allowed