### PR TITLE
Add Emoji webhook listener

### DIFF
--- a/logdetective/remote_log.py
+++ b/logdetective/remote_log.py
@@ -1,23 +1,15 @@
-import io
 import logging
-from typing import Union
 from urllib.parse import urlparse
 
 import aiohttp
-
-from logdetective.server.compressors import TextCompressor
-
 
 LOG = logging.getLogger("logdetective")
 
 
 class RemoteLog:
     """
-    Handles retrieval and compression of remote log files.
+    Handles retrieval of remote log files.
     """
-
-    LOG_FILE_NAME = "log.txt"
-    COMPRESSOR = TextCompressor()
 
     def __init__(self, url: str, http_session: aiohttp.ClientSession):
         """
@@ -39,39 +31,6 @@ class RemoteLog:
     async def content(self) -> str:
         """Content of the url."""
         return await self.get_url_content()
-
-    @classmethod
-    def zip_text(cls, text: str) -> bytes:
-        """
-        Compress the given text.
-
-        Returns:
-            bytes: Compressed text
-        """
-        return cls.COMPRESSOR.zip({cls.LOG_FILE_NAME: text})
-
-    async def zip_content(self) -> bytes:
-        """
-        Compress the content of the remote log.
-
-        Returns:
-            bytes: Compressed log content
-        """
-        content_text = await self.content
-        return self.zip_text(content_text)
-
-    @classmethod
-    def unzip(cls, zip_data: Union[bytes, io.BytesIO]) -> str:
-        """
-        Uncompress the zipped content of the remote log.
-
-        Args:
-            zip_data: Compressed data as bytes or BytesIO
-
-        Returns:
-            str: The decompressed log content
-        """
-        return cls.COMPRESSOR.unzip(zip_data)[cls.LOG_FILE_NAME]
 
     def validate_url(self) -> bool:
         """Validate incoming URL to be at least somewhat sensible for log files

--- a/logdetective/server/config.py
+++ b/logdetective/server/config.py
@@ -1,18 +1,8 @@
+import os
 import logging
 import yaml
-from logdetective.constants import SNIPPET_DELIMITER
-from logdetective.server.models import Config, AnalyzedSnippet
-
-
-def format_analyzed_snippets(snippets: list[AnalyzedSnippet]) -> str:
-    """Format snippets for submission into staged prompt."""
-    summary = f"\n{SNIPPET_DELIMITER}\n".join(
-        [
-            f"[{e.text}] at line [{e.line_number}]: [{e.explanation.text}]"
-            for e in snippets
-        ]
-    )
-    return summary
+from logdetective.utils import load_prompts
+from logdetective.server.models import Config
 
 
 def load_server_config(path: str | None) -> Config:
@@ -57,3 +47,12 @@ def get_log(config: Config):
 
     log.initialized = True
     return log
+
+
+SERVER_CONFIG_PATH = os.environ.get("LOGDETECTIVE_SERVER_CONF", None)
+SERVER_PROMPT_PATH = os.environ.get("LOGDETECTIVE_PROMPTS", None)
+
+SERVER_CONFIG = load_server_config(SERVER_CONFIG_PATH)
+PROMPT_CONFIG = load_prompts(SERVER_PROMPT_PATH)
+
+LOG = get_log(SERVER_CONFIG)

--- a/logdetective/server/database/models/merge_request_jobs.py
+++ b/logdetective/server/database/models/merge_request_jobs.py
@@ -170,12 +170,7 @@ class Comments(Base):
         index=True,
         comment="The associated merge request job (db) id",
     )
-    forge = Column(
-        Enum(Forge),
-        nullable=False,
-        index=True,
-        comment="The forge name"
-    )
+    forge = Column(Enum(Forge), nullable=False, index=True, comment="The forge name")
     comment_id = Column(
         String(50),  # e.g. 'd5a3ff139356ce33e37e73add446f16869741b50'
         nullable=False,
@@ -361,6 +356,20 @@ class Comments(Base):
             id_ = Comments.create(forge, project_id, mr_iid, job_id, comment_id)
             comment = GitlabMergeRequestJobs.get_by_id(id_)
         return comment
+
+    @classmethod
+    def get_since(cls, time: datetime.datetime) -> Optional["Comments"]:
+        """Get all the comments created after the given time."""
+        with transaction(commit=False) as session:
+            comments = (
+                session.query(cls)
+                .filter(
+                    Comments.created_at > time,
+                )
+                .all()
+            )
+
+            return comments
 
 
 class Reactions(Base):

--- a/logdetective/server/database/models/merge_request_jobs.py
+++ b/logdetective/server/database/models/merge_request_jobs.py
@@ -132,6 +132,24 @@ class GitlabMergeRequestJobs(Base):
             return mr
 
     @classmethod
+    def get_by_mr_iid(
+        cls, forge: Forge, project_id: int, mr_iid
+    ) -> Optional["GitlabMergeRequestJobs"]:
+        """Get all the mr jobs saved for the specified mr iid and project id."""
+        with transaction(commit=False) as session:
+            comments = (
+                session.query(cls)
+                .filter(
+                    GitlabMergeRequestJobs.forge == forge,
+                    GitlabMergeRequestJobs.project_id == project_id,
+                    GitlabMergeRequestJobs.mr_iid == mr_iid,
+                )
+                .all()
+            )
+
+            return comments
+
+    @classmethod
     def get_or_create(
         cls,
         forge: Forge,
@@ -367,6 +385,22 @@ class Comments(Base):
                     Comments.created_at > time,
                 )
                 .all()
+            )
+
+            return comments
+
+    @classmethod
+    def get_by_mr_job(
+        cls, merge_request_job: GitlabMergeRequestJobs
+    ) -> Optional["Comments"]:
+        """Get the comment added for the specified merge request's job."""
+        with transaction(commit=False) as session:
+            comments = (
+                session.query(cls)
+                .filter(
+                    Comments.merge_request_job == merge_request_job,
+                )
+                .first()  # just one
             )
 
             return comments

--- a/logdetective/server/emoji.py
+++ b/logdetective/server/emoji.py
@@ -1,4 +1,3 @@
-import datetime
 import asyncio
 
 from typing import List
@@ -27,20 +26,13 @@ async def collect_emojis(gitlab_conn: gitlab.Gitlab, period: TimePeriod):
 
 
 async def collect_emojis_for_mr(
-    project_id: int, mr_iid: int, gitlab_conn: gitlab.Gitlab, period: TimePeriod
+    project_id: int, mr_iid: int, gitlab_conn: gitlab.Gitlab
 ):
     """
     Collect emoji feedback from logdetective comments in the specified MR.
-    Check only MR comments created in the last given period of time.
     """
     mr_jobs = GitlabMergeRequestJobs.get_by_mr_iid(gitlab_conn.url, project_id, mr_iid)
-    comments_for_mr = [Comments.get_by_mr_job(mr_job) for mr_job in mr_jobs]
-    comments = [
-        comment
-        for comment in comments_for_mr
-        if comment.created_at.replace(tzinfo=datetime.timezone.utc)
-        > period.get_period_start_time()  # noqa: W503 ruff vs flake
-    ]
+    comments = [Comments.get_by_mr_job(mr_job) for mr_job in mr_jobs]
     await collect_emojis_in_comments(comments, gitlab_conn)
 
 

--- a/logdetective/server/emoji.py
+++ b/logdetective/server/emoji.py
@@ -68,7 +68,12 @@ async def collect_emojis_in_comments(
         else:
             mr = mrs[mr_iid]
 
-        note = mr.notes.get(comment.comment_id)
+        discussion = mr.discussions.get(comment.comment_id)
+
+        # Get the ID of the first note
+        note_id = discussion.attributes["notes"][0]["id"]
+        note = mr.notes.get(note_id)
+
         emoji_counts = Counter(emoji.name for emoji in note.awardemojis.list())
 
         for key, value in emoji_counts.items():

--- a/logdetective/server/emoji.py
+++ b/logdetective/server/emoji.py
@@ -1,0 +1,53 @@
+import asyncio
+from collections import Counter
+
+import gitlab
+
+from logdetective.server.models import TimePeriod
+from logdetective.server.database.models import (
+    Comments,
+    Reactions,
+    GitlabMergeRequestJobs,
+)
+
+
+async def collect_emojis(gitlab_conn: gitlab.Gitlab, period: TimePeriod):
+    """
+    Collect emoji feedback from logdetective comments in MRs.
+    Check only MRs comments created on the last given period of time.
+    """
+    comments = Comments.get_since(period.get_period_start_time())
+    comments_for_gitlab_connection = [
+        comment for comment in comments if comment.forge == gitlab_conn.url
+    ]
+    projects = {}
+    mrs = {}
+    for comment in comments_for_gitlab_connection:
+        mr_job_db = GitlabMergeRequestJobs.get_by_id(comment.merge_request_job_id)
+        if mr_job_db.id not in projects:
+            projects[mr_job_db.id] = project = await asyncio.to_thread(
+                gitlab_conn.projects.get, mr_job_db.project_id
+            )
+        else:
+            project = projects[mr_job_db.id]
+        mr_iid = mr_job_db.mr_iid
+        if mr_iid not in mrs:
+            mrs[mr_iid] = mr = await asyncio.to_thread(
+                project.mergerequests.get, mr_iid
+            )
+        else:
+            mr = mrs[mr_iid]
+
+        note = mr.notes.get(comment.comment_id)
+        emoji_counts = Counter(emoji.name for emoji in note.awardemojis.list())
+
+        for key, value in emoji_counts.items():
+            Reactions.create_or_update(
+                comment.forge,
+                mr_job_db.project_id,
+                mr_job_db.mr_iid,
+                mr_job_db.job_id,
+                comment.comment_id,
+                key,
+                value,
+            )

--- a/logdetective/server/gitlab.py
+++ b/logdetective/server/gitlab.py
@@ -1,0 +1,408 @@
+import re
+import asyncio
+import zipfile
+from pathlib import Path, PurePath
+from tempfile import TemporaryFile
+
+from fastapi import HTTPException
+
+import gitlab
+import gitlab.v4
+import gitlab.v4.objects
+import jinja2
+import aiohttp
+import sqlalchemy
+
+from logdetective.server.config import SERVER_CONFIG, LOG
+from logdetective.server.llm import perform_staged_analysis
+from logdetective.server.metric import add_new_metrics, update_metrics
+from logdetective.server.models import (
+    JobHook,
+    StagedResponse,
+)
+from logdetective.server.database.models import (
+    Comments,
+    EndpointType,
+    Forge,
+    AnalyzeRequestMetrics,
+)
+from logdetective.server.compressors import RemoteLogCompressor
+
+MR_REGEX = re.compile(r"refs/merge-requests/(\d+)/.*$")
+FAILURE_LOG_REGEX = re.compile(r"(\w*\.log)")
+
+
+async def process_gitlab_job_event(
+    http: aiohttp.ClientSession,
+    gitlab_conn: gitlab.Gitlab,
+    forge: Forge,
+    job_hook: JobHook,
+):
+    """Handle a received job_event webhook from GitLab"""
+    LOG.debug("Received webhook message from %s:\n%s", forge.value, job_hook)
+
+    # Look up the project this job belongs to
+    project = await asyncio.to_thread(gitlab_conn.projects.get, job_hook.project_id)
+    LOG.info("Processing failed job for %s", project.name)
+
+    # Retrieve data about the job from the GitLab API
+    job = await asyncio.to_thread(project.jobs.get, job_hook.build_id)
+
+    # For easy retrieval later, we'll add project_name and project_url to the
+    # job object
+    job.project_name = project.name
+    job.project_url = project.web_url
+
+    # Retrieve the pipeline that started this job
+    pipeline = await asyncio.to_thread(project.pipelines.get, job_hook.pipeline_id)
+
+    # Verify this is a merge request
+    if pipeline.source != "merge_request_event":
+        LOG.info("Not a merge request pipeline. Ignoring.")
+        return
+
+    # Extract the merge-request ID from the job
+    match = MR_REGEX.search(pipeline.ref)
+    if not match:
+        LOG.error(
+            "Pipeline source is merge_request_event but no merge request ID was provided."
+        )
+        return
+    merge_request_iid = int(match.group(1))
+
+    LOG.debug("Retrieving log artifacts")
+    # Retrieve the build logs from the merge request artifacts and preprocess them
+    try:
+        log_url, preprocessed_log = await retrieve_and_preprocess_koji_logs(http, job)
+    except LogsTooLargeError:
+        LOG.error("Could not retrieve logs. Too large.")
+        raise
+
+    # Submit log to Log Detective and await the results.
+    log_text = preprocessed_log.read().decode(encoding="utf-8")
+    metrics_id = await add_new_metrics(
+        api_name=EndpointType.ANALYZE_GITLAB_JOB,
+        url=log_url,
+        http_session=http,
+        compressed_log_content=RemoteLogCompressor.zip_text(log_text),
+    )
+    staged_response = await perform_staged_analysis(http, log_text=log_text)
+    update_metrics(metrics_id, staged_response)
+    preprocessed_log.close()
+
+    # check if this project is on the opt-in list for posting comments.
+    if project.name not in SERVER_CONFIG.general.packages:
+        LOG.info("Not publishing comment for unrecognized package %s", project.name)
+        return
+
+    # Add the Log Detective response as a comment to the merge request
+    await comment_on_mr(
+        forge,
+        project,
+        merge_request_iid,
+        job,
+        log_url,
+        staged_response,
+        metrics_id,
+    )
+
+    return staged_response
+
+
+class LogsTooLargeError(RuntimeError):
+    """The log archive exceeds the configured maximum size"""
+
+
+async def retrieve_and_preprocess_koji_logs(
+    http: aiohttp.ClientSession, job: gitlab.v4.objects.ProjectJob
+):  # pylint: disable=too-many-branches
+    """Download logs from the merge request artifacts
+
+    This function will retrieve the build logs and do some minimal
+    preprocessing to determine which log is relevant for analysis.
+
+    returns: The URL pointing to the selected log file and an open, file-like
+    object containing the log contents to be sent for processing by Log
+    Detective. The calling function is responsible for closing this object."""
+
+    # Make sure the file isn't too large to process.
+    if not await check_artifacts_file_size(http, job):
+        raise LogsTooLargeError(
+            f"Oversized logs for job {job.id} in project {job.project_id}"
+        )
+
+    # Create a temporary file to store the downloaded log zipfile.
+    # This will be automatically deleted when the last reference into it
+    # (returned by this function) is closed.
+    tempfile = TemporaryFile(mode="w+b")
+    await asyncio.to_thread(job.artifacts, streamed=True, action=tempfile.write)
+    tempfile.seek(0)
+
+    failed_arches = {}
+    artifacts_zip = zipfile.ZipFile(tempfile, mode="r")  # pylint: disable=consider-using-with
+    for zipinfo in artifacts_zip.infolist():
+        if zipinfo.filename.endswith("task_failed.log"):
+            # The koji logs store this file in two places: 1) in the
+            # directory with the failed architecture and 2) in the parent
+            # directory. Most of the time, we want to ignore the one in the
+            # parent directory, since the rest of the information is in the
+            # specific task directory. However, there are some situations
+            # where non-build failures (such as "Target build already exists")
+            # may be presented only at the top level.
+            # The paths look like `kojilogs/noarch-XXXXXX/task_failed.log`
+            # or `kojilogs/noarch-XXXXXX/x86_64-XXXXXX/task_failed.log`
+            path = PurePath(zipinfo.filename)
+            if len(path.parts) <= 3:
+                failed_arches["toplevel"] = path
+                continue
+
+            # Extract the architecture from the immediate parent path
+            architecture = path.parent.parts[-1].split("-")[0]
+
+            # Open this file and read which log failed.
+            # The string in this log has the format
+            # `see <log> for more information`.
+            # Note: it may sometimes say
+            # `see build.log or root.log for more information`, but in
+            # that situation, we only want to handle build.log (for now),
+            # which means accepting only the first match for the regular
+            # expression.
+            with artifacts_zip.open(zipinfo.filename) as task_failed_log:
+                contents = task_failed_log.read().decode("utf-8")
+                match = FAILURE_LOG_REGEX.search(contents)
+                if not match:
+                    LOG.error(
+                        "task_failed.log does not indicate which log contains the failure."
+                    )
+                    raise SyntaxError(
+                        "task_failed.log does not indicate which log contains the failure."
+                    )
+                failure_log_name = match.group(1)
+
+            failed_arches[architecture] = PurePath(path.parent, failure_log_name)
+
+    if not failed_arches:
+        # No failed task found in the sub-tasks.
+        raise FileNotFoundError("Could not detect failed architecture.")
+
+    # We only want to handle one arch, so we'll check them in order of
+    # "most to least likely for the maintainer to have access to hardware"
+    # This means: x86_64 > aarch64 > riscv > ppc64le > s390x
+    if "x86_64" in failed_arches:
+        failed_arch = "x86_64"
+    elif "aarch64" in failed_arches:
+        failed_arch = "aarch64"
+    elif "riscv" in failed_arches:
+        failed_arch = "riscv"
+    elif "ppc64le" in failed_arches:
+        failed_arch = "ppc64le"
+    elif "s390x" in failed_arches:
+        failed_arch = "s390x"
+    elif "noarch" in failed_arches:
+        # May have failed during BuildSRPMFromSCM phase
+        failed_arch = "noarch"
+    elif "toplevel" in failed_arches:
+        # Probably a Koji-specific error, not a build error
+        failed_arch = "toplevel"
+    else:
+        # We have one or more architectures that we don't know about? Just
+        # pick the first alphabetically.
+        failed_arch = sorted(list(failed_arches.keys()))[0]
+
+    LOG.debug("Failed architecture: %s", failed_arch)
+
+    log_path = failed_arches[failed_arch].as_posix()
+
+    log_url = f"{SERVER_CONFIG.gitlab.api_url}/projects/{job.project_id}/jobs/{job.id}/artifacts/{log_path}"  # pylint: disable=line-too-long
+    LOG.debug("Returning contents of %s", log_url)
+
+    # Return the log as a file-like object with .read() function
+    return log_url, artifacts_zip.open(log_path)
+
+
+async def check_artifacts_file_size(
+    http: aiohttp.ClientSession,
+    job: gitlab.v4.objects.ProjectJob,
+):
+    """Method to determine if the artifacts are too large to process"""
+    # First, make sure that the artifacts are of a reasonable size. The
+    # zipped artifact collection will be stored in memory below. The
+    # python-gitlab library doesn't expose a way to check this value directly,
+    # so we need to interact with directly with the headers.
+    artifacts_url = f"{SERVER_CONFIG.gitlab.api_url}/projects/{job.project_id}/jobs/{job.id}/artifacts"  # pylint: disable=line-too-long
+    LOG.debug("checking artifact URL %s", artifacts_url)
+    try:
+        head_response = await http.head(
+            artifacts_url,
+            allow_redirects=True,
+            headers={"Authorization": f"Bearer {SERVER_CONFIG.gitlab.api_token}"},
+            timeout=5,
+            raise_for_status=True,
+        )
+    except aiohttp.ClientResponseError as ex:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unable to check artifact URL: [{ex.status}] {ex.message}",
+        ) from ex
+    content_length = int(head_response.headers.get("content-length"))
+    LOG.debug(
+        "URL: %s, content-length: %d, max length: %d",
+        artifacts_url,
+        content_length,
+        SERVER_CONFIG.gitlab.max_artifact_size,
+    )
+    return content_length <= SERVER_CONFIG.gitlab.max_artifact_size
+
+
+async def comment_on_mr(  # pylint: disable=too-many-arguments disable=too-many-positional-arguments
+    forge: Forge,
+    project: gitlab.v4.objects.Project,
+    merge_request_iid: int,
+    job: gitlab.v4.objects.ProjectJob,
+    log_url: str,
+    response: StagedResponse,
+    metrics_id: int,
+):
+    """Add the Log Detective response as a comment to the merge request"""
+    LOG.debug(
+        "Primary Explanation for %s MR %d: %s",
+        project.name,
+        merge_request_iid,
+        response.explanation.text,
+    )
+
+    # First, we'll see if there's an existing comment on this Merge Request
+    # and wrap it in <details></details> to reduce noise.
+    await suppress_latest_comment(forge, project, merge_request_iid)
+
+    # Get the formatted short comment.
+    short_comment = await generate_mr_comment(job, log_url, response, full=False)
+
+    # Look up the merge request
+    merge_request = await asyncio.to_thread(
+        project.mergerequests.get, merge_request_iid
+    )
+
+    # Submit a new comment to the Merge Request using the Gitlab API
+    discussion = await asyncio.to_thread(
+        merge_request.discussions.create, {"body": short_comment}
+    )
+
+    # Get the ID of the first note
+    note_id = discussion.attributes["notes"][0]["id"]
+    note = discussion.notes.get(note_id)
+
+    # Update the comment with the full details
+    # We do this in a second step so we don't bombard the user's email
+    # notifications with a massive message. Gitlab doesn't send email for
+    # comment edits.
+    full_comment = await generate_mr_comment(job, log_url, response, full=True)
+    note.body = full_comment
+
+    # Pause for five seconds before sending the snippet data, otherwise
+    # Gitlab may bundle the edited message together with the creation
+    # message in email.
+    await asyncio.sleep(5)
+    await asyncio.to_thread(note.save)
+
+    # Save the new comment to the database
+    try:
+        metrics = AnalyzeRequestMetrics.get_metric_by_id(metrics_id)
+        Comments.create(
+            forge,
+            project.id,
+            merge_request_iid,
+            job.id,
+            discussion.id,
+            metrics,
+        )
+    except sqlalchemy.exc.IntegrityError:
+        # We most likely attempted to save a new comment for the same
+        # build job. This is somewhat common during development when we're
+        # submitting requests manually. It shouldn't really happen in
+        # production.
+        if not SERVER_CONFIG.general.devmode:
+            raise
+
+
+async def suppress_latest_comment(
+    gitlab_instance: str,
+    project: gitlab.v4.objects.Project,
+    merge_request_iid: int,
+) -> None:
+    """Look up the latest comment on this Merge Request, if any, and wrap it
+    in a <details></details> block with a comment indicating that it has been
+    superseded by a new push."""
+
+    # Ask the database for the last known comment for this MR
+    previous_comment = Comments.get_latest_comment(
+        gitlab_instance, project.id, merge_request_iid
+    )
+
+    if previous_comment is None:
+        # No existing comment, so nothing to do.
+        return
+
+    # Retrieve its content from the Gitlab API
+
+    # Look up the merge request
+    merge_request = await asyncio.to_thread(
+        project.mergerequests.get, merge_request_iid
+    )
+
+    # Find the discussion matching the latest comment ID
+    discussion = await asyncio.to_thread(
+        merge_request.discussions.get, previous_comment.comment_id
+    )
+
+    # Get the ID of the first note
+    note_id = discussion.attributes["notes"][0]["id"]
+    note = discussion.notes.get(note_id)
+
+    # Wrap the note in <details>, indicating why.
+    note.body = (
+        "This comment has been superseded by a newer "
+        f"Log Detective analysis.\n<details>\n{note.body}\n</details>"
+    )
+    await asyncio.to_thread(note.save)
+
+
+async def generate_mr_comment(
+    job: gitlab.v4.objects.ProjectJob,
+    log_url: str,
+    response: StagedResponse,
+    full: bool = True,
+) -> str:
+    """Use a template to generate a comment string to submit to Gitlab"""
+
+    # Locate and load the comment template
+    script_path = Path(__file__).resolve().parent
+    template_path = Path(script_path, "templates")
+    jinja_env = jinja2.Environment(loader=jinja2.FileSystemLoader(template_path))
+
+    if full:
+        tpl = jinja_env.get_template("gitlab_full_comment.md.j2")
+    else:
+        tpl = jinja_env.get_template("gitlab_short_comment.md.j2")
+
+    artifacts_url = f"{job.project_url}/-/jobs/{job.id}/artifacts/download"
+
+    if response.response_certainty >= 90:
+        emoji_face = ":slight_smile:"
+    elif response.response_certainty >= 70:
+        emoji_face = ":neutral_face:"
+    else:
+        emoji_face = ":frowning2:"
+
+    # Generate the comment from the template
+    content = tpl.render(
+        package=job.project_name,
+        explanation=response.explanation.text,
+        certainty=f"{response.response_certainty:.2f}",
+        emoji_face=emoji_face,
+        snippets=response.snippets,
+        log_url=log_url,
+        artifacts_url=artifacts_url,
+    )
+
+    return content

--- a/logdetective/server/llm.py
+++ b/logdetective/server/llm.py
@@ -1,0 +1,284 @@
+import os
+import asyncio
+import json
+from typing import List, Tuple, Dict, Any, Union
+
+import backoff
+from aiohttp import StreamReader
+from fastapi import HTTPException
+
+import aiohttp
+
+from logdetective.constants import SNIPPET_DELIMITER
+from logdetective.extractors import DrainExtractor
+from logdetective.utils import (
+    compute_certainty,
+)
+from logdetective.server.config import LOG, SERVER_CONFIG, PROMPT_CONFIG
+from logdetective.server.models import (
+    StagedResponse,
+    Explanation,
+    AnalyzedSnippet,
+)
+
+
+LLM_CPP_SERVER_TIMEOUT = os.environ.get("LLAMA_CPP_SERVER_TIMEOUT", 600)
+
+
+def format_analyzed_snippets(snippets: list[AnalyzedSnippet]) -> str:
+    """Format snippets for submission into staged prompt."""
+    summary = f"\n{SNIPPET_DELIMITER}\n".join(
+        [
+            f"[{e.text}] at line [{e.line_number}]: [{e.explanation.text}]"
+            for e in snippets
+        ]
+    )
+    return summary
+
+
+def mine_logs(log: str) -> List[Tuple[int, str]]:
+    """Extract snippets from log text"""
+    extractor = DrainExtractor(
+        verbose=True, context=True, max_clusters=SERVER_CONFIG.extractor.max_clusters
+    )
+
+    LOG.info("Getting summary")
+    log_summary = extractor(log)
+
+    ratio = len(log_summary) / len(log.split("\n"))
+    LOG.debug("Log summary: \n %s", log_summary)
+    LOG.info("Compression ratio: %s", ratio)
+
+    return log_summary
+
+
+async def submit_to_llm_endpoint(
+    http: aiohttp.ClientSession,
+    url: str,
+    data: Dict[str, Any],
+    headers: Dict[str, str],
+    stream: bool,
+) -> Any:
+    """Send request to selected API endpoint. Verifying successful request unless
+    the using the stream response.
+
+    url:
+    data:
+    headers:
+    stream:
+    """
+    LOG.debug("async request %s headers=%s data=%s", url, headers, data)
+    response = await http.post(
+        url,
+        headers=headers,
+        # we need to use the `json=` parameter here and let aiohttp
+        # handle the json-encoding
+        json=data,
+        timeout=int(LLM_CPP_SERVER_TIMEOUT),
+        # Docs says chunked takes int, but:
+        #   DeprecationWarning: Chunk size is deprecated #1615
+        # So let's make sure we either put True or None here
+        chunked=True if stream else None,
+        raise_for_status=True,
+    )
+    if stream:
+        return response
+    try:
+        return json.loads(await response.text())
+    except UnicodeDecodeError as ex:
+        LOG.error("Error encountered while parsing llama server response: %s", ex)
+        raise HTTPException(
+            status_code=400,
+            detail=f"Couldn't parse the response.\nError: {ex}\nData: {response.text}",
+        ) from ex
+
+
+def should_we_giveup(exc: aiohttp.ClientResponseError) -> bool:
+    """
+    From backoff's docs:
+
+    > a function which accepts the exception and returns
+    > a truthy value if the exception should not be retried
+    """
+    LOG.info("Should we give up on retrying error %s", exc)
+    return exc.status < 500
+
+
+def we_give_up(details: backoff._typing.Details):
+    """
+    retries didn't work (or we got a different exc)
+    we give up and raise proper 500 for our API endpoint
+    """
+    LOG.error("Inference error: %s", details["args"])
+    raise HTTPException(500, "Request to the inference API failed")
+
+
+@backoff.on_exception(
+    backoff.expo,
+    aiohttp.ClientResponseError,
+    max_tries=3,
+    giveup=should_we_giveup,
+    raise_on_giveup=False,
+    on_giveup=we_give_up,
+)
+async def submit_text(  # pylint: disable=R0913,R0917
+    http: aiohttp.ClientSession,
+    text: str,
+    max_tokens: int = -1,
+    log_probs: int = 1,
+    stream: bool = False,
+    model: str = "default-model",
+) -> Explanation:
+    """Submit prompt to LLM using a selected endpoint.
+    max_tokens: number of tokens to be produces, 0 indicates run until encountering EOS
+    log_probs: number of token choices to produce log probs for
+    """
+    LOG.info("Analyzing the text")
+
+    headers = {"Content-Type": "application/json"}
+
+    if SERVER_CONFIG.inference.api_token:
+        headers["Authorization"] = f"Bearer {SERVER_CONFIG.inference.api_token}"
+
+    if SERVER_CONFIG.inference.api_endpoint == "/chat/completions":
+        return await submit_text_chat_completions(
+            http, text, headers, max_tokens, log_probs > 0, stream, model
+        )
+    return await submit_text_completions(
+        http, text, headers, max_tokens, log_probs, stream, model
+    )
+
+
+async def submit_text_completions(  # pylint: disable=R0913,R0917
+    http: aiohttp.ClientSession,
+    text: str,
+    headers: dict,
+    max_tokens: int = -1,
+    log_probs: int = 1,
+    stream: bool = False,
+    model: str = "default-model",
+) -> Explanation:
+    """Submit prompt to OpenAI API completions endpoint.
+    max_tokens: number of tokens to be produces, 0 indicates run until encountering EOS
+    log_probs: number of token choices to produce log probs for
+    """
+    LOG.info("Submitting to /v1/completions endpoint")
+    data = {
+        "prompt": text,
+        "max_tokens": max_tokens,
+        "logprobs": log_probs,
+        "stream": stream,
+        "model": model,
+        "temperature": SERVER_CONFIG.inference.temperature,
+    }
+
+    response = await submit_to_llm_endpoint(
+        http,
+        f"{SERVER_CONFIG.inference.url}/v1/completions",
+        data,
+        headers,
+        stream,
+    )
+
+    return Explanation(
+        text=response["choices"][0]["text"], logprobs=response["choices"][0]["logprobs"]
+    )
+
+
+async def submit_text_chat_completions(  # pylint: disable=R0913,R0917
+    http: aiohttp.ClientSession,
+    text: str,
+    headers: dict,
+    max_tokens: int = -1,
+    log_probs: int = 1,
+    stream: bool = False,
+    model: str = "default-model",
+) -> Union[Explanation, StreamReader]:
+    """Submit prompt to OpenAI API /chat/completions endpoint.
+    max_tokens: number of tokens to be produces, 0 indicates run until encountering EOS
+    log_probs: number of token choices to produce log probs for
+    """
+    LOG.info("Submitting to /v1/chat/completions endpoint")
+
+    data = {
+        "messages": [
+            {
+                "role": "user",
+                "content": text,
+            }
+        ],
+        "max_tokens": max_tokens,
+        "logprobs": log_probs,
+        "stream": stream,
+        "model": model,
+        "temperature": SERVER_CONFIG.inference.temperature,
+    }
+
+    response = await submit_to_llm_endpoint(
+        http,
+        f"{SERVER_CONFIG.inference.url}/v1/chat/completions",
+        data,
+        headers,
+        stream,
+    )
+
+    if stream:
+        return response
+    return Explanation(
+        text=response["choices"][0]["message"]["content"],
+        logprobs=response["choices"][0]["logprobs"]["content"],
+    )
+
+
+async def perform_staged_analysis(
+    http: aiohttp.ClientSession, log_text: str
+) -> StagedResponse:
+    """Submit the log file snippets to the LLM and retrieve their results"""
+    log_summary = mine_logs(log_text)
+
+    # Process snippets asynchronously
+    analyzed_snippets = await asyncio.gather(
+        *[
+            submit_text(
+                http,
+                PROMPT_CONFIG.snippet_prompt_template.format(s),
+                model=SERVER_CONFIG.inference.model,
+                max_tokens=SERVER_CONFIG.inference.max_tokens,
+            )
+            for s in log_summary
+        ]
+    )
+
+    analyzed_snippets = [
+        AnalyzedSnippet(line_number=e[0][0], text=e[0][1], explanation=e[1])
+        for e in zip(log_summary, analyzed_snippets)
+    ]
+    final_prompt = PROMPT_CONFIG.prompt_template_staged.format(
+        format_analyzed_snippets(analyzed_snippets)
+    )
+
+    final_analysis = await submit_text(
+        http,
+        final_prompt,
+        model=SERVER_CONFIG.inference.model,
+        max_tokens=SERVER_CONFIG.inference.max_tokens,
+    )
+
+    certainty = 0
+
+    if final_analysis.logprobs:
+        try:
+            certainty = compute_certainty(final_analysis.logprobs)
+        except ValueError as ex:
+            LOG.error("Error encountered while computing certainty: %s", ex)
+            raise HTTPException(
+                status_code=400,
+                detail=f"Couldn't compute certainty with data:\n"
+                f"{final_analysis.logprobs}",
+            ) from ex
+
+    return StagedResponse(
+        explanation=final_analysis,
+        snippets=analyzed_snippets,
+        response_certainty=certainty,
+    )

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -232,7 +232,7 @@ class TimePeriod(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def check_exclusive_fields(cls, data):
-        """ Check that only one key between weeks, days and hours is defined"""
+        """Check that only one key between weeks, days and hours is defined"""
         if isinstance(data, dict):
             how_many_fields = sum(
                 1
@@ -284,6 +284,6 @@ class TimePeriod(BaseModel):
             datetime.datetime: The start time of the period.
         """
         time = end_time or datetime.datetime.now(datetime.timezone.utc)
-        if end_time.tzinfo is None:
+        if time.tzinfo is None:
             end_time = end_time.replace(tzinfo=datetime.timezone.utc)
         return time - self.get_time_period()

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -46,6 +46,33 @@ class JobHook(BaseModel):
     project_id: int
 
 
+class EmojiMergeRequest(BaseModel):
+    """Model of the 'merge_request' subsection of Emoji webhook messages.
+    This model implements only the fields that we care about. The webhook
+    sends many more fields that we will ignore."""
+
+    # The identifier of the target project
+    target_project_id: int
+
+    # The internal identifier (relative to the target project)
+    iid: int
+
+
+class EmojiHook(BaseModel):
+    """Model of Job Hook events sent from GitLab.
+    Full details of the specification are available at
+    https://docs.gitlab.com/user/project/integrations/webhook_events/#job-events
+    This model implements only the fields that we care about. The webhook
+    sends many more fields that we will ignore."""
+
+    # The kind of webhook message. We are only interested in 'emoji' messages
+    # which represents awarding or revoking emoji reactions on notes.
+    object_kind: str = Field(pattern=r"^emoji$")
+
+    # Information about the merge request this emoji applies to, if any.
+    merge_request: EmojiMergeRequest = Field(default=None)
+
+
 class Explanation(BaseModel):
     """Model of snippet or general log explanation from Log Detective"""
 

--- a/logdetective/server/server.py
+++ b/logdetective/server/server.py
@@ -1,4 +1,4 @@
-import asyncio
+import asyncio  # pylint: disable=too-many-lines
 import json
 import os
 import re

--- a/logdetective/server/server.py
+++ b/logdetective/server/server.py
@@ -1,78 +1,56 @@
-import asyncio  # pylint: disable=too-many-lines
-import json
 import os
-import re
-import zipfile
+import asyncio
 import datetime
 from enum import Enum
 from contextlib import asynccontextmanager
-from pathlib import Path, PurePath
-from tempfile import TemporaryFile
-from typing import List, Annotated, Tuple, Dict, Any, Union
+from typing import Annotated
 from io import BytesIO
 
-import backoff
 import matplotlib
 import matplotlib.pyplot
-from aiohttp import StreamReader
 from fastapi import FastAPI, HTTPException, BackgroundTasks, Depends, Header, Request
 
 from fastapi.responses import StreamingResponse
 from fastapi.responses import Response as BasicResponse
 import gitlab
-import gitlab.v4
-import gitlab.v4.objects
-import jinja2
 import aiohttp
-import sqlalchemy
 import sentry_sdk
 
 import logdetective.server.database.base
 
-from logdetective.extractors import DrainExtractor
 from logdetective.utils import (
     compute_certainty,
     format_snippets,
-    load_prompts,
 )
-from logdetective.server.utils import (
-    load_server_config,
-    get_log,
-    format_analyzed_snippets,
+
+from logdetective.server.config import SERVER_CONFIG, PROMPT_CONFIG, LOG
+from logdetective.remote_log import RemoteLog
+from logdetective.server.llm import (
+    mine_logs,
+    perform_staged_analysis,
+    submit_text,
+    submit_text_chat_completions,
 )
-from logdetective.server.metric import track_request, add_new_metrics, update_metrics
+from logdetective.server.gitlab import process_gitlab_job_event
+from logdetective.server.metric import track_request
 from logdetective.server.models import (
     BuildLog,
     JobHook,
     Response,
     StagedResponse,
-    Explanation,
-    AnalyzedSnippet,
     TimePeriod,
 )
 from logdetective.server import plot as plot_engine
-from logdetective.server.remote_log import RemoteLog
 from logdetective.server.database.models import (
-    Comments,
     EndpointType,
     Forge,
 )
-from logdetective.server.database.models import AnalyzeRequestMetrics
 from logdetective.server.emoji import collect_emojis
 
-LLM_CPP_SERVER_TIMEOUT = os.environ.get("LLAMA_CPP_SERVER_TIMEOUT", 600)
+
 LOG_SOURCE_REQUEST_TIMEOUT = os.environ.get("LOG_SOURCE_REQUEST_TIMEOUT", 60)
 API_TOKEN = os.environ.get("LOGDETECTIVE_TOKEN", None)
-SERVER_CONFIG_PATH = os.environ.get("LOGDETECTIVE_SERVER_CONF", None)
-SERVER_PROMPT_PATH = os.environ.get("LOGDETECTIVE_PROMPTS", None)
 
-SERVER_CONFIG = load_server_config(SERVER_CONFIG_PATH)
-PROMPT_CONFIG = load_prompts(SERVER_PROMPT_PATH)
-
-MR_REGEX = re.compile(r"refs/merge-requests/(\d+)/.*$")
-FAILURE_LOG_REGEX = re.compile(r"(\w*\.log)")
-
-LOG = get_log(SERVER_CONFIG)
 
 if sentry_dsn := SERVER_CONFIG.general.sentry_dsn:
     sentry_sdk.init(dsn=str(sentry_dsn), traces_sample_rate=1.0)
@@ -142,200 +120,6 @@ app.gitlab_conn = gitlab.Gitlab(
 )
 
 
-def mine_logs(log: str) -> List[Tuple[int, str]]:
-    """Extract snippets from log text"""
-    extractor = DrainExtractor(
-        verbose=True, context=True, max_clusters=SERVER_CONFIG.extractor.max_clusters
-    )
-
-    LOG.info("Getting summary")
-    log_summary = extractor(log)
-
-    ratio = len(log_summary) / len(log.split("\n"))
-    LOG.debug("Log summary: \n %s", log_summary)
-    LOG.info("Compression ratio: %s", ratio)
-
-    return log_summary
-
-
-async def submit_to_llm_endpoint(
-    http: aiohttp.ClientSession,
-    url: str,
-    data: Dict[str, Any],
-    headers: Dict[str, str],
-    stream: bool,
-) -> Any:
-    """Send request to selected API endpoint. Verifying successful request unless
-    the using the stream response.
-
-    url:
-    data:
-    headers:
-    stream:
-    """
-    LOG.debug("async request %s headers=%s data=%s", url, headers, data)
-    response = await http.post(
-        url,
-        headers=headers,
-        # we need to use the `json=` parameter here and let aiohttp
-        # handle the json-encoding
-        json=data,
-        timeout=int(LLM_CPP_SERVER_TIMEOUT),
-        # Docs says chunked takes int, but:
-        #   DeprecationWarning: Chunk size is deprecated #1615
-        # So let's make sure we either put True or None here
-        chunked=True if stream else None,
-        raise_for_status=True,
-    )
-    if stream:
-        return response
-    try:
-        return json.loads(await response.text())
-    except UnicodeDecodeError as ex:
-        LOG.error("Error encountered while parsing llama server response: %s", ex)
-        raise HTTPException(
-            status_code=400,
-            detail=f"Couldn't parse the response.\nError: {ex}\nData: {response.text}",
-        ) from ex
-
-
-def should_we_giveup(exc: aiohttp.ClientResponseError) -> bool:
-    """
-    From backoff's docs:
-
-    > a function which accepts the exception and returns
-    > a truthy value if the exception should not be retried
-    """
-    LOG.info("Should we give up on retrying error %s", exc)
-    return exc.status < 500
-
-
-def we_give_up(details: backoff._typing.Details):
-    """
-    retries didn't work (or we got a different exc)
-    we give up and raise proper 500 for our API endpoint
-    """
-    LOG.error("Inference error: %s", details["args"])
-    raise HTTPException(500, "Request to the inference API failed")
-
-
-@backoff.on_exception(
-    backoff.expo,
-    aiohttp.ClientResponseError,
-    max_tries=3,
-    giveup=should_we_giveup,
-    raise_on_giveup=False,
-    on_giveup=we_give_up,
-)
-async def submit_text(  # pylint: disable=R0913,R0917
-    http: aiohttp.ClientSession,
-    text: str,
-    max_tokens: int = -1,
-    log_probs: int = 1,
-    stream: bool = False,
-    model: str = "default-model",
-) -> Explanation:
-    """Submit prompt to LLM using a selected endpoint.
-    max_tokens: number of tokens to be produces, 0 indicates run until encountering EOS
-    log_probs: number of token choices to produce log probs for
-    """
-    LOG.info("Analyzing the text")
-
-    headers = {"Content-Type": "application/json"}
-
-    if SERVER_CONFIG.inference.api_token:
-        headers["Authorization"] = f"Bearer {SERVER_CONFIG.inference.api_token}"
-
-    if SERVER_CONFIG.inference.api_endpoint == "/chat/completions":
-        return await submit_text_chat_completions(
-            http, text, headers, max_tokens, log_probs > 0, stream, model
-        )
-    return await submit_text_completions(
-        http, text, headers, max_tokens, log_probs, stream, model
-    )
-
-
-async def submit_text_completions(  # pylint: disable=R0913,R0917
-    http: aiohttp.ClientSession,
-    text: str,
-    headers: dict,
-    max_tokens: int = -1,
-    log_probs: int = 1,
-    stream: bool = False,
-    model: str = "default-model",
-) -> Explanation:
-    """Submit prompt to OpenAI API completions endpoint.
-    max_tokens: number of tokens to be produces, 0 indicates run until encountering EOS
-    log_probs: number of token choices to produce log probs for
-    """
-    LOG.info("Submitting to /v1/completions endpoint")
-    data = {
-        "prompt": text,
-        "max_tokens": max_tokens,
-        "logprobs": log_probs,
-        "stream": stream,
-        "model": model,
-        "temperature": SERVER_CONFIG.inference.temperature,
-    }
-
-    response = await submit_to_llm_endpoint(
-        http,
-        f"{SERVER_CONFIG.inference.url}/v1/completions",
-        data,
-        headers,
-        stream,
-    )
-
-    return Explanation(
-        text=response["choices"][0]["text"], logprobs=response["choices"][0]["logprobs"]
-    )
-
-
-async def submit_text_chat_completions(  # pylint: disable=R0913,R0917
-    http: aiohttp.ClientSession,
-    text: str,
-    headers: dict,
-    max_tokens: int = -1,
-    log_probs: int = 1,
-    stream: bool = False,
-    model: str = "default-model",
-) -> Union[Explanation, StreamReader]:
-    """Submit prompt to OpenAI API /chat/completions endpoint.
-    max_tokens: number of tokens to be produces, 0 indicates run until encountering EOS
-    log_probs: number of token choices to produce log probs for
-    """
-    LOG.info("Submitting to /v1/chat/completions endpoint")
-
-    data = {
-        "messages": [
-            {
-                "role": "user",
-                "content": text,
-            }
-        ],
-        "max_tokens": max_tokens,
-        "logprobs": log_probs,
-        "stream": stream,
-        "model": model,
-        "temperature": SERVER_CONFIG.inference.temperature,
-    }
-
-    response = await submit_to_llm_endpoint(
-        http,
-        f"{SERVER_CONFIG.inference.url}/v1/chat/completions",
-        data,
-        headers,
-        stream,
-    )
-
-    if stream:
-        return response
-    return Explanation(
-        text=response["choices"][0]["message"]["content"],
-        logprobs=response["choices"][0]["logprobs"]["content"],
-    )
-
-
 @app.post("/analyze", response_model=Response)
 @track_request()
 async def analyze_log(
@@ -387,60 +171,6 @@ async def analyze_log_staged(
     log_text = await remote_log.process_url()
 
     return await perform_staged_analysis(http_session, log_text=log_text)
-
-
-async def perform_staged_analysis(
-    http: aiohttp.ClientSession, log_text: str
-) -> StagedResponse:
-    """Submit the log file snippets to the LLM and retrieve their results"""
-    log_summary = mine_logs(log_text)
-
-    # Process snippets asynchronously
-    analyzed_snippets = await asyncio.gather(
-        *[
-            submit_text(
-                http,
-                PROMPT_CONFIG.snippet_prompt_template.format(s),
-                model=SERVER_CONFIG.inference.model,
-                max_tokens=SERVER_CONFIG.inference.max_tokens,
-            )
-            for s in log_summary
-        ]
-    )
-
-    analyzed_snippets = [
-        AnalyzedSnippet(line_number=e[0][0], text=e[0][1], explanation=e[1])
-        for e in zip(log_summary, analyzed_snippets)
-    ]
-    final_prompt = PROMPT_CONFIG.prompt_template_staged.format(
-        format_analyzed_snippets(analyzed_snippets)
-    )
-
-    final_analysis = await submit_text(
-        http,
-        final_prompt,
-        model=SERVER_CONFIG.inference.model,
-        max_tokens=SERVER_CONFIG.inference.max_tokens,
-    )
-
-    certainty = 0
-
-    if final_analysis.logprobs:
-        try:
-            certainty = compute_certainty(final_analysis.logprobs)
-        except ValueError as ex:
-            LOG.error("Error encountered while computing certainty: %s", ex)
-            raise HTTPException(
-                status_code=400,
-                detail=f"Couldn't compute certainty with data:\n"
-                f"{final_analysis.logprobs}",
-            ) from ex
-
-    return StagedResponse(
-        explanation=final_analysis,
-        snippets=analyzed_snippets,
-        response_certainty=certainty,
-    )
 
 
 @app.post("/analyze/stream", response_class=StreamingResponse)
@@ -503,386 +233,13 @@ async def receive_gitlab_job_event_webhook(
         return BasicResponse(status_code=400)
 
     # Handle the message in the background so we can return 200 immediately
-    background_tasks.add_task(process_gitlab_job_event, http, forge, job_hook)
+    background_tasks.add_task(
+        process_gitlab_job_event, http, app.gitlab_conn, forge, job_hook
+    )
 
     # No return value or body is required for a webhook.
     # 204: No Content
     return BasicResponse(status_code=204)
-
-
-async def process_gitlab_job_event(
-    http: aiohttp.ClientSession,
-    forge: Forge,
-    job_hook: JobHook,
-):
-    """Handle a received job_event webhook from GitLab"""
-    LOG.debug("Received webhook message from %s:\n%s", forge.value, job_hook)
-
-    # Look up the project this job belongs to
-    project = await asyncio.to_thread(app.gitlab_conn.projects.get, job_hook.project_id)
-    LOG.info("Processing failed job for %s", project.name)
-
-    # Retrieve data about the job from the GitLab API
-    job = await asyncio.to_thread(project.jobs.get, job_hook.build_id)
-
-    # For easy retrieval later, we'll add project_name and project_url to the
-    # job object
-    job.project_name = project.name
-    job.project_url = project.web_url
-
-    # Retrieve the pipeline that started this job
-    pipeline = await asyncio.to_thread(project.pipelines.get, job_hook.pipeline_id)
-
-    # Verify this is a merge request
-    if pipeline.source != "merge_request_event":
-        LOG.info("Not a merge request pipeline. Ignoring.")
-        return
-
-    # Extract the merge-request ID from the job
-    match = MR_REGEX.search(pipeline.ref)
-    if not match:
-        LOG.error(
-            "Pipeline source is merge_request_event but no merge request ID was provided."
-        )
-        return
-    merge_request_iid = int(match.group(1))
-
-    LOG.debug("Retrieving log artifacts")
-    # Retrieve the build logs from the merge request artifacts and preprocess them
-    try:
-        log_url, preprocessed_log = await retrieve_and_preprocess_koji_logs(http, job)
-    except LogsTooLargeError:
-        LOG.error("Could not retrieve logs. Too large.")
-        raise
-
-    # Submit log to Log Detective and await the results.
-    log_text = preprocessed_log.read().decode(encoding="utf-8")
-    metrics_id = await add_new_metrics(
-        api_name=EndpointType.ANALYZE_GITLAB_JOB,
-        url=log_url,
-        http_session=http,
-        compressed_log_content=RemoteLog.zip_text(log_text),
-    )
-    staged_response = await perform_staged_analysis(http, log_text=log_text)
-    update_metrics(metrics_id, staged_response)
-    preprocessed_log.close()
-
-    # check if this project is on the opt-in list for posting comments.
-    if project.name not in SERVER_CONFIG.general.packages:
-        LOG.info("Not publishing comment for unrecognized package %s", project.name)
-        return
-
-    # Add the Log Detective response as a comment to the merge request
-    await comment_on_mr(
-        forge,
-        project,
-        merge_request_iid,
-        job,
-        log_url,
-        staged_response,
-        metrics_id,
-    )
-
-    return staged_response
-
-
-class LogsTooLargeError(RuntimeError):
-    """The log archive exceeds the configured maximum size"""
-
-
-async def retrieve_and_preprocess_koji_logs(
-    http: aiohttp.ClientSession, job: gitlab.v4.objects.ProjectJob
-):  # pylint: disable=too-many-branches
-    """Download logs from the merge request artifacts
-
-    This function will retrieve the build logs and do some minimal
-    preprocessing to determine which log is relevant for analysis.
-
-    returns: The URL pointing to the selected log file and an open, file-like
-    object containing the log contents to be sent for processing by Log
-    Detective. The calling function is responsible for closing this object."""
-
-    # Make sure the file isn't too large to process.
-    if not await check_artifacts_file_size(http, job):
-        raise LogsTooLargeError(
-            f"Oversized logs for job {job.id} in project {job.project_id}"
-        )
-
-    # Create a temporary file to store the downloaded log zipfile.
-    # This will be automatically deleted when the last reference into it
-    # (returned by this function) is closed.
-    tempfile = TemporaryFile(mode="w+b")
-    await asyncio.to_thread(job.artifacts, streamed=True, action=tempfile.write)
-    tempfile.seek(0)
-
-    failed_arches = {}
-    artifacts_zip = zipfile.ZipFile(tempfile, mode="r")  # pylint: disable=consider-using-with
-    for zipinfo in artifacts_zip.infolist():
-        if zipinfo.filename.endswith("task_failed.log"):
-            # The koji logs store this file in two places: 1) in the
-            # directory with the failed architecture and 2) in the parent
-            # directory. Most of the time, we want to ignore the one in the
-            # parent directory, since the rest of the information is in the
-            # specific task directory. However, there are some situations
-            # where non-build failures (such as "Target build already exists")
-            # may be presented only at the top level.
-            # The paths look like `kojilogs/noarch-XXXXXX/task_failed.log`
-            # or `kojilogs/noarch-XXXXXX/x86_64-XXXXXX/task_failed.log`
-            path = PurePath(zipinfo.filename)
-            if len(path.parts) <= 3:
-                failed_arches["toplevel"] = path
-                continue
-
-            # Extract the architecture from the immediate parent path
-            architecture = path.parent.parts[-1].split("-")[0]
-
-            # Open this file and read which log failed.
-            # The string in this log has the format
-            # `see <log> for more information`.
-            # Note: it may sometimes say
-            # `see build.log or root.log for more information`, but in
-            # that situation, we only want to handle build.log (for now),
-            # which means accepting only the first match for the regular
-            # expression.
-            with artifacts_zip.open(zipinfo.filename) as task_failed_log:
-                contents = task_failed_log.read().decode("utf-8")
-                match = FAILURE_LOG_REGEX.search(contents)
-                if not match:
-                    LOG.error(
-                        "task_failed.log does not indicate which log contains the failure."
-                    )
-                    raise SyntaxError(
-                        "task_failed.log does not indicate which log contains the failure."
-                    )
-                failure_log_name = match.group(1)
-
-            failed_arches[architecture] = PurePath(path.parent, failure_log_name)
-
-    if not failed_arches:
-        # No failed task found in the sub-tasks.
-        raise FileNotFoundError("Could not detect failed architecture.")
-
-    # We only want to handle one arch, so we'll check them in order of
-    # "most to least likely for the maintainer to have access to hardware"
-    # This means: x86_64 > aarch64 > riscv > ppc64le > s390x
-    if "x86_64" in failed_arches:
-        failed_arch = "x86_64"
-    elif "aarch64" in failed_arches:
-        failed_arch = "aarch64"
-    elif "riscv" in failed_arches:
-        failed_arch = "riscv"
-    elif "ppc64le" in failed_arches:
-        failed_arch = "ppc64le"
-    elif "s390x" in failed_arches:
-        failed_arch = "s390x"
-    elif "noarch" in failed_arches:
-        # May have failed during BuildSRPMFromSCM phase
-        failed_arch = "noarch"
-    elif "toplevel" in failed_arches:
-        # Probably a Koji-specific error, not a build error
-        failed_arch = "toplevel"
-    else:
-        # We have one or more architectures that we don't know about? Just
-        # pick the first alphabetically.
-        failed_arch = sorted(list(failed_arches.keys()))[0]
-
-    LOG.debug("Failed architecture: %s", failed_arch)
-
-    log_path = failed_arches[failed_arch].as_posix()
-
-    log_url = f"{SERVER_CONFIG.gitlab.api_url}/projects/{job.project_id}/jobs/{job.id}/artifacts/{log_path}"  # pylint: disable=line-too-long
-    LOG.debug("Returning contents of %s", log_url)
-
-    # Return the log as a file-like object with .read() function
-    return log_url, artifacts_zip.open(log_path)
-
-
-async def check_artifacts_file_size(
-    http: aiohttp.ClientSession,
-    job: gitlab.v4.objects.ProjectJob,
-):
-    """Method to determine if the artifacts are too large to process"""
-    # First, make sure that the artifacts are of a reasonable size. The
-    # zipped artifact collection will be stored in memory below. The
-    # python-gitlab library doesn't expose a way to check this value directly,
-    # so we need to interact with directly with the headers.
-    artifacts_url = f"{SERVER_CONFIG.gitlab.api_url}/projects/{job.project_id}/jobs/{job.id}/artifacts"  # pylint: disable=line-too-long
-    LOG.debug("checking artifact URL %s", artifacts_url)
-    try:
-        head_response = await http.head(
-            artifacts_url,
-            allow_redirects=True,
-            headers={"Authorization": f"Bearer {SERVER_CONFIG.gitlab.api_token}"},
-            timeout=5,
-            raise_for_status=True,
-        )
-    except aiohttp.ClientResponseError as ex:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Unable to check artifact URL: [{ex.status}] {ex.message}",
-        ) from ex
-    content_length = int(head_response.headers.get("content-length"))
-    LOG.debug(
-        "URL: %s, content-length: %d, max length: %d",
-        artifacts_url,
-        content_length,
-        SERVER_CONFIG.gitlab.max_artifact_size,
-    )
-    return content_length <= SERVER_CONFIG.gitlab.max_artifact_size
-
-
-async def comment_on_mr(  # pylint: disable=too-many-arguments disable=too-many-positional-arguments
-    forge: Forge,
-    project: gitlab.v4.objects.Project,
-    merge_request_iid: int,
-    job: gitlab.v4.objects.ProjectJob,
-    log_url: str,
-    response: StagedResponse,
-    metrics_id: int,
-):
-    """Add the Log Detective response as a comment to the merge request"""
-    LOG.debug(
-        "Primary Explanation for %s MR %d: %s",
-        project.name,
-        merge_request_iid,
-        response.explanation.text,
-    )
-
-    # First, we'll see if there's an existing comment on this Merge Request
-    # and wrap it in <details></details> to reduce noise.
-    await suppress_latest_comment(forge, project, merge_request_iid)
-
-    # Get the formatted short comment.
-    short_comment = await generate_mr_comment(job, log_url, response, full=False)
-
-    # Look up the merge request
-    merge_request = await asyncio.to_thread(
-        project.mergerequests.get, merge_request_iid
-    )
-
-    # Submit a new comment to the Merge Request using the Gitlab API
-    discussion = await asyncio.to_thread(
-        merge_request.discussions.create, {"body": short_comment}
-    )
-
-    # Get the ID of the first note
-    note_id = discussion.attributes["notes"][0]["id"]
-    note = discussion.notes.get(note_id)
-
-    # Update the comment with the full details
-    # We do this in a second step so we don't bombard the user's email
-    # notifications with a massive message. Gitlab doesn't send email for
-    # comment edits.
-    full_comment = await generate_mr_comment(job, log_url, response, full=True)
-    note.body = full_comment
-
-    # Pause for five seconds before sending the snippet data, otherwise
-    # Gitlab may bundle the edited message together with the creation
-    # message in email.
-    await asyncio.sleep(5)
-    await asyncio.to_thread(note.save)
-
-    # Save the new comment to the database
-    try:
-        metrics = AnalyzeRequestMetrics.get_metric_by_id(metrics_id)
-        Comments.create(
-            forge,
-            project.id,
-            merge_request_iid,
-            job.id,
-            discussion.id,
-            metrics,
-        )
-    except sqlalchemy.exc.IntegrityError:
-        # We most likely attempted to save a new comment for the same
-        # build job. This is somewhat common during development when we're
-        # submitting requests manually. It shouldn't really happen in
-        # production.
-        if not SERVER_CONFIG.general.devmode:
-            raise
-
-
-async def suppress_latest_comment(
-    gitlab_instance: str,
-    project: gitlab.v4.objects.Project,
-    merge_request_iid: int,
-) -> None:
-    """Look up the latest comment on this Merge Request, if any, and wrap it
-    in a <details></details> block with a comment indicating that it has been
-    superseded by a new push."""
-
-    # Ask the database for the last known comment for this MR
-    previous_comment = Comments.get_latest_comment(
-        gitlab_instance, project.id, merge_request_iid
-    )
-
-    if previous_comment is None:
-        # No existing comment, so nothing to do.
-        return
-
-    # Retrieve its content from the Gitlab API
-
-    # Look up the merge request
-    merge_request = await asyncio.to_thread(
-        project.mergerequests.get, merge_request_iid
-    )
-
-    # Find the discussion matching the latest comment ID
-    discussion = await asyncio.to_thread(
-        merge_request.discussions.get, previous_comment.comment_id
-    )
-
-    # Get the ID of the first note
-    note_id = discussion.attributes["notes"][0]["id"]
-    note = discussion.notes.get(note_id)
-
-    # Wrap the note in <details>, indicating why.
-    note.body = (
-        "This comment has been superseded by a newer "
-        f"Log Detective analysis.\n<details>\n{note.body}\n</details>"
-    )
-    await asyncio.to_thread(note.save)
-
-
-async def generate_mr_comment(
-    job: gitlab.v4.objects.ProjectJob,
-    log_url: str,
-    response: StagedResponse,
-    full: bool = True,
-) -> str:
-    """Use a template to generate a comment string to submit to Gitlab"""
-
-    # Locate and load the comment template
-    script_path = Path(__file__).resolve().parent
-    template_path = Path(script_path, "templates")
-    jinja_env = jinja2.Environment(loader=jinja2.FileSystemLoader(template_path))
-
-    if full:
-        tpl = jinja_env.get_template("gitlab_full_comment.md.j2")
-    else:
-        tpl = jinja_env.get_template("gitlab_short_comment.md.j2")
-
-    artifacts_url = f"{job.project_url}/-/jobs/{job.id}/artifacts/download"
-
-    if response.response_certainty >= 90:
-        emoji_face = ":slight_smile:"
-    elif response.response_certainty >= 70:
-        emoji_face = ":neutral_face:"
-    else:
-        emoji_face = ":frowning2:"
-
-    # Generate the comment from the template
-    content = tpl.render(
-        package=job.project_name,
-        explanation=response.explanation.text,
-        certainty=f"{response.response_certainty:.2f}",
-        emoji_face=emoji_face,
-        snippets=response.snippets,
-        log_url=log_url,
-        artifacts_url=artifacts_url,
-    )
-
-    return content
 
 
 def _svg_figure_response(fig: matplotlib.figure.Figure):

--- a/logdetective/utils.py
+++ b/logdetective/utils.py
@@ -9,7 +9,7 @@ import yaml
 
 from llama_cpp import Llama, CreateCompletionResponse, CreateCompletionStreamResponse
 from logdetective.models import PromptConfig
-from logdetective.server.remote_log import RemoteLog
+from logdetective.remote_log import RemoteLog
 
 
 LOG = logging.getLogger("logdetective")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ include = [
     "logdetective/server/templates/gitlab_comment.md.j2",
     "logdetective/prompts.yml",
     "logdetective.1.asciidoc",
-    "logdetective/tests/data/**/*",
 ]
 packages = [
     { include = "logdetective" }
@@ -70,4 +69,9 @@ disable = [
     "missing-module-docstring",
     "too-few-public-methods",
     "unspecified-encoding",
+]
+
+[tool.pytest.ini_options]
+testpaths = [
+    "tests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ include = [
     "logdetective/server/templates/gitlab_comment.md.j2",
     "logdetective/prompts.yml",
     "logdetective.1.asciidoc",
+    "logdetective/tests/data/**/*",
 ]
 packages = [
     { include = "logdetective" }

--- a/tests/data/test_collect_emojis.yaml
+++ b/tests/data/test_collect_emojis.yaml
@@ -3,28 +3,28 @@ responses:
     auto_calculate_content_length: false
     body: '{"id":23667077,"description":"The libtiff rpms","name":"libtiff","name_with_namespace":"Red
       Hat / centos-stream / rpms / libtiff","path":"libtiff","path_with_namespace":"redhat/centos-stream/rpms/libtiff","created_at":"2021-01-14T13:33:43.455Z","default_branch":"c10s","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:redhat/centos-stream/rpms/libtiff.git","http_url_to_repo":"https://gitlab.com/redhat/centos-stream/rpms/libtiff.git","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff","readme_url":null,"forks_count":6,"avatar_url":null,"star_count":2,"last_activity_at":"2025-05-05T16:06:55.870Z","namespace":{"id":8794173,"name":"rpms","path":"rpms","kind":"group","full_path":"redhat/centos-stream/rpms","parent_id":8706831,"avatar_url":null,"web_url":"https://gitlab.com/groups/redhat/centos-stream/rpms"},"container_registry_image_prefix":"registry.gitlab.com/redhat/centos-stream/rpms/libtiff","_links":{"self":"https://gitlab.com/api/v4/projects/23667077","merge_requests":"https://gitlab.com/api/v4/projects/23667077/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/23667077/repository/branches","labels":"https://gitlab.com/api/v4/projects/23667077/labels","events":"https://gitlab.com/api/v4/projects/23667077/events","members":"https://gitlab.com/api/v4/projects/23667077/members","cluster_agents":"https://gitlab.com/api/v4/projects/23667077/cluster_agents"},"marked_for_deletion_at":null,"marked_for_deletion_on":null,"packages_enabled":false,"empty_repo":false,"archived":false,"visibility":"public","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-01-15T13:33:43.485Z"},"repository_object_format":"sha1","issues_enabled":false,"merge_requests_enabled":true,"wiki_enabled":false,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"can_create_merge_request_in":true,"issues_access_level":"disabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"disabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","analytics_access_level":"enabled","container_registry_access_level":"enabled","security_and_compliance_access_level":"private","releases_access_level":"enabled","environments_access_level":"disabled","feature_flags_access_level":"disabled","infrastructure_access_level":"disabled","monitor_access_level":"disabled","model_experiments_access_level":"enabled","model_registry_access_level":"enabled","emails_disabled":false,"emails_enabled":true,"shared_runners_enabled":true,"lfs_enabled":false,"creator_id":6007577,"import_status":"none","description_html":"\u003cp
-      data-sourcepos=\"1:1-1:16\" dir=\"auto\"\u003eThe libtiff rpms\u003c/p\u003e","updated_at":"2025-05-05T16:15:15.015Z","ci_config_path":"global-tasks.yml@redhat/centos-stream/ci-cd/dist-git-gating-tests","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"request_access_enabled":false,"only_allow_merge_if_all_discussions_are_resolved":true,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","merge_request_title_regex":null,"squash_option":"never","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"approvals_before_merge":0,"mirror":false,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"merge_requests_template":"","merge_pipelines_enabled":true,"merge_trains_enabled":true,"merge_trains_skip_train_allowed":false,"allow_pipeline_trigger_approve_deployment":false,"auto_duo_code_review_enabled":false,"permissions":{"project_access":null,"group_access":null}}'
+      data-sourcepos=\"1:1-1:16\" dir=\"auto\"\u003eThe libtiff rpms\u003c/p\u003e","updated_at":"2025-05-07T15:22:25.055Z","ci_config_path":"global-tasks.yml@redhat/centos-stream/ci-cd/dist-git-gating-tests","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"request_access_enabled":false,"only_allow_merge_if_all_discussions_are_resolved":true,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","merge_request_title_regex":null,"squash_option":"never","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"approvals_before_merge":0,"mirror":false,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"merge_requests_template":"","merge_pipelines_enabled":true,"merge_trains_enabled":true,"merge_trains_skip_train_allowed":false,"allow_pipeline_trigger_approve_deployment":false,"auto_duo_code_review_enabled":false,"permissions":{"project_access":null,"group_access":null}}'
     content_type: application/json
     headers:
       CF-Cache-Status: MISS
-      CF-Ray: 93b71474bf69ed18-MXP
+      CF-Ray: 93c7890cab10ba9f-MXP
       Cache-Control: max-age=0, private, must-revalidate
-      ETag: W/"3dca2067a7699b0582f6e7971355b3d2"
-      Set-Cookie: _cfuvid=lEtaED.DtDEVwUQjgdtPaIKmVoUu6lUXb9IsuDi1avs-1746519852574-0.0.1.1-604800000;
+      ETag: W/"7bcd1b327972f0654df91402d94e9b70"
+      Set-Cookie: _cfuvid=EtMS9pZnx2tNd5BnikEo0tqbYFAQ6xqBXXnBUVxo7dE-1746692400431-0.0.1.1-604800000;
         path=/; domain=.gitlab.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security: max-age=31536000
       Transfer-Encoding: chunked
       Vary: Origin, Accept-Encoding
       content-security-policy: default-src 'none'
-      gitlab-lb: haproxy-main-36-lb-gprd
-      gitlab-sv: api-gke-us-east1-d
+      gitlab-lb: haproxy-main-07-lb-gprd
+      gitlab-sv: api-gke-us-east1-b
       nel: '{"max_age": 0}'
       referrer-policy: strict-origin-when-cross-origin
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-gitlab-meta: '{"correlation_id":"cacc9a1321778eb32e198958983cdf7e","version":"1"}'
-      x-request-id: cacc9a1321778eb32e198958983cdf7e
-      x-runtime: '0.137229'
+      x-gitlab-meta: '{"correlation_id":"d56ded447ff370d61e6132bb05d44636","version":"1"}'
+      x-request-id: d56ded447ff370d61e6132bb05d44636
+      x-runtime: '0.166136'
     method: GET
     status: 200
     url: https://gitlab.com/api/v4/projects/23667077
@@ -36,25 +36,193 @@ responses:
     content_type: application/json
     headers:
       CF-Cache-Status: MISS
-      CF-Ray: 93b71476db3bed18-MXP
+      CF-Ray: 93c7890f6cecba9f-MXP
       Cache-Control: max-age=0, private, must-revalidate
       ETag: W/"04cac7b091f4ff7c7038be61ce98e1f7"
       Strict-Transport-Security: max-age=31536000
       Transfer-Encoding: chunked
       Vary: Origin, Accept-Encoding
       content-security-policy: default-src 'none'
-      gitlab-lb: haproxy-main-43-lb-gprd
-      gitlab-sv: api-gke-us-east1-b
+      gitlab-lb: haproxy-main-06-lb-gprd
+      gitlab-sv: api-gke-us-east1-d
       nel: '{"max_age": 0}'
       referrer-policy: strict-origin-when-cross-origin
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-gitlab-meta: '{"correlation_id":"4c15460f2b419f98c7389096f3a3077a","version":"1"}'
-      x-request-id: 4c15460f2b419f98c7389096f3a3077a
-      x-runtime: '0.203379'
+      x-gitlab-meta: '{"correlation_id":"64a45c58268d15d0a9c599fd673474d4","version":"1"}'
+      x-request-id: 64a45c58268d15d0a9c599fd673474d4
+      x-runtime: '0.293672'
     method: GET
     status: 200
     url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":"1ba1f46903f2b4e0573d514ed6d2cae29ab040f6","individual_note":false,"notes":[{"id":2462509330,"type":"DiscussionNote","body":"The
+      package libtiff failed to build, here is a possible explanation why.\n\nPlease
+      know that the explanation was provided by AI and may be incorrect.\nIn this
+      case, we are 99.71% certain of the response :slight_smile:.\n\n Based on the
+      provided log snippets, it appears that there was a failure during the RPM build
+      process for a package named \"libtiff\". The exact cause of the failure cannot
+      be determined from the given information alone, but there are a few clues that
+      suggest what the issue might be.\n\nThe most significant indication of a problem
+      is the error message at line [10] that mentions \"RPM build errors: error: Bad
+      file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch: No such file
+      or directory\". This error suggests that a necessary patch file was missing
+      during the build process. The patch file is identified as \"libtiff-4.4.0-CVE-2023-52356.patch\",
+      and it was expected to be located in the \"/builddir/build/SOURCES/\" directory.
+      However, this file could not be found, causing the build to fail.\n\nAnother
+      snippet (line [14]) shows that an exception was raised during the build process,
+      with the message \"Command failed: # bash --login -c ''/usr/bin/rpmbuild -bs
+      --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''\". This
+      error message confirms the failure of the \"rpmbuild\" command and indicates
+      that the issue was likely related to the missing patch file mentioned earlier.\n\nTo
+      resolve the issue, you should first ensure that all required patch files are
+      present in the correct location. Check the SPEC file for the \"libtiff\" package
+      to confirm that it specifies the correct patch file(s) and that their download
+      or extraction was successful during the build process. If necessary, manually
+      download and install the missing patch files in the expected directory. Once
+      all necessary patch files are present and accessible, try rebuilding the \"libtiff\"
+      package using the \"rpmbuild\" command to see if the issue is resolved. If the
+      issue persists, further investigation may be required to determine if there
+      are any other dependencies or issues that may be preventing the build from completing
+      successfully.\n\n\u003cdetails\u003e\n\u003cul\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      0:\u003c/b\u003e \u003ccode\u003eMock Version: 5.4\n\u003c/code\u003e\n The
+      given RPM build log snippet indicates the version of Mock being used during
+      the RPM build process. In this case, the version is 5.4.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      5:\u003c/b\u003e \u003ccode\u003eENTER [''do_with_status'']([''bash'', ''--login'',
+      ''-c'', ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''],
+      chrootPath=''/var/lib/mock/c9s-build-671467-759558/root''env={''TERM'': ''vt100'',
+      ''SHELL'': ''/bin/bash'', ''HOME'': ''/builddir'', ''HOSTNAME'': ''mock'', ''PATH'':
+      ''/usr/bin:/bin:/usr/sbin:/sbin'', ''PROMPT_COMMAND'': ''printf \"\\\\033]0;\u003cmock-chroot\u003e\\\\007\"'',
+      ''PS1'': ''\u003cmock-chroot\u003e \\\\s-\\\\v\\\\$ '', ''LANG'': ''C.UTF-8''}shell=Falselogger=\u003cmockbuild.trace_decorator.getLog
+      object at 0x7fff8ccaca58\u003etimeout=86400uid=989gid=135user=''mockbuild''nspawn_args=[]unshare_net=FalseprintOutput=False)\n\u003c/code\u003e\n
+      This snippet is a Python script that sets up a call to the RPM (Red Hat Package
+      Manager) build process. The script sets up an environment for RPM build in mock
+      chroot (mock-chroot), which is a feature that allows building RPM packages in
+      an isolated environment. The following are the key elements of the script:\n\n*
+      The script calls the `rpmbuild` command with the following arguments: `-bs`,
+      `--noclean`, `--target noarch`, `--nodeps`, and the path to the SPEC file `/builddir/build/SPECS/libtiff.spec`.
+      `-bs` flag means that the build process will be done in the background. `--noclean`
+      flag skips the clean target. `--target noarch` means that the built package
+      will be noarch (not architecture-specific). `--nodeps` flag skips the dependency
+      resolution.\n* `chrootPath` is the path to the mock chroot environment.\n* `env`
+      is a dictionary containing environment variables for the build process, including
+      `TERM`, `SHELL`, `HOME`, `HOSTNAME`, `PATH`, `PROMPT_COMMAND`, `PS1`, `LANG`,
+      `uid`, `gid`, `user`, and `nspawn_args`. These variables are used to set up
+      the environment for the build process.\n* `shell` is a boolean value indicating
+      whether to run the shell in the build process or not.\n* `logger` is an object
+      used for logging the build process.\n* `timeout` is the maximum build time in
+      seconds.\n* `uid` and `gid` are the user and group IDs to run the build process
+      as.\n* `user` is the username for the user running the build process.\n* `nspawn_args`
+      is an empty list of arguments for unshare network namespace.\n* `unshare_net`
+      is a boolean value indicating whether to use unshare network namespace or not.\n*
+      `printOutput` is a boolean value indicating whether to print the build output
+      or not.\n\nThe script sets up these variables and creates a call to the `rpmbuild`
+      command inside a mock chroot environment.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      6:\u003c/b\u003e \u003ccode\u003eExecuting command: [''bash'', ''--login'',
+      ''-c'', ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec'']
+      with env {''TERM'': ''vt100'', ''SHELL'': ''/bin/bash'', ''HOME'': ''/builddir'',
+      ''HOSTNAME'': ''mock'', ''PATH'': ''/usr/bin:/bin:/usr/sbin:/sbin'', ''PROMPT_COMMAND'':
+      ''printf \"\\\\033]0;\u003cmock-chroot\u003e\\\\007\"'', ''PS1'': ''\u003cmock-chroot\u003e
+      \\\\s-\\\\v\\\\$ '', ''LANG'': ''C.UTF-8''} and shell False\n\u003c/code\u003e\n
+      The given RPM build log snippet describes the execution of a command using RPM
+      build system. The command being executed is ''rpmbuild'' with specific build
+      options and no dependencies (-bs --noclean --target noarch --nodeps). The command
+      is being run in a ''mock'' environment, which is indicated by the ''mock-chroot''
+      in the PS1 variable. The environment variables for TERM, SHELL, HOME, HOSTNAME,
+      PATH, PROMPT_COMMAND, and LANG are also shown. The shell for the command is
+      set to ''False'', suggesting that an interpreter other than a shell, such as
+      a Perl or Python script, may be used to execute the RPM build command.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      7:\u003c/b\u003e \u003ccode\u003eBuilding target platforms: noarch\n\u003c/code\u003e\n
+      The RPM build log snippet indicates that the build process is currently working
+      on creating target platforms of type ''noarch''. Noarch is a common RPM target
+      architecture that stands for \"no architecture\" or \"noarchitecture\". It is
+      used for building packages that do not have any architecture-specific components
+      and can be installed on any system regardless of its hardware architecture.
+      Therefore, this log message implies that the RPM package builder is in the process
+      of creating a ''noarch'' variant of the RPM package being built.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      9:\u003c/b\u003e \u003ccode\u003esetting SOURCE_DATE_EPOCH=1745280000\n\u003c/code\u003e\n
+      This RPM build log snippet sets the SOURCE_DATE_EPOCH variable to the value
+      1745280000. This variable is used by RPM to preserve the build time of the source
+      code during the build process. The value is in the number of seconds since the
+      Unix epoch (January 1, 1970).\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      10:\u003c/b\u003e \u003ccode\u003eRPM build errors:\nerror: Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\n    Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\n\u003c/code\u003e\n The RPM build log indicates that
+      there were two build errors related to a patch file named \"libtiff-4.4.0-CVE-2023-52356.patch\".
+      The error message states that the file does not exist in the specified path
+      \"/builddir/build/SOURCES/\".\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      13:\u003c/b\u003e \u003ccode\u003eChild return code was: 1\n\u003c/code\u003e\n
+      The RPM build log snippet indicates that the child process during the RPM build
+      procedure returned an error code of 1. This is an indication that the build
+      process of the specified RPM package encountered an issue during execution.
+      The exact nature of the issue cannot be determined from this log snippet alone.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      14:\u003c/b\u003e \u003ccode\u003eEXCEPTION: [Error(\"Command failed: \\n #
+      bash --login -c ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''\\n\",
+      1)]\n\u003c/code\u003e\n This RPM build log snippet indicates that an exception
+      has occurred during the RPM build process. The exception message states that
+      the command \"rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec\"
+      has failed. The message is preceded by the number 14, which likely represents
+      the build number or sequence number of the build process. The failure of the
+      command is the only piece of information provided in this snippet. No further
+      details about the cause of the failure are given.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      15:\u003c/b\u003e \u003ccode\u003eTraceback (most recent call last):\n  File
+      \"/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py\", line 93,
+      in trace\n    result = func(*args, **kw)\n  File \"/usr/lib/python3.6/site-packages/mockbuild/util.py\",
+      line 612, in do_with_status\n    raise exception.Error(\"Command failed: \\n
+      # %s\\n%s\" % (cmd_pretty(command, env), output), child.returncode)\n\u003c/code\u003e\n
+      The snippet is an error message from a RPM build process using the Mockbuild
+      tool. The error indicates that a command executed during the build process has
+      failed. The specific error occurs in the \"do_with_status\" function, located
+      in the \"util.py\" file in the Mockbuild library.\n\nThe error message includes
+      a traceback, which shows that the error was raised by the \"Error\" exception
+      in the \"do_with_status\" function. The error message itself contains the command
+      that failed, indicated by `cmd_pretty(command, env)`, and the output of the
+      command. The return code of the command is also included in the error message.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      20:\u003c/b\u003e \u003ccode\u003emockbuild.exception.Error: Command failed:
+      \n # bash --login -c ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps
+      /builddir/build/SPECS/libtiff.spec''\n\n\u003c/code\u003e\n The log snippet
+      indicates that an error occurred during the RPM build process for the \"libtiff\"
+      package using mockbuild. Specifically, the command \"rpmbuild -bs --noclean
+      --target noarch --nodeps /builddir/build/SPECS/libtiff.spec\" failed. The error
+      message is not provided in the log snippet, only that the command failed.\n\u003c/li\u003e\n\n\u003c/ul\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eLogs\u003c/summary\u003e\n  \u003cp\u003e\n    Log
+      Detective analyzed the following logs files to provide an explanation:\n  \u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://gitlab.com/api/v4/projects/23667077/jobs/9789376408/artifacts/kojilogs/noarch-5653506/noarch-5653507/build.log\"\u003ehttps://gitlab.com/api/v4/projects/23667077/jobs/9789376408/artifacts/kojilogs/noarch-5653506/noarch-5653507/build.log\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\n  \u003cp\u003e\n    Additional
+      logs are available from:\n    \u003cul\u003e\n    \u003cli\u003e\u003ca href=\"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/jobs/9789376408/artifacts/download\"\u003eartifacts.zip\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n  \u003c/p\u003e\n\n  \u003cp\u003e\n    Please
+      know that these log files are automatically removed after some\n    time, so
+      you might need a backup.\n  \u003c/p\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eHelp\u003c/summary\u003e\n  \u003cp\u003eDon''t
+      hesitate to reach out.\u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective\"\u003eUpstream\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective/issues\"\u003eIssue tracker\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://redhat.enterprise.slack.com/archives/C06DWNVKKDE\"\u003eSlack\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://log-detective.com/documentation\"\u003eDocumentation\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\u003c/details\u003e\n\n\n---\nThis
+      comment was created by [Log Detective][log-detective].\n\nWas the provided feedback
+      accurate and helpful? \u003cbr\u003ePlease vote with :thumbsup:\nor :thumbsdown:
+      to help us improve.\u003cbr\u003e\n\n\n\n[log-detective]: https://log-detective.com/\n[contact]:
+      https://github.com/fedora-copr","author":{"id":27211590,"username":"group_8794173_bot_029d2e92d461920a3695e55137a87774","public_email":null,"name":"****","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/c16bbfef2c60f8447985835437fc6442310027fe3e08fca895081b06f089abce?s=80\u0026d=identicon","web_url":"https://gitlab.com/group_8794173_bot_029d2e92d461920a3695e55137a87774"},"created_at":"2025-04-22T15:05:38.431Z","updated_at":"2025-04-22T15:21:21.994Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-22T15:11:00.983Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}},{"id":2462523126,"type":"DiscussionNote","body":"correct
+      analysis, but a bit tl;dr","author":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"created_at":"2025-04-22T15:11:00.436Z","updated_at":"2025-04-22T15:11:00.983Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-22T15:11:00.983Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}}]}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c789132fbdba9f-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"56c7b72183071ab15bae67a27b9cbd18"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-03-lb-gprd
+      gitlab-sv: api-gke-us-east1-d
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"1341b3e10a8249ee0b222254b2903b8e","version":"1"}'
+      x-request-id: 1341b3e10a8249ee0b222254b2903b8e
+      x-runtime: '0.606882'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/discussions/1ba1f46903f2b4e0573d514ed6d2cae29ab040f6
 - response:
     auto_calculate_content_length: false
     body: '{"id":2462509330,"type":"DiscussionNote","body":"The package libtiff failed
@@ -202,22 +370,22 @@ responses:
     content_type: application/json
     headers:
       CF-Cache-Status: MISS
-      CF-Ray: 93b714793f81ed18-MXP
+      CF-Ray: 93c7891a3d35ba9f-MXP
       Cache-Control: max-age=0, private, must-revalidate
       ETag: W/"b3e02019edf96e96f09b413bd0961ca9"
       Strict-Transport-Security: max-age=31536000
       Transfer-Encoding: chunked
       Vary: Origin, Accept-Encoding
       content-security-policy: default-src 'none'
-      gitlab-lb: haproxy-main-14-lb-gprd
-      gitlab-sv: api-gke-us-east1-c
+      gitlab-lb: haproxy-main-09-lb-gprd
+      gitlab-sv: gke-cny-api
       nel: '{"max_age": 0}'
       referrer-policy: strict-origin-when-cross-origin
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-gitlab-meta: '{"correlation_id":"50566409a6d5c029ccf9210f1446d18b","version":"1"}'
-      x-request-id: 50566409a6d5c029ccf9210f1446d18b
-      x-runtime: '0.109780'
+      x-gitlab-meta: '{"correlation_id":"92529bdbe9569558b4904a0969bd3631","version":"1"}'
+      x-request-id: 92529bdbe9569558b4904a0969bd3631
+      x-runtime: '0.107251'
     method: GET
     status: 200
     url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330
@@ -227,7 +395,7 @@ responses:
     content_type: application/json
     headers:
       CF-Cache-Status: MISS
-      CF-Ray: 93b7147b1ba3ed18-MXP
+      CF-Ray: 93c7891ccf54ba9f-MXP
       Cache-Control: max-age=0, private, must-revalidate
       ETag: W/"7da7fe52d08c291e201c0b9f7350e6a4"
       Link: <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
@@ -237,19 +405,19 @@ responses:
       Transfer-Encoding: chunked
       Vary: Origin, Accept-Encoding
       content-security-policy: default-src 'none'
-      gitlab-lb: haproxy-main-25-lb-gprd
-      gitlab-sv: api-gke-us-east1-b
+      gitlab-lb: haproxy-main-47-lb-gprd
+      gitlab-sv: api-gke-us-east1-c
       nel: '{"max_age": 0}'
       referrer-policy: strict-origin-when-cross-origin
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-gitlab-meta: '{"correlation_id":"182a9559486ff90df13afaf59499af99","version":"1"}'
+      x-gitlab-meta: '{"correlation_id":"6c817afc39209c8c6d52f1fce5c8745e","version":"1"}'
       x-next-page: ''
       x-page: '1'
       x-per-page: '20'
       x-prev-page: ''
-      x-request-id: 182a9559486ff90df13afaf59499af99
-      x-runtime: '0.085420'
+      x-request-id: 6c817afc39209c8c6d52f1fce5c8745e
+      x-runtime: '0.133011'
       x-total: '1'
       x-total-pages: '1'
     method: GET
@@ -259,29 +427,185 @@ responses:
     auto_calculate_content_length: false
     body: '{"id":23667077,"description":"The libtiff rpms","name":"libtiff","name_with_namespace":"Red
       Hat / centos-stream / rpms / libtiff","path":"libtiff","path_with_namespace":"redhat/centos-stream/rpms/libtiff","created_at":"2021-01-14T13:33:43.455Z","default_branch":"c10s","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:redhat/centos-stream/rpms/libtiff.git","http_url_to_repo":"https://gitlab.com/redhat/centos-stream/rpms/libtiff.git","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff","readme_url":null,"forks_count":6,"avatar_url":null,"star_count":2,"last_activity_at":"2025-05-05T16:06:55.870Z","namespace":{"id":8794173,"name":"rpms","path":"rpms","kind":"group","full_path":"redhat/centos-stream/rpms","parent_id":8706831,"avatar_url":null,"web_url":"https://gitlab.com/groups/redhat/centos-stream/rpms"},"container_registry_image_prefix":"registry.gitlab.com/redhat/centos-stream/rpms/libtiff","_links":{"self":"https://gitlab.com/api/v4/projects/23667077","merge_requests":"https://gitlab.com/api/v4/projects/23667077/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/23667077/repository/branches","labels":"https://gitlab.com/api/v4/projects/23667077/labels","events":"https://gitlab.com/api/v4/projects/23667077/events","members":"https://gitlab.com/api/v4/projects/23667077/members","cluster_agents":"https://gitlab.com/api/v4/projects/23667077/cluster_agents"},"marked_for_deletion_at":null,"marked_for_deletion_on":null,"packages_enabled":false,"empty_repo":false,"archived":false,"visibility":"public","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-01-15T13:33:43.485Z"},"repository_object_format":"sha1","issues_enabled":false,"merge_requests_enabled":true,"wiki_enabled":false,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"can_create_merge_request_in":true,"issues_access_level":"disabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"disabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","analytics_access_level":"enabled","container_registry_access_level":"enabled","security_and_compliance_access_level":"private","releases_access_level":"enabled","environments_access_level":"disabled","feature_flags_access_level":"disabled","infrastructure_access_level":"disabled","monitor_access_level":"disabled","model_experiments_access_level":"enabled","model_registry_access_level":"enabled","emails_disabled":false,"emails_enabled":true,"shared_runners_enabled":true,"lfs_enabled":false,"creator_id":6007577,"import_status":"none","description_html":"\u003cp
-      data-sourcepos=\"1:1-1:16\" dir=\"auto\"\u003eThe libtiff rpms\u003c/p\u003e","updated_at":"2025-05-05T16:15:15.015Z","ci_config_path":"global-tasks.yml@redhat/centos-stream/ci-cd/dist-git-gating-tests","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"request_access_enabled":false,"only_allow_merge_if_all_discussions_are_resolved":true,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","merge_request_title_regex":null,"squash_option":"never","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"approvals_before_merge":0,"mirror":false,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"merge_requests_template":"","merge_pipelines_enabled":true,"merge_trains_enabled":true,"merge_trains_skip_train_allowed":false,"allow_pipeline_trigger_approve_deployment":false,"auto_duo_code_review_enabled":false,"permissions":{"project_access":null,"group_access":null}}'
+      data-sourcepos=\"1:1-1:16\" dir=\"auto\"\u003eThe libtiff rpms\u003c/p\u003e","updated_at":"2025-05-07T15:22:25.055Z","ci_config_path":"global-tasks.yml@redhat/centos-stream/ci-cd/dist-git-gating-tests","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"request_access_enabled":false,"only_allow_merge_if_all_discussions_are_resolved":true,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","merge_request_title_regex":null,"squash_option":"never","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"approvals_before_merge":0,"mirror":false,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"merge_requests_template":"","merge_pipelines_enabled":true,"merge_trains_enabled":true,"merge_trains_skip_train_allowed":false,"allow_pipeline_trigger_approve_deployment":false,"auto_duo_code_review_enabled":false,"permissions":{"project_access":null,"group_access":null}}'
     content_type: application/json
     headers:
       CF-Cache-Status: MISS
-      CF-Ray: 93b7147cef4ced18-MXP
+      CF-Ray: 93c78920da86ba9f-MXP
       Cache-Control: max-age=0, private, must-revalidate
-      ETag: W/"3dca2067a7699b0582f6e7971355b3d2"
+      ETag: W/"7bcd1b327972f0654df91402d94e9b70"
       Strict-Transport-Security: max-age=31536000
       Transfer-Encoding: chunked
       Vary: Origin, Accept-Encoding
       content-security-policy: default-src 'none'
-      gitlab-lb: haproxy-main-39-lb-gprd
-      gitlab-sv: api-gke-us-east1-d
+      gitlab-lb: haproxy-main-16-lb-gprd
+      gitlab-sv: api-gke-us-east1-b
       nel: '{"max_age": 0}'
       referrer-policy: strict-origin-when-cross-origin
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-gitlab-meta: '{"correlation_id":"086f690dcd4197f42386d3f4f1266b6f","version":"1"}'
-      x-request-id: 086f690dcd4197f42386d3f4f1266b6f
-      x-runtime: '0.117985'
+      x-gitlab-meta: '{"correlation_id":"f0cdf9785adb455fb30357697a7570c8","version":"1"}'
+      x-request-id: f0cdf9785adb455fb30357697a7570c8
+      x-runtime: '0.134918'
     method: GET
     status: 200
     url: https://gitlab.com/api/v4/projects/23667077
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":"91090f16d27d4ad053f39990c5a47a592565d38f","individual_note":false,"notes":[{"id":2464715549,"type":"DiscussionNote","body":"The
+      package libtiff failed to build, here is a possible explanation why.\n\nPlease
+      know that the explanation was provided by AI and may be incorrect.\nIn this
+      case, we are 99.49% certain of the response :slight_smile:.\n\n The RPM build
+      process of the \"libtiff.spec\" package encountered an error during the `%build`
+      phase. Specifically, the command `/usr/bin/rpmbuild -bb --noclean --target x86_64
+      --nodeps /builddir/build/SPECS/libtiff.spec` failed to execute successfully,
+      as indicated by a non-zero exit status of 1. This error was reported by Mockbuild,
+      the RPM testing framework.\n\nThe log snippets do not provide enough information
+      to determine the exact cause of the build failure. Potential issues could include
+      missing or incompatible dependencies, incorrect build variables, or compilation
+      errors. It is recommended to review the build script in `/builddir/build/SPECS/libtiff.spec`
+      and the corresponding source code to identify and resolve the cause of the build
+      error. Additionally, checking the RPM dependency tree and build environment
+      variables may help identify any missing dependencies or misconfigurations.\n\n\u003cdetails\u003e\n\u003cul\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      10:\u003c/b\u003e \u003ccode\u003eChild return code was: 0\n\u003c/code\u003e\n
+      This log snippet indicates that a child process, likely a sub-build or dependency
+      during the RPM build process, has completed with an exit status code of 0. An
+      exit status code of 0 typically signifies a successful execution.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      450:\u003c/b\u003e \u003ccode\u003emake[2]: Entering directory ''/builddir/build/BUILD/tiff-4.4.0/port''\n\u003c/code\u003e\n
+      This RPM build log snippet indicates that the make process (specifically make[2])
+      is entering the directory ''/builddir/build/BUILD/tiff-4.4.0/port''. The number
+      preceding the message (450) represents the line number in the build script where
+      this event occurs.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine 710:\u003c/b\u003e
+      \u003ccode\u003egcc -DHAVE_CONFIG_H -I. -I../config -I../libtiff -I../port  -I../libtiff
+      -I../port -DTIFF_DISABLE_DEPRECATED   -O2 -flto=auto -ffat-lto-objects -fexceptions
+      -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2
+      -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong
+      -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64-v2 -mtune=generic
+      -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-strict-aliasing
+      -Wall -W -c -o fax2tiff.o fax2tiff.c\n\u003c/code\u003e\n The RPM build log
+      snippet represents a gcc compilation command with various flags and options
+      for building the ''fax2tiff.o'' object file from ''fax2tiff.c''.\n\nThe command
+      includes:\n- Compiler: gcc\n- Preprocessor flags:\n  - Include directories:
+      ., ../config, ../libtiff, ../port\n  - Defines: HAVE_CONFIG_H, TIFF_DISABLE_DEPRECATED\n\n-
+      Optimization flags:\n  - Compiler optimization: -O2\n  - Link-time optimization:
+      -flto=auto -ffat-lto-objects\n\n- Exception handling: -fexceptions\n\n- Debugging
+      flags: -g -grecord-gcc-switches\n\n- Warnings: -Wall -Werror=format-security\n\n-
+      Security: -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS\n\n- Hardened build:
+      -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1\n\n- Stack protection: -fstack-protector-strong\n\n-
+      Code protection: -fcf-protection\n\n- Aliasing: -fno-strict-aliasing\n\n- Target
+      architecture: -m64 -march=x86-64-v2 -mtune=generic\n\n- Asynchronous unwind
+      tables: -fasynchronous-unwind-tables\n\n- Stack clash protection: -fstack-clash-protection.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      786:\u003c/b\u003e \u003ccode\u003ecollect2: error: ld returned 1 exit status\n\u003c/code\u003e\n
+      The RPM build log snippet indicates an error during the linking (ld) stage of
+      the build process. The linker returned an exit status of 1, which signifies
+      an unsuccessful linking attempt. The exact cause of the error is not provided
+      in the snippet, but potential issues could include missing or incompatible libraries,
+      incorrect library versions, or syntax errors in the linker script. Further investigation
+      is required to determine the specific cause and resolve the issue.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      787:\u003c/b\u003e \u003ccode\u003emake[1]: *** [Makefile:653: tiffdither] Error
+      1\n\u003c/code\u003e\n The RPM build log snippet indicates that there was an
+      error during the execution of the \"make\" command, specifically with the target
+      \"tiffdither\" mentioned in the Makefile on line 653. The error resulted in
+      the make process exiting with a status code of 1.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      905:\u003c/b\u003e \u003ccode\u003etiffcrop.c: In function ''writeBufferToSeparateStrips'':\ntiffcrop.c:1244:28:
+      warning: comparison of integer expressions of different signedness: ''tsize_t''
+      {aka ''long int''} and ''long long unsigned int'' [-Wsign-compare]\n 1244 |           if
+      (scanlinesize \u003e 0x0ffffffffULL) {\n      |                            ^\n\u003c/code\u003e\n
+      The RPM build log snippet indicates a compiler warning during the build process
+      of the ''tiffcrop.c'' file. The warning message specifically mentions a comparison
+      of two data types with different signedness in line 1244 of the file: ''tsize_t''
+      (a long int type) and ''long long unsigned int''. The compiler is advising that
+      such a comparison may result in unexpected behavior due to potential sign conversions.
+      The warning message concludes with the location of the issue in the code.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      913:\u003c/b\u003e \u003ccode\u003emake: *** [Makefile:561: all-recursive] Error
+      1\n\u003c/code\u003e\n The RPM build log snippet indicates an error occurred
+      during the \"make all-recursive\" step in the RPM package build process. Specifically,
+      the \"make\" command returned an error status code 1. There is no further information
+      provided in the log snippet regarding the nature of the error.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      914:\u003c/b\u003e \u003ccode\u003eerror: Bad exit status from /var/tmp/rpm-tmp.JH52lB
+      (%build)\n\u003c/code\u003e\n The RPM build process encountered an error during
+      the `%build` phase of the build. Specifically, there was a \"Bad exit status\"
+      from the build script located at `/var/tmp/rpm-tmp.JH52lB`. This indicates that
+      the commands executed within the `%build` script did not complete successfully,
+      resulting in an error. The cause of this error is not apparent from the given
+      log snippet and requires further investigation into the contents of the `%build`
+      script and build environment.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      915:\u003c/b\u003e \u003ccode\u003eRPM build errors:\n    Bad exit status from
+      /var/tmp/rpm-tmp.JH52lB (%build)\n\u003c/code\u003e\n The given RPM build log
+      snippet indicates that during the build process, an error occurred in the %build
+      phase. The error resulted in an unsuccessful exit status from the file location
+      ''/var/tmp/rpm-tmp.JH52lB''. No further information is provided in the log regarding
+      the nature of the error.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      918:\u003c/b\u003e \u003ccode\u003eEXCEPTION: [Error(\"Command failed: \\n #
+      bash --login -c ''/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec''\\n\",
+      1)]\n\u003c/code\u003e\n The log snippet indicates an error occurred during
+      the RPM build process using the `rpmbuild` command. The command being executed
+      is:\n\n`/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec`\n\nThe
+      error message reads ''Command failed'' and is accompanied by an exception. The
+      cause of the command failure is not explicitly stated in the provided log snippet.
+      The error is marked with a non-zero exit status of 1.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      919:\u003c/b\u003e \u003ccode\u003eTraceback (most recent call last):\n  File
+      \"/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py\", line 93,
+      in trace\n    result = func(*args, **kw)\n  File \"/usr/lib/python3.6/site-packages/mockbuild/util.py\",
+      line 612, in do_with_status\n    raise exception.Error(\"Command failed: \\n
+      # %s\\n%s\" % (cmd_pretty(command, env), output), child.returncode)\n\u003c/code\u003e\n
+      This log snippet is a Python traceback indicating an error during the execution
+      of an RPM build using the mockbuild tool. The error occurred at the line where
+      the command execution failed in the mockbuild utility file (do_with_status,
+      line 612). The specific error message states that a command failed with the
+      given error message and return code. The command and its environment variables
+      can be found in the cmd_pretty function call. No further information is provided
+      in the log snippet.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine 924:\u003c/b\u003e
+      \u003ccode\u003emockbuild.exception.Error: Command failed: \n # bash --login
+      -c ''/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec''\n\n\u003c/code\u003e\n
+      The build log snippet indicates an error occurred during the RPM build process
+      of the \"libtiff.spec\" file, using the x86\\_64 architecture. The command \"rpmbuild
+      -bb --noclean --target x86\\_64 --nodeps /builddir/build/SPECS/libtiff.spec\"
+      failed to execute successfully. This error is reported by Mockbuild, an RPM
+      testing framework. No further information about the nature of the command failure
+      is provided in the log.\n\u003c/li\u003e\n\n\u003c/ul\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eLogs\u003c/summary\u003e\n  \u003cp\u003e\n    Log
+      Detective analyzed the following logs files to provide an explanation:\n  \u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://gitlab.com/api/v4/projects/23667077/jobs/9789725965/artifacts/kojilogs/noarch-5653531/x86_64-5653534/build.log\"\u003ehttps://gitlab.com/api/v4/projects/23667077/jobs/9789725965/artifacts/kojilogs/noarch-5653531/x86_64-5653534/build.log\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\n  \u003cp\u003e\n    Additional
+      logs are available from:\n    \u003cul\u003e\n    \u003cli\u003e\u003ca href=\"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/jobs/9789725965/artifacts/download\"\u003eartifacts.zip\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n  \u003c/p\u003e\n\n  \u003cp\u003e\n    Please
+      know that these log files are automatically removed after some\n    time, so
+      you might need a backup.\n  \u003c/p\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eHelp\u003c/summary\u003e\n  \u003cp\u003eDon''t
+      hesitate to reach out.\u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective\"\u003eUpstream\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective/issues\"\u003eIssue tracker\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://redhat.enterprise.slack.com/archives/C06DWNVKKDE\"\u003eSlack\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://log-detective.com/documentation\"\u003eDocumentation\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\u003c/details\u003e\n\n\n---\nThis
+      comment was created by [Log Detective][log-detective].\n\nWas the provided feedback
+      accurate and helpful? \u003cbr\u003ePlease vote with :thumbsup:\nor :thumbsdown:
+      to help us improve.\u003cbr\u003e\n\n\n\n[log-detective]: https://log-detective.com/\n[contact]:
+      https://github.com/fedora-copr","author":{"id":27211590,"username":"group_8794173_bot_029d2e92d461920a3695e55137a87774","public_email":null,"name":"****","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/c16bbfef2c60f8447985835437fc6442310027fe3e08fca895081b06f089abce?s=80\u0026d=identicon","web_url":"https://gitlab.com/group_8794173_bot_029d2e92d461920a3695e55137a87774"},"created_at":"2025-04-23T14:02:31.332Z","updated_at":"2025-04-23T14:12:56.887Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-23T14:12:56.887Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}},{"id":2464747301,"type":"DiscussionNote","body":"unsuccessful
+      analysis:\nerror that caused failure:\n/usr/bin/ld: ../libtiff/.libs/libtiff.so:
+      undefined reference to `TIFFErrorExtR''\ncollect2: error: ld returned 1 exit
+      status\nmake[1]: *** [Makefile:653: tiffdither] Error 1\n\nprimary source of
+      that error:\ntif_getimage.c: In function ''TIFFReadRGBAStripExt'':\ntif_getimage.c:2948:13:
+      warning: implicit declaration of function ''TIFFErrorExtR''; did you mean ''TIFFErrorExt''?
+      [-Wimplicit-function-declaration]\n 2948 |             TIFFErrorExtR(tif, TIFFFileName(tif),\n      |             ^~~~~~~~~~~~~\n      |             TIFFErrorExt","author":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"created_at":"2025-04-23T14:12:56.320Z","updated_at":"2025-04-23T14:12:56.887Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-23T14:12:56.887Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}}]}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c789251d86ba9f-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"23b1b755a58fd004e2846cb538b22eac"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-40-lb-gprd
+      gitlab-sv: gke-cny-api
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"fbad85899f80d934cad7742a59ff6439","version":"1"}'
+      x-request-id: fbad85899f80d934cad7742a59ff6439
+      x-runtime: '0.135038'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/discussions/91090f16d27d4ad053f39990c5a47a592565d38f
 - response:
     auto_calculate_content_length: false
     body: '{"id":2464715549,"type":"DiscussionNote","body":"The package libtiff failed
@@ -413,22 +737,22 @@ responses:
     content_type: application/json
     headers:
       CF-Cache-Status: MISS
-      CF-Ray: 93b7147efb07ed18-MXP
+      CF-Ray: 93c78928c869ba9f-MXP
       Cache-Control: max-age=0, private, must-revalidate
       ETag: W/"4300ea10b3d9f8472c79f7631e87fe00"
       Strict-Transport-Security: max-age=31536000
       Transfer-Encoding: chunked
       Vary: Origin, Accept-Encoding
       content-security-policy: default-src 'none'
-      gitlab-lb: haproxy-main-38-lb-gprd
-      gitlab-sv: api-gke-us-east1-c
+      gitlab-lb: haproxy-main-58-lb-gprd
+      gitlab-sv: api-gke-us-east1-b
       nel: '{"max_age": 0}'
       referrer-policy: strict-origin-when-cross-origin
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-gitlab-meta: '{"correlation_id":"a8313f454198c79d18b0c2bc4f897d05","version":"1"}'
-      x-request-id: a8313f454198c79d18b0c2bc4f897d05
-      x-runtime: '0.080985'
+      x-gitlab-meta: '{"correlation_id":"9e18250943f64069464edcf3b7012285","version":"1"}'
+      x-request-id: 9e18250943f64069464edcf3b7012285
+      x-runtime: '0.152086'
     method: GET
     status: 200
     url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549
@@ -439,7 +763,7 @@ responses:
     content_type: application/json
     headers:
       CF-Cache-Status: MISS
-      CF-Ray: 93b71480ae36ed18-MXP
+      CF-Ray: 93c7892f2d24ba9f-MXP
       Cache-Control: max-age=0, private, must-revalidate
       ETag: W/"f19fe711af9debb1837206f66dccbedd"
       Link: <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
@@ -449,19 +773,19 @@ responses:
       Transfer-Encoding: chunked
       Vary: Origin, Accept-Encoding
       content-security-policy: default-src 'none'
-      gitlab-lb: haproxy-main-03-lb-gprd
-      gitlab-sv: api-gke-us-east1-d
+      gitlab-lb: haproxy-main-52-lb-gprd
+      gitlab-sv: gke-cny-api
       nel: '{"max_age": 0}'
       referrer-policy: strict-origin-when-cross-origin
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-gitlab-meta: '{"correlation_id":"b3a078e1eae0d0d67c252bf39cbe5f7c","version":"1"}'
+      x-gitlab-meta: '{"correlation_id":"e84fa791a1b5c2d101b3cd18c8ea2ffc","version":"1"}'
       x-next-page: ''
       x-page: '1'
       x-per-page: '20'
       x-prev-page: ''
-      x-request-id: b3a078e1eae0d0d67c252bf39cbe5f7c
-      x-runtime: '0.148146'
+      x-request-id: e84fa791a1b5c2d101b3cd18c8ea2ffc
+      x-runtime: '0.141933'
       x-total: '1'
       x-total-pages: '1'
     method: GET

--- a/tests/data/test_collect_emojis.yaml
+++ b/tests/data/test_collect_emojis.yaml
@@ -1,0 +1,469 @@
+responses:
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":23667077,"description":"The libtiff rpms","name":"libtiff","name_with_namespace":"Red
+      Hat / centos-stream / rpms / libtiff","path":"libtiff","path_with_namespace":"redhat/centos-stream/rpms/libtiff","created_at":"2021-01-14T13:33:43.455Z","default_branch":"c10s","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:redhat/centos-stream/rpms/libtiff.git","http_url_to_repo":"https://gitlab.com/redhat/centos-stream/rpms/libtiff.git","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff","readme_url":null,"forks_count":6,"avatar_url":null,"star_count":2,"last_activity_at":"2025-05-05T16:06:55.870Z","namespace":{"id":8794173,"name":"rpms","path":"rpms","kind":"group","full_path":"redhat/centos-stream/rpms","parent_id":8706831,"avatar_url":null,"web_url":"https://gitlab.com/groups/redhat/centos-stream/rpms"},"container_registry_image_prefix":"registry.gitlab.com/redhat/centos-stream/rpms/libtiff","_links":{"self":"https://gitlab.com/api/v4/projects/23667077","merge_requests":"https://gitlab.com/api/v4/projects/23667077/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/23667077/repository/branches","labels":"https://gitlab.com/api/v4/projects/23667077/labels","events":"https://gitlab.com/api/v4/projects/23667077/events","members":"https://gitlab.com/api/v4/projects/23667077/members","cluster_agents":"https://gitlab.com/api/v4/projects/23667077/cluster_agents"},"marked_for_deletion_at":null,"marked_for_deletion_on":null,"packages_enabled":false,"empty_repo":false,"archived":false,"visibility":"public","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-01-15T13:33:43.485Z"},"repository_object_format":"sha1","issues_enabled":false,"merge_requests_enabled":true,"wiki_enabled":false,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"can_create_merge_request_in":true,"issues_access_level":"disabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"disabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","analytics_access_level":"enabled","container_registry_access_level":"enabled","security_and_compliance_access_level":"private","releases_access_level":"enabled","environments_access_level":"disabled","feature_flags_access_level":"disabled","infrastructure_access_level":"disabled","monitor_access_level":"disabled","model_experiments_access_level":"enabled","model_registry_access_level":"enabled","emails_disabled":false,"emails_enabled":true,"shared_runners_enabled":true,"lfs_enabled":false,"creator_id":6007577,"import_status":"none","description_html":"\u003cp
+      data-sourcepos=\"1:1-1:16\" dir=\"auto\"\u003eThe libtiff rpms\u003c/p\u003e","updated_at":"2025-05-05T16:15:15.015Z","ci_config_path":"global-tasks.yml@redhat/centos-stream/ci-cd/dist-git-gating-tests","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"request_access_enabled":false,"only_allow_merge_if_all_discussions_are_resolved":true,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","merge_request_title_regex":null,"squash_option":"never","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"approvals_before_merge":0,"mirror":false,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"merge_requests_template":"","merge_pipelines_enabled":true,"merge_trains_enabled":true,"merge_trains_skip_train_allowed":false,"allow_pipeline_trigger_approve_deployment":false,"auto_duo_code_review_enabled":false,"permissions":{"project_access":null,"group_access":null}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93b71474bf69ed18-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"3dca2067a7699b0582f6e7971355b3d2"
+      Set-Cookie: _cfuvid=lEtaED.DtDEVwUQjgdtPaIKmVoUu6lUXb9IsuDi1avs-1746519852574-0.0.1.1-604800000;
+        path=/; domain=.gitlab.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-36-lb-gprd
+      gitlab-sv: api-gke-us-east1-d
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"cacc9a1321778eb32e198958983cdf7e","version":"1"}'
+      x-request-id: cacc9a1321778eb32e198958983cdf7e
+      x-runtime: '0.137229'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":378085175,"iid":26,"project_id":23667077,"title":"Merge fix for RHEL-17337","description":"Merge
+      request for:\nissue RHEL-17337 - CVE-2023-52356 libtiff: Segment fault in libtiff  in
+      TIFFReadRGBATileExt() leading to denial of service [rhel-9]","state":"merged","created_at":"2025-04-22T14:59:54.425Z","updated_at":"2025-05-05T16:15:05.719Z","merged_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"merge_user":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"merged_at":"2025-05-05T16:15:05.741Z","closed_by":null,"closed_at":null,"target_branch":"c9s","source_branch":"c9s","user_notes_count":6,"upvotes":0,"downvotes":0,"author":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":61073452,"target_project_id":23667077,"labels":["target::latest"],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"can_be_merged","detailed_merge_status":"not_open","merge_after":null,"sha":"1d8f0e982d3beff79b63559640b7bd578109ceaf","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":"2025-04-22T14:59:59.635Z","allow_collaboration":false,"allow_maintainer_to_push":false,"reference":"!26","references":{"short":"!26","relative":"!26","full":"redhat/centos-stream/rpms/libtiff!26"},"web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/merge_requests/26","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":false,"squash_on_merge":false,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":false,"changes_count":"3","latest_build_started_at":"2025-05-05T15:17:22.392Z","latest_build_finished_at":"2025-05-05T16:07:40.651Z","first_deployed_to_production_at":null,"pipeline":{"id":1800983320,"iid":70,"project_id":23667077,"sha":"bf8b085aa0833394ab0ec10112e61521c6d169a0","ref":"refs/merge-requests/26/merge","status":"success","source":"merge_request_event","created_at":"2025-05-05T15:16:52.231Z","updated_at":"2025-05-05T16:07:40.669Z","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/pipelines/1800983320"},"head_pipeline":{"id":1800983320,"iid":70,"project_id":23667077,"sha":"bf8b085aa0833394ab0ec10112e61521c6d169a0","ref":"refs/merge-requests/26/merge","status":"success","source":"merge_request_event","created_at":"2025-05-05T15:16:52.231Z","updated_at":"2025-05-05T16:07:40.669Z","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/pipelines/1800983320","before_sha":"bf8b085aa0833394ab0ec10112e61521c6d169a0","tag":false,"yaml_errors":null,"user":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"started_at":"2025-05-05T15:17:22.392Z","finished_at":"2025-05-05T16:07:40.651Z","committed_at":null,"duration":2924,"queued_duration":30,"coverage":null,"detailed_status":{"icon":"status_success","text":"Passed","label":"passed","group":"success","tooltip":"passed","has_details":true,"details_path":"/redhat/centos-stream/rpms/libtiff/-/pipelines/1800983320","illustration":null,"favicon":"/assets/ci_favicons/favicon_status_success-8451333011eee8ce9f2ab25dc487fe24a8758c694827a582f17f42b0a90446a2.png"}},"diff_refs":{"base_sha":"3fc1a85f8a59af6101f675a1a02d95932ace85c8","head_sha":"1d8f0e982d3beff79b63559640b7bd578109ceaf","start_sha":"3fc1a85f8a59af6101f675a1a02d95932ace85c8"},"merge_error":null,"first_contribution":false,"user":{"can_merge":false}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93b71476db3bed18-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"04cac7b091f4ff7c7038be61ce98e1f7"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-43-lb-gprd
+      gitlab-sv: api-gke-us-east1-b
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"4c15460f2b419f98c7389096f3a3077a","version":"1"}'
+      x-request-id: 4c15460f2b419f98c7389096f3a3077a
+      x-runtime: '0.203379'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":2462509330,"type":"DiscussionNote","body":"The package libtiff failed
+      to build, here is a possible explanation why.\n\nPlease know that the explanation
+      was provided by AI and may be incorrect.\nIn this case, we are 99.71% certain
+      of the response :slight_smile:.\n\n Based on the provided log snippets, it appears
+      that there was a failure during the RPM build process for a package named \"libtiff\".
+      The exact cause of the failure cannot be determined from the given information
+      alone, but there are a few clues that suggest what the issue might be.\n\nThe
+      most significant indication of a problem is the error message at line [10] that
+      mentions \"RPM build errors: error: Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\". This error suggests that a necessary patch file
+      was missing during the build process. The patch file is identified as \"libtiff-4.4.0-CVE-2023-52356.patch\",
+      and it was expected to be located in the \"/builddir/build/SOURCES/\" directory.
+      However, this file could not be found, causing the build to fail.\n\nAnother
+      snippet (line [14]) shows that an exception was raised during the build process,
+      with the message \"Command failed: # bash --login -c ''/usr/bin/rpmbuild -bs
+      --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''\". This
+      error message confirms the failure of the \"rpmbuild\" command and indicates
+      that the issue was likely related to the missing patch file mentioned earlier.\n\nTo
+      resolve the issue, you should first ensure that all required patch files are
+      present in the correct location. Check the SPEC file for the \"libtiff\" package
+      to confirm that it specifies the correct patch file(s) and that their download
+      or extraction was successful during the build process. If necessary, manually
+      download and install the missing patch files in the expected directory. Once
+      all necessary patch files are present and accessible, try rebuilding the \"libtiff\"
+      package using the \"rpmbuild\" command to see if the issue is resolved. If the
+      issue persists, further investigation may be required to determine if there
+      are any other dependencies or issues that may be preventing the build from completing
+      successfully.\n\n\u003cdetails\u003e\n\u003cul\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      0:\u003c/b\u003e \u003ccode\u003eMock Version: 5.4\n\u003c/code\u003e\n The
+      given RPM build log snippet indicates the version of Mock being used during
+      the RPM build process. In this case, the version is 5.4.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      5:\u003c/b\u003e \u003ccode\u003eENTER [''do_with_status'']([''bash'', ''--login'',
+      ''-c'', ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''],
+      chrootPath=''/var/lib/mock/c9s-build-671467-759558/root''env={''TERM'': ''vt100'',
+      ''SHELL'': ''/bin/bash'', ''HOME'': ''/builddir'', ''HOSTNAME'': ''mock'', ''PATH'':
+      ''/usr/bin:/bin:/usr/sbin:/sbin'', ''PROMPT_COMMAND'': ''printf \"\\\\033]0;\u003cmock-chroot\u003e\\\\007\"'',
+      ''PS1'': ''\u003cmock-chroot\u003e \\\\s-\\\\v\\\\$ '', ''LANG'': ''C.UTF-8''}shell=Falselogger=\u003cmockbuild.trace_decorator.getLog
+      object at 0x7fff8ccaca58\u003etimeout=86400uid=989gid=135user=''mockbuild''nspawn_args=[]unshare_net=FalseprintOutput=False)\n\u003c/code\u003e\n
+      This snippet is a Python script that sets up a call to the RPM (Red Hat Package
+      Manager) build process. The script sets up an environment for RPM build in mock
+      chroot (mock-chroot), which is a feature that allows building RPM packages in
+      an isolated environment. The following are the key elements of the script:\n\n*
+      The script calls the `rpmbuild` command with the following arguments: `-bs`,
+      `--noclean`, `--target noarch`, `--nodeps`, and the path to the SPEC file `/builddir/build/SPECS/libtiff.spec`.
+      `-bs` flag means that the build process will be done in the background. `--noclean`
+      flag skips the clean target. `--target noarch` means that the built package
+      will be noarch (not architecture-specific). `--nodeps` flag skips the dependency
+      resolution.\n* `chrootPath` is the path to the mock chroot environment.\n* `env`
+      is a dictionary containing environment variables for the build process, including
+      `TERM`, `SHELL`, `HOME`, `HOSTNAME`, `PATH`, `PROMPT_COMMAND`, `PS1`, `LANG`,
+      `uid`, `gid`, `user`, and `nspawn_args`. These variables are used to set up
+      the environment for the build process.\n* `shell` is a boolean value indicating
+      whether to run the shell in the build process or not.\n* `logger` is an object
+      used for logging the build process.\n* `timeout` is the maximum build time in
+      seconds.\n* `uid` and `gid` are the user and group IDs to run the build process
+      as.\n* `user` is the username for the user running the build process.\n* `nspawn_args`
+      is an empty list of arguments for unshare network namespace.\n* `unshare_net`
+      is a boolean value indicating whether to use unshare network namespace or not.\n*
+      `printOutput` is a boolean value indicating whether to print the build output
+      or not.\n\nThe script sets up these variables and creates a call to the `rpmbuild`
+      command inside a mock chroot environment.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      6:\u003c/b\u003e \u003ccode\u003eExecuting command: [''bash'', ''--login'',
+      ''-c'', ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec'']
+      with env {''TERM'': ''vt100'', ''SHELL'': ''/bin/bash'', ''HOME'': ''/builddir'',
+      ''HOSTNAME'': ''mock'', ''PATH'': ''/usr/bin:/bin:/usr/sbin:/sbin'', ''PROMPT_COMMAND'':
+      ''printf \"\\\\033]0;\u003cmock-chroot\u003e\\\\007\"'', ''PS1'': ''\u003cmock-chroot\u003e
+      \\\\s-\\\\v\\\\$ '', ''LANG'': ''C.UTF-8''} and shell False\n\u003c/code\u003e\n
+      The given RPM build log snippet describes the execution of a command using RPM
+      build system. The command being executed is ''rpmbuild'' with specific build
+      options and no dependencies (-bs --noclean --target noarch --nodeps). The command
+      is being run in a ''mock'' environment, which is indicated by the ''mock-chroot''
+      in the PS1 variable. The environment variables for TERM, SHELL, HOME, HOSTNAME,
+      PATH, PROMPT_COMMAND, and LANG are also shown. The shell for the command is
+      set to ''False'', suggesting that an interpreter other than a shell, such as
+      a Perl or Python script, may be used to execute the RPM build command.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      7:\u003c/b\u003e \u003ccode\u003eBuilding target platforms: noarch\n\u003c/code\u003e\n
+      The RPM build log snippet indicates that the build process is currently working
+      on creating target platforms of type ''noarch''. Noarch is a common RPM target
+      architecture that stands for \"no architecture\" or \"noarchitecture\". It is
+      used for building packages that do not have any architecture-specific components
+      and can be installed on any system regardless of its hardware architecture.
+      Therefore, this log message implies that the RPM package builder is in the process
+      of creating a ''noarch'' variant of the RPM package being built.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      9:\u003c/b\u003e \u003ccode\u003esetting SOURCE_DATE_EPOCH=1745280000\n\u003c/code\u003e\n
+      This RPM build log snippet sets the SOURCE_DATE_EPOCH variable to the value
+      1745280000. This variable is used by RPM to preserve the build time of the source
+      code during the build process. The value is in the number of seconds since the
+      Unix epoch (January 1, 1970).\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      10:\u003c/b\u003e \u003ccode\u003eRPM build errors:\nerror: Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\n    Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\n\u003c/code\u003e\n The RPM build log indicates that
+      there were two build errors related to a patch file named \"libtiff-4.4.0-CVE-2023-52356.patch\".
+      The error message states that the file does not exist in the specified path
+      \"/builddir/build/SOURCES/\".\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      13:\u003c/b\u003e \u003ccode\u003eChild return code was: 1\n\u003c/code\u003e\n
+      The RPM build log snippet indicates that the child process during the RPM build
+      procedure returned an error code of 1. This is an indication that the build
+      process of the specified RPM package encountered an issue during execution.
+      The exact nature of the issue cannot be determined from this log snippet alone.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      14:\u003c/b\u003e \u003ccode\u003eEXCEPTION: [Error(\"Command failed: \\n #
+      bash --login -c ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''\\n\",
+      1)]\n\u003c/code\u003e\n This RPM build log snippet indicates that an exception
+      has occurred during the RPM build process. The exception message states that
+      the command \"rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec\"
+      has failed. The message is preceded by the number 14, which likely represents
+      the build number or sequence number of the build process. The failure of the
+      command is the only piece of information provided in this snippet. No further
+      details about the cause of the failure are given.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      15:\u003c/b\u003e \u003ccode\u003eTraceback (most recent call last):\n  File
+      \"/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py\", line 93,
+      in trace\n    result = func(*args, **kw)\n  File \"/usr/lib/python3.6/site-packages/mockbuild/util.py\",
+      line 612, in do_with_status\n    raise exception.Error(\"Command failed: \\n
+      # %s\\n%s\" % (cmd_pretty(command, env), output), child.returncode)\n\u003c/code\u003e\n
+      The snippet is an error message from a RPM build process using the Mockbuild
+      tool. The error indicates that a command executed during the build process has
+      failed. The specific error occurs in the \"do_with_status\" function, located
+      in the \"util.py\" file in the Mockbuild library.\n\nThe error message includes
+      a traceback, which shows that the error was raised by the \"Error\" exception
+      in the \"do_with_status\" function. The error message itself contains the command
+      that failed, indicated by `cmd_pretty(command, env)`, and the output of the
+      command. The return code of the command is also included in the error message.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      20:\u003c/b\u003e \u003ccode\u003emockbuild.exception.Error: Command failed:
+      \n # bash --login -c ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps
+      /builddir/build/SPECS/libtiff.spec''\n\n\u003c/code\u003e\n The log snippet
+      indicates that an error occurred during the RPM build process for the \"libtiff\"
+      package using mockbuild. Specifically, the command \"rpmbuild -bs --noclean
+      --target noarch --nodeps /builddir/build/SPECS/libtiff.spec\" failed. The error
+      message is not provided in the log snippet, only that the command failed.\n\u003c/li\u003e\n\n\u003c/ul\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eLogs\u003c/summary\u003e\n  \u003cp\u003e\n    Log
+      Detective analyzed the following logs files to provide an explanation:\n  \u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://gitlab.com/api/v4/projects/23667077/jobs/9789376408/artifacts/kojilogs/noarch-5653506/noarch-5653507/build.log\"\u003ehttps://gitlab.com/api/v4/projects/23667077/jobs/9789376408/artifacts/kojilogs/noarch-5653506/noarch-5653507/build.log\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\n  \u003cp\u003e\n    Additional
+      logs are available from:\n    \u003cul\u003e\n    \u003cli\u003e\u003ca href=\"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/jobs/9789376408/artifacts/download\"\u003eartifacts.zip\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n  \u003c/p\u003e\n\n  \u003cp\u003e\n    Please
+      know that these log files are automatically removed after some\n    time, so
+      you might need a backup.\n  \u003c/p\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eHelp\u003c/summary\u003e\n  \u003cp\u003eDon''t
+      hesitate to reach out.\u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective\"\u003eUpstream\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective/issues\"\u003eIssue tracker\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://redhat.enterprise.slack.com/archives/C06DWNVKKDE\"\u003eSlack\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://log-detective.com/documentation\"\u003eDocumentation\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\u003c/details\u003e\n\n\n---\nThis
+      comment was created by [Log Detective][log-detective].\n\nWas the provided feedback
+      accurate and helpful? \u003cbr\u003ePlease vote with :thumbsup:\nor :thumbsdown:
+      to help us improve.\u003cbr\u003e\n\n\n\n[log-detective]: https://log-detective.com/\n[contact]:
+      https://github.com/fedora-copr","author":{"id":27211590,"username":"group_8794173_bot_029d2e92d461920a3695e55137a87774","public_email":null,"name":"****","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/c16bbfef2c60f8447985835437fc6442310027fe3e08fca895081b06f089abce?s=80\u0026d=identicon","web_url":"https://gitlab.com/group_8794173_bot_029d2e92d461920a3695e55137a87774"},"created_at":"2025-04-22T15:05:38.431Z","updated_at":"2025-04-22T15:21:21.994Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-22T15:11:00.983Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93b714793f81ed18-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"b3e02019edf96e96f09b413bd0961ca9"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-14-lb-gprd
+      gitlab-sv: api-gke-us-east1-c
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"50566409a6d5c029ccf9210f1446d18b","version":"1"}'
+      x-request-id: 50566409a6d5c029ccf9210f1446d18b
+      x-runtime: '0.109780'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330
+- response:
+    auto_calculate_content_length: false
+    body: '[{"id":34008518,"name":"thumbsup","user":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"created_at":"2025-04-22T15:21:21.992Z","updated_at":"2025-04-22T15:21:21.992Z","awardable_id":2462509330,"awardable_type":"Note","url":null}]'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93b7147b1ba3ed18-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"7da7fe52d08c291e201c0b9f7350e6a4"
+      Link: <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
+        rel="first", <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
+        rel="last"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-25-lb-gprd
+      gitlab-sv: api-gke-us-east1-b
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"182a9559486ff90df13afaf59499af99","version":"1"}'
+      x-next-page: ''
+      x-page: '1'
+      x-per-page: '20'
+      x-prev-page: ''
+      x-request-id: 182a9559486ff90df13afaf59499af99
+      x-runtime: '0.085420'
+      x-total: '1'
+      x-total-pages: '1'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330/award_emoji
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":23667077,"description":"The libtiff rpms","name":"libtiff","name_with_namespace":"Red
+      Hat / centos-stream / rpms / libtiff","path":"libtiff","path_with_namespace":"redhat/centos-stream/rpms/libtiff","created_at":"2021-01-14T13:33:43.455Z","default_branch":"c10s","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:redhat/centos-stream/rpms/libtiff.git","http_url_to_repo":"https://gitlab.com/redhat/centos-stream/rpms/libtiff.git","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff","readme_url":null,"forks_count":6,"avatar_url":null,"star_count":2,"last_activity_at":"2025-05-05T16:06:55.870Z","namespace":{"id":8794173,"name":"rpms","path":"rpms","kind":"group","full_path":"redhat/centos-stream/rpms","parent_id":8706831,"avatar_url":null,"web_url":"https://gitlab.com/groups/redhat/centos-stream/rpms"},"container_registry_image_prefix":"registry.gitlab.com/redhat/centos-stream/rpms/libtiff","_links":{"self":"https://gitlab.com/api/v4/projects/23667077","merge_requests":"https://gitlab.com/api/v4/projects/23667077/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/23667077/repository/branches","labels":"https://gitlab.com/api/v4/projects/23667077/labels","events":"https://gitlab.com/api/v4/projects/23667077/events","members":"https://gitlab.com/api/v4/projects/23667077/members","cluster_agents":"https://gitlab.com/api/v4/projects/23667077/cluster_agents"},"marked_for_deletion_at":null,"marked_for_deletion_on":null,"packages_enabled":false,"empty_repo":false,"archived":false,"visibility":"public","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-01-15T13:33:43.485Z"},"repository_object_format":"sha1","issues_enabled":false,"merge_requests_enabled":true,"wiki_enabled":false,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"can_create_merge_request_in":true,"issues_access_level":"disabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"disabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","analytics_access_level":"enabled","container_registry_access_level":"enabled","security_and_compliance_access_level":"private","releases_access_level":"enabled","environments_access_level":"disabled","feature_flags_access_level":"disabled","infrastructure_access_level":"disabled","monitor_access_level":"disabled","model_experiments_access_level":"enabled","model_registry_access_level":"enabled","emails_disabled":false,"emails_enabled":true,"shared_runners_enabled":true,"lfs_enabled":false,"creator_id":6007577,"import_status":"none","description_html":"\u003cp
+      data-sourcepos=\"1:1-1:16\" dir=\"auto\"\u003eThe libtiff rpms\u003c/p\u003e","updated_at":"2025-05-05T16:15:15.015Z","ci_config_path":"global-tasks.yml@redhat/centos-stream/ci-cd/dist-git-gating-tests","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"request_access_enabled":false,"only_allow_merge_if_all_discussions_are_resolved":true,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","merge_request_title_regex":null,"squash_option":"never","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"approvals_before_merge":0,"mirror":false,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"merge_requests_template":"","merge_pipelines_enabled":true,"merge_trains_enabled":true,"merge_trains_skip_train_allowed":false,"allow_pipeline_trigger_approve_deployment":false,"auto_duo_code_review_enabled":false,"permissions":{"project_access":null,"group_access":null}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93b7147cef4ced18-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"3dca2067a7699b0582f6e7971355b3d2"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-39-lb-gprd
+      gitlab-sv: api-gke-us-east1-d
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"086f690dcd4197f42386d3f4f1266b6f","version":"1"}'
+      x-request-id: 086f690dcd4197f42386d3f4f1266b6f
+      x-runtime: '0.117985'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":2464715549,"type":"DiscussionNote","body":"The package libtiff failed
+      to build, here is a possible explanation why.\n\nPlease know that the explanation
+      was provided by AI and may be incorrect.\nIn this case, we are 99.49% certain
+      of the response :slight_smile:.\n\n The RPM build process of the \"libtiff.spec\"
+      package encountered an error during the `%build` phase. Specifically, the command
+      `/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec`
+      failed to execute successfully, as indicated by a non-zero exit status of 1.
+      This error was reported by Mockbuild, the RPM testing framework.\n\nThe log
+      snippets do not provide enough information to determine the exact cause of the
+      build failure. Potential issues could include missing or incompatible dependencies,
+      incorrect build variables, or compilation errors. It is recommended to review
+      the build script in `/builddir/build/SPECS/libtiff.spec` and the corresponding
+      source code to identify and resolve the cause of the build error. Additionally,
+      checking the RPM dependency tree and build environment variables may help identify
+      any missing dependencies or misconfigurations.\n\n\u003cdetails\u003e\n\u003cul\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      10:\u003c/b\u003e \u003ccode\u003eChild return code was: 0\n\u003c/code\u003e\n
+      This log snippet indicates that a child process, likely a sub-build or dependency
+      during the RPM build process, has completed with an exit status code of 0. An
+      exit status code of 0 typically signifies a successful execution.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      450:\u003c/b\u003e \u003ccode\u003emake[2]: Entering directory ''/builddir/build/BUILD/tiff-4.4.0/port''\n\u003c/code\u003e\n
+      This RPM build log snippet indicates that the make process (specifically make[2])
+      is entering the directory ''/builddir/build/BUILD/tiff-4.4.0/port''. The number
+      preceding the message (450) represents the line number in the build script where
+      this event occurs.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine 710:\u003c/b\u003e
+      \u003ccode\u003egcc -DHAVE_CONFIG_H -I. -I../config -I../libtiff -I../port  -I../libtiff
+      -I../port -DTIFF_DISABLE_DEPRECATED   -O2 -flto=auto -ffat-lto-objects -fexceptions
+      -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2
+      -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong
+      -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64-v2 -mtune=generic
+      -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-strict-aliasing
+      -Wall -W -c -o fax2tiff.o fax2tiff.c\n\u003c/code\u003e\n The RPM build log
+      snippet represents a gcc compilation command with various flags and options
+      for building the ''fax2tiff.o'' object file from ''fax2tiff.c''.\n\nThe command
+      includes:\n- Compiler: gcc\n- Preprocessor flags:\n  - Include directories:
+      ., ../config, ../libtiff, ../port\n  - Defines: HAVE_CONFIG_H, TIFF_DISABLE_DEPRECATED\n\n-
+      Optimization flags:\n  - Compiler optimization: -O2\n  - Link-time optimization:
+      -flto=auto -ffat-lto-objects\n\n- Exception handling: -fexceptions\n\n- Debugging
+      flags: -g -grecord-gcc-switches\n\n- Warnings: -Wall -Werror=format-security\n\n-
+      Security: -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS\n\n- Hardened build:
+      -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1\n\n- Stack protection: -fstack-protector-strong\n\n-
+      Code protection: -fcf-protection\n\n- Aliasing: -fno-strict-aliasing\n\n- Target
+      architecture: -m64 -march=x86-64-v2 -mtune=generic\n\n- Asynchronous unwind
+      tables: -fasynchronous-unwind-tables\n\n- Stack clash protection: -fstack-clash-protection.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      786:\u003c/b\u003e \u003ccode\u003ecollect2: error: ld returned 1 exit status\n\u003c/code\u003e\n
+      The RPM build log snippet indicates an error during the linking (ld) stage of
+      the build process. The linker returned an exit status of 1, which signifies
+      an unsuccessful linking attempt. The exact cause of the error is not provided
+      in the snippet, but potential issues could include missing or incompatible libraries,
+      incorrect library versions, or syntax errors in the linker script. Further investigation
+      is required to determine the specific cause and resolve the issue.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      787:\u003c/b\u003e \u003ccode\u003emake[1]: *** [Makefile:653: tiffdither] Error
+      1\n\u003c/code\u003e\n The RPM build log snippet indicates that there was an
+      error during the execution of the \"make\" command, specifically with the target
+      \"tiffdither\" mentioned in the Makefile on line 653. The error resulted in
+      the make process exiting with a status code of 1.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      905:\u003c/b\u003e \u003ccode\u003etiffcrop.c: In function ''writeBufferToSeparateStrips'':\ntiffcrop.c:1244:28:
+      warning: comparison of integer expressions of different signedness: ''tsize_t''
+      {aka ''long int''} and ''long long unsigned int'' [-Wsign-compare]\n 1244 |           if
+      (scanlinesize \u003e 0x0ffffffffULL) {\n      |                            ^\n\u003c/code\u003e\n
+      The RPM build log snippet indicates a compiler warning during the build process
+      of the ''tiffcrop.c'' file. The warning message specifically mentions a comparison
+      of two data types with different signedness in line 1244 of the file: ''tsize_t''
+      (a long int type) and ''long long unsigned int''. The compiler is advising that
+      such a comparison may result in unexpected behavior due to potential sign conversions.
+      The warning message concludes with the location of the issue in the code.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      913:\u003c/b\u003e \u003ccode\u003emake: *** [Makefile:561: all-recursive] Error
+      1\n\u003c/code\u003e\n The RPM build log snippet indicates an error occurred
+      during the \"make all-recursive\" step in the RPM package build process. Specifically,
+      the \"make\" command returned an error status code 1. There is no further information
+      provided in the log snippet regarding the nature of the error.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      914:\u003c/b\u003e \u003ccode\u003eerror: Bad exit status from /var/tmp/rpm-tmp.JH52lB
+      (%build)\n\u003c/code\u003e\n The RPM build process encountered an error during
+      the `%build` phase of the build. Specifically, there was a \"Bad exit status\"
+      from the build script located at `/var/tmp/rpm-tmp.JH52lB`. This indicates that
+      the commands executed within the `%build` script did not complete successfully,
+      resulting in an error. The cause of this error is not apparent from the given
+      log snippet and requires further investigation into the contents of the `%build`
+      script and build environment.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      915:\u003c/b\u003e \u003ccode\u003eRPM build errors:\n    Bad exit status from
+      /var/tmp/rpm-tmp.JH52lB (%build)\n\u003c/code\u003e\n The given RPM build log
+      snippet indicates that during the build process, an error occurred in the %build
+      phase. The error resulted in an unsuccessful exit status from the file location
+      ''/var/tmp/rpm-tmp.JH52lB''. No further information is provided in the log regarding
+      the nature of the error.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      918:\u003c/b\u003e \u003ccode\u003eEXCEPTION: [Error(\"Command failed: \\n #
+      bash --login -c ''/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec''\\n\",
+      1)]\n\u003c/code\u003e\n The log snippet indicates an error occurred during
+      the RPM build process using the `rpmbuild` command. The command being executed
+      is:\n\n`/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec`\n\nThe
+      error message reads ''Command failed'' and is accompanied by an exception. The
+      cause of the command failure is not explicitly stated in the provided log snippet.
+      The error is marked with a non-zero exit status of 1.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      919:\u003c/b\u003e \u003ccode\u003eTraceback (most recent call last):\n  File
+      \"/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py\", line 93,
+      in trace\n    result = func(*args, **kw)\n  File \"/usr/lib/python3.6/site-packages/mockbuild/util.py\",
+      line 612, in do_with_status\n    raise exception.Error(\"Command failed: \\n
+      # %s\\n%s\" % (cmd_pretty(command, env), output), child.returncode)\n\u003c/code\u003e\n
+      This log snippet is a Python traceback indicating an error during the execution
+      of an RPM build using the mockbuild tool. The error occurred at the line where
+      the command execution failed in the mockbuild utility file (do_with_status,
+      line 612). The specific error message states that a command failed with the
+      given error message and return code. The command and its environment variables
+      can be found in the cmd_pretty function call. No further information is provided
+      in the log snippet.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine 924:\u003c/b\u003e
+      \u003ccode\u003emockbuild.exception.Error: Command failed: \n # bash --login
+      -c ''/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec''\n\n\u003c/code\u003e\n
+      The build log snippet indicates an error occurred during the RPM build process
+      of the \"libtiff.spec\" file, using the x86\\_64 architecture. The command \"rpmbuild
+      -bb --noclean --target x86\\_64 --nodeps /builddir/build/SPECS/libtiff.spec\"
+      failed to execute successfully. This error is reported by Mockbuild, an RPM
+      testing framework. No further information about the nature of the command failure
+      is provided in the log.\n\u003c/li\u003e\n\n\u003c/ul\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eLogs\u003c/summary\u003e\n  \u003cp\u003e\n    Log
+      Detective analyzed the following logs files to provide an explanation:\n  \u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://gitlab.com/api/v4/projects/23667077/jobs/9789725965/artifacts/kojilogs/noarch-5653531/x86_64-5653534/build.log\"\u003ehttps://gitlab.com/api/v4/projects/23667077/jobs/9789725965/artifacts/kojilogs/noarch-5653531/x86_64-5653534/build.log\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\n  \u003cp\u003e\n    Additional
+      logs are available from:\n    \u003cul\u003e\n    \u003cli\u003e\u003ca href=\"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/jobs/9789725965/artifacts/download\"\u003eartifacts.zip\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n  \u003c/p\u003e\n\n  \u003cp\u003e\n    Please
+      know that these log files are automatically removed after some\n    time, so
+      you might need a backup.\n  \u003c/p\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eHelp\u003c/summary\u003e\n  \u003cp\u003eDon''t
+      hesitate to reach out.\u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective\"\u003eUpstream\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective/issues\"\u003eIssue tracker\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://redhat.enterprise.slack.com/archives/C06DWNVKKDE\"\u003eSlack\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://log-detective.com/documentation\"\u003eDocumentation\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\u003c/details\u003e\n\n\n---\nThis
+      comment was created by [Log Detective][log-detective].\n\nWas the provided feedback
+      accurate and helpful? \u003cbr\u003ePlease vote with :thumbsup:\nor :thumbsdown:
+      to help us improve.\u003cbr\u003e\n\n\n\n[log-detective]: https://log-detective.com/\n[contact]:
+      https://github.com/fedora-copr","author":{"id":27211590,"username":"group_8794173_bot_029d2e92d461920a3695e55137a87774","public_email":null,"name":"****","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/c16bbfef2c60f8447985835437fc6442310027fe3e08fca895081b06f089abce?s=80\u0026d=identicon","web_url":"https://gitlab.com/group_8794173_bot_029d2e92d461920a3695e55137a87774"},"created_at":"2025-04-23T14:02:31.332Z","updated_at":"2025-04-23T14:12:56.887Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-23T14:12:56.887Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93b7147efb07ed18-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"4300ea10b3d9f8472c79f7631e87fe00"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-38-lb-gprd
+      gitlab-sv: api-gke-us-east1-c
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"a8313f454198c79d18b0c2bc4f897d05","version":"1"}'
+      x-request-id: a8313f454198c79d18b0c2bc4f897d05
+      x-runtime: '0.080985'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549
+- response:
+    auto_calculate_content_length: false
+    body: '[{"id":34038545,"name":"thumbsdown","user":{"id":737640,"username":"TomasTomecek","public_email":"","name":"Tomas
+      Tomecek","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/545461259a87a9b40ef14e381b4257d476bc183ab44b293f084084ada15a2dcc?s=80\u0026d=identicon","web_url":"https://gitlab.com/TomasTomecek"},"created_at":"2025-04-23T14:11:12.123Z","updated_at":"2025-04-23T14:11:12.123Z","awardable_id":2464715549,"awardable_type":"Note","url":null}]'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93b71480ae36ed18-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"f19fe711af9debb1837206f66dccbedd"
+      Link: <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
+        rel="first", <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
+        rel="last"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-03-lb-gprd
+      gitlab-sv: api-gke-us-east1-d
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"b3a078e1eae0d0d67c252bf39cbe5f7c","version":"1"}'
+      x-next-page: ''
+      x-page: '1'
+      x-per-page: '20'
+      x-prev-page: ''
+      x-request-id: b3a078e1eae0d0d67c252bf39cbe5f7c
+      x-runtime: '0.148146'
+      x-total: '1'
+      x-total-pages: '1'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549/award_emoji

--- a/tests/data/test_collect_emojis_for_mr.yaml
+++ b/tests/data/test_collect_emojis_for_mr.yaml
@@ -3,28 +3,26 @@ responses:
     auto_calculate_content_length: false
     body: '{"id":23667077,"description":"The libtiff rpms","name":"libtiff","name_with_namespace":"Red
       Hat / centos-stream / rpms / libtiff","path":"libtiff","path_with_namespace":"redhat/centos-stream/rpms/libtiff","created_at":"2021-01-14T13:33:43.455Z","default_branch":"c10s","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:redhat/centos-stream/rpms/libtiff.git","http_url_to_repo":"https://gitlab.com/redhat/centos-stream/rpms/libtiff.git","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff","readme_url":null,"forks_count":6,"avatar_url":null,"star_count":2,"last_activity_at":"2025-05-05T16:06:55.870Z","namespace":{"id":8794173,"name":"rpms","path":"rpms","kind":"group","full_path":"redhat/centos-stream/rpms","parent_id":8706831,"avatar_url":null,"web_url":"https://gitlab.com/groups/redhat/centos-stream/rpms"},"container_registry_image_prefix":"registry.gitlab.com/redhat/centos-stream/rpms/libtiff","_links":{"self":"https://gitlab.com/api/v4/projects/23667077","merge_requests":"https://gitlab.com/api/v4/projects/23667077/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/23667077/repository/branches","labels":"https://gitlab.com/api/v4/projects/23667077/labels","events":"https://gitlab.com/api/v4/projects/23667077/events","members":"https://gitlab.com/api/v4/projects/23667077/members","cluster_agents":"https://gitlab.com/api/v4/projects/23667077/cluster_agents"},"marked_for_deletion_at":null,"marked_for_deletion_on":null,"packages_enabled":false,"empty_repo":false,"archived":false,"visibility":"public","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-01-15T13:33:43.485Z"},"repository_object_format":"sha1","issues_enabled":false,"merge_requests_enabled":true,"wiki_enabled":false,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"can_create_merge_request_in":true,"issues_access_level":"disabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"disabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","analytics_access_level":"enabled","container_registry_access_level":"enabled","security_and_compliance_access_level":"private","releases_access_level":"enabled","environments_access_level":"disabled","feature_flags_access_level":"disabled","infrastructure_access_level":"disabled","monitor_access_level":"disabled","model_experiments_access_level":"enabled","model_registry_access_level":"enabled","emails_disabled":false,"emails_enabled":true,"shared_runners_enabled":true,"lfs_enabled":false,"creator_id":6007577,"import_status":"none","description_html":"\u003cp
-      data-sourcepos=\"1:1-1:16\" dir=\"auto\"\u003eThe libtiff rpms\u003c/p\u003e","updated_at":"2025-05-05T16:15:15.015Z","ci_config_path":"global-tasks.yml@redhat/centos-stream/ci-cd/dist-git-gating-tests","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"request_access_enabled":false,"only_allow_merge_if_all_discussions_are_resolved":true,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","merge_request_title_regex":null,"squash_option":"never","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"approvals_before_merge":0,"mirror":false,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"merge_requests_template":"","merge_pipelines_enabled":true,"merge_trains_enabled":true,"merge_trains_skip_train_allowed":false,"allow_pipeline_trigger_approve_deployment":false,"auto_duo_code_review_enabled":false,"permissions":{"project_access":null,"group_access":null}}'
+      data-sourcepos=\"1:1-1:16\" dir=\"auto\"\u003eThe libtiff rpms\u003c/p\u003e","updated_at":"2025-05-07T15:22:25.055Z","ci_config_path":"global-tasks.yml@redhat/centos-stream/ci-cd/dist-git-gating-tests","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"request_access_enabled":false,"only_allow_merge_if_all_discussions_are_resolved":true,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","merge_request_title_regex":null,"squash_option":"never","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"approvals_before_merge":0,"mirror":false,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"merge_requests_template":"","merge_pipelines_enabled":true,"merge_trains_enabled":true,"merge_trains_skip_train_allowed":false,"allow_pipeline_trigger_approve_deployment":false,"auto_duo_code_review_enabled":false,"permissions":{"project_access":null,"group_access":null}}'
     content_type: application/json
     headers:
       CF-Cache-Status: MISS
-      CF-Ray: 93b8f6285b85255b-MXP
+      CF-Ray: 93c7893de835ba9f-MXP
       Cache-Control: max-age=0, private, must-revalidate
-      ETag: W/"3dca2067a7699b0582f6e7971355b3d2"
-      Set-Cookie: _cfuvid=0P9_9IYZbQV0JVQBeMe3r_oFWvSfAe7YfeBfKRz.lz0-1746539583142-0.0.1.1-604800000;
-        path=/; domain=.gitlab.com; HttpOnly; Secure; SameSite=None
+      ETag: W/"7bcd1b327972f0654df91402d94e9b70"
       Strict-Transport-Security: max-age=31536000
       Transfer-Encoding: chunked
       Vary: Origin, Accept-Encoding
       content-security-policy: default-src 'none'
-      gitlab-lb: haproxy-main-28-lb-gprd
-      gitlab-sv: api-gke-us-east1-b
+      gitlab-lb: haproxy-main-08-lb-gprd
+      gitlab-sv: gke-cny-api
       nel: '{"max_age": 0}'
       referrer-policy: strict-origin-when-cross-origin
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-gitlab-meta: '{"correlation_id":"17c1d2780a5e806910444ee093b6770c","version":"1"}'
-      x-request-id: 17c1d2780a5e806910444ee093b6770c
-      x-runtime: '0.217633'
+      x-gitlab-meta: '{"correlation_id":"6e930cfe8f6191c2fdb2bb06ec4a8573","version":"1"}'
+      x-request-id: 6e930cfe8f6191c2fdb2bb06ec4a8573
+      x-runtime: '0.322199'
     method: GET
     status: 200
     url: https://gitlab.com/api/v4/projects/23667077
@@ -36,25 +34,193 @@ responses:
     content_type: application/json
     headers:
       CF-Cache-Status: MISS
-      CF-Ray: 93b8f62ad993255b-MXP
+      CF-Ray: 93c789429be9ba9f-MXP
       Cache-Control: max-age=0, private, must-revalidate
       ETag: W/"04cac7b091f4ff7c7038be61ce98e1f7"
       Strict-Transport-Security: max-age=31536000
       Transfer-Encoding: chunked
       Vary: Origin, Accept-Encoding
       content-security-policy: default-src 'none'
-      gitlab-lb: haproxy-main-09-lb-gprd
+      gitlab-lb: haproxy-main-22-lb-gprd
+      gitlab-sv: gke-cny-api
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"2101855af41c11f203361832544f13cf","version":"1"}'
+      x-request-id: 2101855af41c11f203361832544f13cf
+      x-runtime: '0.214039'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":"1ba1f46903f2b4e0573d514ed6d2cae29ab040f6","individual_note":false,"notes":[{"id":2462509330,"type":"DiscussionNote","body":"The
+      package libtiff failed to build, here is a possible explanation why.\n\nPlease
+      know that the explanation was provided by AI and may be incorrect.\nIn this
+      case, we are 99.71% certain of the response :slight_smile:.\n\n Based on the
+      provided log snippets, it appears that there was a failure during the RPM build
+      process for a package named \"libtiff\". The exact cause of the failure cannot
+      be determined from the given information alone, but there are a few clues that
+      suggest what the issue might be.\n\nThe most significant indication of a problem
+      is the error message at line [10] that mentions \"RPM build errors: error: Bad
+      file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch: No such file
+      or directory\". This error suggests that a necessary patch file was missing
+      during the build process. The patch file is identified as \"libtiff-4.4.0-CVE-2023-52356.patch\",
+      and it was expected to be located in the \"/builddir/build/SOURCES/\" directory.
+      However, this file could not be found, causing the build to fail.\n\nAnother
+      snippet (line [14]) shows that an exception was raised during the build process,
+      with the message \"Command failed: # bash --login -c ''/usr/bin/rpmbuild -bs
+      --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''\". This
+      error message confirms the failure of the \"rpmbuild\" command and indicates
+      that the issue was likely related to the missing patch file mentioned earlier.\n\nTo
+      resolve the issue, you should first ensure that all required patch files are
+      present in the correct location. Check the SPEC file for the \"libtiff\" package
+      to confirm that it specifies the correct patch file(s) and that their download
+      or extraction was successful during the build process. If necessary, manually
+      download and install the missing patch files in the expected directory. Once
+      all necessary patch files are present and accessible, try rebuilding the \"libtiff\"
+      package using the \"rpmbuild\" command to see if the issue is resolved. If the
+      issue persists, further investigation may be required to determine if there
+      are any other dependencies or issues that may be preventing the build from completing
+      successfully.\n\n\u003cdetails\u003e\n\u003cul\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      0:\u003c/b\u003e \u003ccode\u003eMock Version: 5.4\n\u003c/code\u003e\n The
+      given RPM build log snippet indicates the version of Mock being used during
+      the RPM build process. In this case, the version is 5.4.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      5:\u003c/b\u003e \u003ccode\u003eENTER [''do_with_status'']([''bash'', ''--login'',
+      ''-c'', ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''],
+      chrootPath=''/var/lib/mock/c9s-build-671467-759558/root''env={''TERM'': ''vt100'',
+      ''SHELL'': ''/bin/bash'', ''HOME'': ''/builddir'', ''HOSTNAME'': ''mock'', ''PATH'':
+      ''/usr/bin:/bin:/usr/sbin:/sbin'', ''PROMPT_COMMAND'': ''printf \"\\\\033]0;\u003cmock-chroot\u003e\\\\007\"'',
+      ''PS1'': ''\u003cmock-chroot\u003e \\\\s-\\\\v\\\\$ '', ''LANG'': ''C.UTF-8''}shell=Falselogger=\u003cmockbuild.trace_decorator.getLog
+      object at 0x7fff8ccaca58\u003etimeout=86400uid=989gid=135user=''mockbuild''nspawn_args=[]unshare_net=FalseprintOutput=False)\n\u003c/code\u003e\n
+      This snippet is a Python script that sets up a call to the RPM (Red Hat Package
+      Manager) build process. The script sets up an environment for RPM build in mock
+      chroot (mock-chroot), which is a feature that allows building RPM packages in
+      an isolated environment. The following are the key elements of the script:\n\n*
+      The script calls the `rpmbuild` command with the following arguments: `-bs`,
+      `--noclean`, `--target noarch`, `--nodeps`, and the path to the SPEC file `/builddir/build/SPECS/libtiff.spec`.
+      `-bs` flag means that the build process will be done in the background. `--noclean`
+      flag skips the clean target. `--target noarch` means that the built package
+      will be noarch (not architecture-specific). `--nodeps` flag skips the dependency
+      resolution.\n* `chrootPath` is the path to the mock chroot environment.\n* `env`
+      is a dictionary containing environment variables for the build process, including
+      `TERM`, `SHELL`, `HOME`, `HOSTNAME`, `PATH`, `PROMPT_COMMAND`, `PS1`, `LANG`,
+      `uid`, `gid`, `user`, and `nspawn_args`. These variables are used to set up
+      the environment for the build process.\n* `shell` is a boolean value indicating
+      whether to run the shell in the build process or not.\n* `logger` is an object
+      used for logging the build process.\n* `timeout` is the maximum build time in
+      seconds.\n* `uid` and `gid` are the user and group IDs to run the build process
+      as.\n* `user` is the username for the user running the build process.\n* `nspawn_args`
+      is an empty list of arguments for unshare network namespace.\n* `unshare_net`
+      is a boolean value indicating whether to use unshare network namespace or not.\n*
+      `printOutput` is a boolean value indicating whether to print the build output
+      or not.\n\nThe script sets up these variables and creates a call to the `rpmbuild`
+      command inside a mock chroot environment.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      6:\u003c/b\u003e \u003ccode\u003eExecuting command: [''bash'', ''--login'',
+      ''-c'', ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec'']
+      with env {''TERM'': ''vt100'', ''SHELL'': ''/bin/bash'', ''HOME'': ''/builddir'',
+      ''HOSTNAME'': ''mock'', ''PATH'': ''/usr/bin:/bin:/usr/sbin:/sbin'', ''PROMPT_COMMAND'':
+      ''printf \"\\\\033]0;\u003cmock-chroot\u003e\\\\007\"'', ''PS1'': ''\u003cmock-chroot\u003e
+      \\\\s-\\\\v\\\\$ '', ''LANG'': ''C.UTF-8''} and shell False\n\u003c/code\u003e\n
+      The given RPM build log snippet describes the execution of a command using RPM
+      build system. The command being executed is ''rpmbuild'' with specific build
+      options and no dependencies (-bs --noclean --target noarch --nodeps). The command
+      is being run in a ''mock'' environment, which is indicated by the ''mock-chroot''
+      in the PS1 variable. The environment variables for TERM, SHELL, HOME, HOSTNAME,
+      PATH, PROMPT_COMMAND, and LANG are also shown. The shell for the command is
+      set to ''False'', suggesting that an interpreter other than a shell, such as
+      a Perl or Python script, may be used to execute the RPM build command.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      7:\u003c/b\u003e \u003ccode\u003eBuilding target platforms: noarch\n\u003c/code\u003e\n
+      The RPM build log snippet indicates that the build process is currently working
+      on creating target platforms of type ''noarch''. Noarch is a common RPM target
+      architecture that stands for \"no architecture\" or \"noarchitecture\". It is
+      used for building packages that do not have any architecture-specific components
+      and can be installed on any system regardless of its hardware architecture.
+      Therefore, this log message implies that the RPM package builder is in the process
+      of creating a ''noarch'' variant of the RPM package being built.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      9:\u003c/b\u003e \u003ccode\u003esetting SOURCE_DATE_EPOCH=1745280000\n\u003c/code\u003e\n
+      This RPM build log snippet sets the SOURCE_DATE_EPOCH variable to the value
+      1745280000. This variable is used by RPM to preserve the build time of the source
+      code during the build process. The value is in the number of seconds since the
+      Unix epoch (January 1, 1970).\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      10:\u003c/b\u003e \u003ccode\u003eRPM build errors:\nerror: Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\n    Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\n\u003c/code\u003e\n The RPM build log indicates that
+      there were two build errors related to a patch file named \"libtiff-4.4.0-CVE-2023-52356.patch\".
+      The error message states that the file does not exist in the specified path
+      \"/builddir/build/SOURCES/\".\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      13:\u003c/b\u003e \u003ccode\u003eChild return code was: 1\n\u003c/code\u003e\n
+      The RPM build log snippet indicates that the child process during the RPM build
+      procedure returned an error code of 1. This is an indication that the build
+      process of the specified RPM package encountered an issue during execution.
+      The exact nature of the issue cannot be determined from this log snippet alone.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      14:\u003c/b\u003e \u003ccode\u003eEXCEPTION: [Error(\"Command failed: \\n #
+      bash --login -c ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''\\n\",
+      1)]\n\u003c/code\u003e\n This RPM build log snippet indicates that an exception
+      has occurred during the RPM build process. The exception message states that
+      the command \"rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec\"
+      has failed. The message is preceded by the number 14, which likely represents
+      the build number or sequence number of the build process. The failure of the
+      command is the only piece of information provided in this snippet. No further
+      details about the cause of the failure are given.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      15:\u003c/b\u003e \u003ccode\u003eTraceback (most recent call last):\n  File
+      \"/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py\", line 93,
+      in trace\n    result = func(*args, **kw)\n  File \"/usr/lib/python3.6/site-packages/mockbuild/util.py\",
+      line 612, in do_with_status\n    raise exception.Error(\"Command failed: \\n
+      # %s\\n%s\" % (cmd_pretty(command, env), output), child.returncode)\n\u003c/code\u003e\n
+      The snippet is an error message from a RPM build process using the Mockbuild
+      tool. The error indicates that a command executed during the build process has
+      failed. The specific error occurs in the \"do_with_status\" function, located
+      in the \"util.py\" file in the Mockbuild library.\n\nThe error message includes
+      a traceback, which shows that the error was raised by the \"Error\" exception
+      in the \"do_with_status\" function. The error message itself contains the command
+      that failed, indicated by `cmd_pretty(command, env)`, and the output of the
+      command. The return code of the command is also included in the error message.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      20:\u003c/b\u003e \u003ccode\u003emockbuild.exception.Error: Command failed:
+      \n # bash --login -c ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps
+      /builddir/build/SPECS/libtiff.spec''\n\n\u003c/code\u003e\n The log snippet
+      indicates that an error occurred during the RPM build process for the \"libtiff\"
+      package using mockbuild. Specifically, the command \"rpmbuild -bs --noclean
+      --target noarch --nodeps /builddir/build/SPECS/libtiff.spec\" failed. The error
+      message is not provided in the log snippet, only that the command failed.\n\u003c/li\u003e\n\n\u003c/ul\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eLogs\u003c/summary\u003e\n  \u003cp\u003e\n    Log
+      Detective analyzed the following logs files to provide an explanation:\n  \u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://gitlab.com/api/v4/projects/23667077/jobs/9789376408/artifacts/kojilogs/noarch-5653506/noarch-5653507/build.log\"\u003ehttps://gitlab.com/api/v4/projects/23667077/jobs/9789376408/artifacts/kojilogs/noarch-5653506/noarch-5653507/build.log\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\n  \u003cp\u003e\n    Additional
+      logs are available from:\n    \u003cul\u003e\n    \u003cli\u003e\u003ca href=\"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/jobs/9789376408/artifacts/download\"\u003eartifacts.zip\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n  \u003c/p\u003e\n\n  \u003cp\u003e\n    Please
+      know that these log files are automatically removed after some\n    time, so
+      you might need a backup.\n  \u003c/p\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eHelp\u003c/summary\u003e\n  \u003cp\u003eDon''t
+      hesitate to reach out.\u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective\"\u003eUpstream\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective/issues\"\u003eIssue tracker\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://redhat.enterprise.slack.com/archives/C06DWNVKKDE\"\u003eSlack\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://log-detective.com/documentation\"\u003eDocumentation\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\u003c/details\u003e\n\n\n---\nThis
+      comment was created by [Log Detective][log-detective].\n\nWas the provided feedback
+      accurate and helpful? \u003cbr\u003ePlease vote with :thumbsup:\nor :thumbsdown:
+      to help us improve.\u003cbr\u003e\n\n\n\n[log-detective]: https://log-detective.com/\n[contact]:
+      https://github.com/fedora-copr","author":{"id":27211590,"username":"group_8794173_bot_029d2e92d461920a3695e55137a87774","public_email":null,"name":"****","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/c16bbfef2c60f8447985835437fc6442310027fe3e08fca895081b06f089abce?s=80\u0026d=identicon","web_url":"https://gitlab.com/group_8794173_bot_029d2e92d461920a3695e55137a87774"},"created_at":"2025-04-22T15:05:38.431Z","updated_at":"2025-04-22T15:21:21.994Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-22T15:11:00.983Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}},{"id":2462523126,"type":"DiscussionNote","body":"correct
+      analysis, but a bit tl;dr","author":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"created_at":"2025-04-22T15:11:00.436Z","updated_at":"2025-04-22T15:11:00.983Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-22T15:11:00.983Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}}]}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c789463f93ba9f-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"56c7b72183071ab15bae67a27b9cbd18"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-54-lb-gprd
       gitlab-sv: api-gke-us-east1-d
       nel: '{"max_age": 0}'
       referrer-policy: strict-origin-when-cross-origin
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-gitlab-meta: '{"correlation_id":"aa12f43341b5022a2bfdda27503adb52","version":"1"}'
-      x-request-id: aa12f43341b5022a2bfdda27503adb52
-      x-runtime: '0.383058'
+      x-gitlab-meta: '{"correlation_id":"d21ae4ba4e2c99154236001973847f94","version":"1"}'
+      x-request-id: d21ae4ba4e2c99154236001973847f94
+      x-runtime: '0.121389'
     method: GET
     status: 200
-    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/discussions/1ba1f46903f2b4e0573d514ed6d2cae29ab040f6
 - response:
     auto_calculate_content_length: false
     body: '{"id":2462509330,"type":"DiscussionNote","body":"The package libtiff failed
@@ -202,22 +368,22 @@ responses:
     content_type: application/json
     headers:
       CF-Cache-Status: MISS
-      CF-Ray: 93b8f62e6a6b255b-MXP
+      CF-Ray: 93c78949fa4bba9f-MXP
       Cache-Control: max-age=0, private, must-revalidate
       ETag: W/"b3e02019edf96e96f09b413bd0961ca9"
       Strict-Transport-Security: max-age=31536000
       Transfer-Encoding: chunked
       Vary: Origin, Accept-Encoding
       content-security-policy: default-src 'none'
-      gitlab-lb: haproxy-main-01-lb-gprd
-      gitlab-sv: api-gke-us-east1-b
+      gitlab-lb: haproxy-main-50-lb-gprd
+      gitlab-sv: api-gke-us-east1-c
       nel: '{"max_age": 0}'
       referrer-policy: strict-origin-when-cross-origin
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-gitlab-meta: '{"correlation_id":"9dc0a4afe1a2a92e854b122f2430c6ba","version":"1"}'
-      x-request-id: 9dc0a4afe1a2a92e854b122f2430c6ba
-      x-runtime: '0.173327'
+      x-gitlab-meta: '{"correlation_id":"b70ccf7ca6719aff7ad8a45cc184bce9","version":"1"}'
+      x-request-id: b70ccf7ca6719aff7ad8a45cc184bce9
+      x-runtime: '0.102242'
     method: GET
     status: 200
     url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330
@@ -227,7 +393,7 @@ responses:
     content_type: application/json
     headers:
       CF-Cache-Status: MISS
-      CF-Ray: 93b8f630afd9255b-MXP
+      CF-Ray: 93c7894c8c8aba9f-MXP
       Cache-Control: max-age=0, private, must-revalidate
       ETag: W/"7da7fe52d08c291e201c0b9f7350e6a4"
       Link: <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
@@ -237,19 +403,19 @@ responses:
       Transfer-Encoding: chunked
       Vary: Origin, Accept-Encoding
       content-security-policy: default-src 'none'
-      gitlab-lb: haproxy-main-05-lb-gprd
-      gitlab-sv: api-gke-us-east1-c
+      gitlab-lb: haproxy-main-46-lb-gprd
+      gitlab-sv: api-gke-us-east1-b
       nel: '{"max_age": 0}'
       referrer-policy: strict-origin-when-cross-origin
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-gitlab-meta: '{"correlation_id":"e1b4c0f573832f0be3ff29331094fa07","version":"1"}'
+      x-gitlab-meta: '{"correlation_id":"6e857c12284d47be76466d8a1c2e1c79","version":"1"}'
       x-next-page: ''
       x-page: '1'
       x-per-page: '20'
       x-prev-page: ''
-      x-request-id: e1b4c0f573832f0be3ff29331094fa07
-      x-runtime: '0.099332'
+      x-request-id: 6e857c12284d47be76466d8a1c2e1c79
+      x-runtime: '0.151703'
       x-total: '1'
       x-total-pages: '1'
     method: GET
@@ -259,29 +425,185 @@ responses:
     auto_calculate_content_length: false
     body: '{"id":23667077,"description":"The libtiff rpms","name":"libtiff","name_with_namespace":"Red
       Hat / centos-stream / rpms / libtiff","path":"libtiff","path_with_namespace":"redhat/centos-stream/rpms/libtiff","created_at":"2021-01-14T13:33:43.455Z","default_branch":"c10s","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:redhat/centos-stream/rpms/libtiff.git","http_url_to_repo":"https://gitlab.com/redhat/centos-stream/rpms/libtiff.git","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff","readme_url":null,"forks_count":6,"avatar_url":null,"star_count":2,"last_activity_at":"2025-05-05T16:06:55.870Z","namespace":{"id":8794173,"name":"rpms","path":"rpms","kind":"group","full_path":"redhat/centos-stream/rpms","parent_id":8706831,"avatar_url":null,"web_url":"https://gitlab.com/groups/redhat/centos-stream/rpms"},"container_registry_image_prefix":"registry.gitlab.com/redhat/centos-stream/rpms/libtiff","_links":{"self":"https://gitlab.com/api/v4/projects/23667077","merge_requests":"https://gitlab.com/api/v4/projects/23667077/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/23667077/repository/branches","labels":"https://gitlab.com/api/v4/projects/23667077/labels","events":"https://gitlab.com/api/v4/projects/23667077/events","members":"https://gitlab.com/api/v4/projects/23667077/members","cluster_agents":"https://gitlab.com/api/v4/projects/23667077/cluster_agents"},"marked_for_deletion_at":null,"marked_for_deletion_on":null,"packages_enabled":false,"empty_repo":false,"archived":false,"visibility":"public","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-01-15T13:33:43.485Z"},"repository_object_format":"sha1","issues_enabled":false,"merge_requests_enabled":true,"wiki_enabled":false,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"can_create_merge_request_in":true,"issues_access_level":"disabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"disabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","analytics_access_level":"enabled","container_registry_access_level":"enabled","security_and_compliance_access_level":"private","releases_access_level":"enabled","environments_access_level":"disabled","feature_flags_access_level":"disabled","infrastructure_access_level":"disabled","monitor_access_level":"disabled","model_experiments_access_level":"enabled","model_registry_access_level":"enabled","emails_disabled":false,"emails_enabled":true,"shared_runners_enabled":true,"lfs_enabled":false,"creator_id":6007577,"import_status":"none","description_html":"\u003cp
-      data-sourcepos=\"1:1-1:16\" dir=\"auto\"\u003eThe libtiff rpms\u003c/p\u003e","updated_at":"2025-05-05T16:15:15.015Z","ci_config_path":"global-tasks.yml@redhat/centos-stream/ci-cd/dist-git-gating-tests","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"request_access_enabled":false,"only_allow_merge_if_all_discussions_are_resolved":true,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","merge_request_title_regex":null,"squash_option":"never","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"approvals_before_merge":0,"mirror":false,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"merge_requests_template":"","merge_pipelines_enabled":true,"merge_trains_enabled":true,"merge_trains_skip_train_allowed":false,"allow_pipeline_trigger_approve_deployment":false,"auto_duo_code_review_enabled":false,"permissions":{"project_access":null,"group_access":null}}'
+      data-sourcepos=\"1:1-1:16\" dir=\"auto\"\u003eThe libtiff rpms\u003c/p\u003e","updated_at":"2025-05-07T15:22:25.055Z","ci_config_path":"global-tasks.yml@redhat/centos-stream/ci-cd/dist-git-gating-tests","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"request_access_enabled":false,"only_allow_merge_if_all_discussions_are_resolved":true,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","merge_request_title_regex":null,"squash_option":"never","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"approvals_before_merge":0,"mirror":false,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"merge_requests_template":"","merge_pipelines_enabled":true,"merge_trains_enabled":true,"merge_trains_skip_train_allowed":false,"allow_pipeline_trigger_approve_deployment":false,"auto_duo_code_review_enabled":false,"permissions":{"project_access":null,"group_access":null}}'
     content_type: application/json
     headers:
       CF-Cache-Status: MISS
-      CF-Ray: 93b8f6328c67255b-MXP
+      CF-Ray: 93c7894fbf93ba9f-MXP
       Cache-Control: max-age=0, private, must-revalidate
-      ETag: W/"3dca2067a7699b0582f6e7971355b3d2"
+      ETag: W/"7bcd1b327972f0654df91402d94e9b70"
       Strict-Transport-Security: max-age=31536000
       Transfer-Encoding: chunked
       Vary: Origin, Accept-Encoding
       content-security-policy: default-src 'none'
-      gitlab-lb: haproxy-main-60-lb-gprd
-      gitlab-sv: api-gke-us-east1-d
+      gitlab-lb: haproxy-main-02-lb-gprd
+      gitlab-sv: api-gke-us-east1-c
       nel: '{"max_age": 0}'
       referrer-policy: strict-origin-when-cross-origin
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-gitlab-meta: '{"correlation_id":"8f0d40e227d63928c730c3a5d851b995","version":"1"}'
-      x-request-id: 8f0d40e227d63928c730c3a5d851b995
-      x-runtime: '0.294620'
+      x-gitlab-meta: '{"correlation_id":"c24c2ab6683811a0d4a4ee07db067eba","version":"1"}'
+      x-request-id: c24c2ab6683811a0d4a4ee07db067eba
+      x-runtime: '0.118093'
     method: GET
     status: 200
     url: https://gitlab.com/api/v4/projects/23667077
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":"91090f16d27d4ad053f39990c5a47a592565d38f","individual_note":false,"notes":[{"id":2464715549,"type":"DiscussionNote","body":"The
+      package libtiff failed to build, here is a possible explanation why.\n\nPlease
+      know that the explanation was provided by AI and may be incorrect.\nIn this
+      case, we are 99.49% certain of the response :slight_smile:.\n\n The RPM build
+      process of the \"libtiff.spec\" package encountered an error during the `%build`
+      phase. Specifically, the command `/usr/bin/rpmbuild -bb --noclean --target x86_64
+      --nodeps /builddir/build/SPECS/libtiff.spec` failed to execute successfully,
+      as indicated by a non-zero exit status of 1. This error was reported by Mockbuild,
+      the RPM testing framework.\n\nThe log snippets do not provide enough information
+      to determine the exact cause of the build failure. Potential issues could include
+      missing or incompatible dependencies, incorrect build variables, or compilation
+      errors. It is recommended to review the build script in `/builddir/build/SPECS/libtiff.spec`
+      and the corresponding source code to identify and resolve the cause of the build
+      error. Additionally, checking the RPM dependency tree and build environment
+      variables may help identify any missing dependencies or misconfigurations.\n\n\u003cdetails\u003e\n\u003cul\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      10:\u003c/b\u003e \u003ccode\u003eChild return code was: 0\n\u003c/code\u003e\n
+      This log snippet indicates that a child process, likely a sub-build or dependency
+      during the RPM build process, has completed with an exit status code of 0. An
+      exit status code of 0 typically signifies a successful execution.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      450:\u003c/b\u003e \u003ccode\u003emake[2]: Entering directory ''/builddir/build/BUILD/tiff-4.4.0/port''\n\u003c/code\u003e\n
+      This RPM build log snippet indicates that the make process (specifically make[2])
+      is entering the directory ''/builddir/build/BUILD/tiff-4.4.0/port''. The number
+      preceding the message (450) represents the line number in the build script where
+      this event occurs.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine 710:\u003c/b\u003e
+      \u003ccode\u003egcc -DHAVE_CONFIG_H -I. -I../config -I../libtiff -I../port  -I../libtiff
+      -I../port -DTIFF_DISABLE_DEPRECATED   -O2 -flto=auto -ffat-lto-objects -fexceptions
+      -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2
+      -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong
+      -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64-v2 -mtune=generic
+      -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-strict-aliasing
+      -Wall -W -c -o fax2tiff.o fax2tiff.c\n\u003c/code\u003e\n The RPM build log
+      snippet represents a gcc compilation command with various flags and options
+      for building the ''fax2tiff.o'' object file from ''fax2tiff.c''.\n\nThe command
+      includes:\n- Compiler: gcc\n- Preprocessor flags:\n  - Include directories:
+      ., ../config, ../libtiff, ../port\n  - Defines: HAVE_CONFIG_H, TIFF_DISABLE_DEPRECATED\n\n-
+      Optimization flags:\n  - Compiler optimization: -O2\n  - Link-time optimization:
+      -flto=auto -ffat-lto-objects\n\n- Exception handling: -fexceptions\n\n- Debugging
+      flags: -g -grecord-gcc-switches\n\n- Warnings: -Wall -Werror=format-security\n\n-
+      Security: -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS\n\n- Hardened build:
+      -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1\n\n- Stack protection: -fstack-protector-strong\n\n-
+      Code protection: -fcf-protection\n\n- Aliasing: -fno-strict-aliasing\n\n- Target
+      architecture: -m64 -march=x86-64-v2 -mtune=generic\n\n- Asynchronous unwind
+      tables: -fasynchronous-unwind-tables\n\n- Stack clash protection: -fstack-clash-protection.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      786:\u003c/b\u003e \u003ccode\u003ecollect2: error: ld returned 1 exit status\n\u003c/code\u003e\n
+      The RPM build log snippet indicates an error during the linking (ld) stage of
+      the build process. The linker returned an exit status of 1, which signifies
+      an unsuccessful linking attempt. The exact cause of the error is not provided
+      in the snippet, but potential issues could include missing or incompatible libraries,
+      incorrect library versions, or syntax errors in the linker script. Further investigation
+      is required to determine the specific cause and resolve the issue.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      787:\u003c/b\u003e \u003ccode\u003emake[1]: *** [Makefile:653: tiffdither] Error
+      1\n\u003c/code\u003e\n The RPM build log snippet indicates that there was an
+      error during the execution of the \"make\" command, specifically with the target
+      \"tiffdither\" mentioned in the Makefile on line 653. The error resulted in
+      the make process exiting with a status code of 1.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      905:\u003c/b\u003e \u003ccode\u003etiffcrop.c: In function ''writeBufferToSeparateStrips'':\ntiffcrop.c:1244:28:
+      warning: comparison of integer expressions of different signedness: ''tsize_t''
+      {aka ''long int''} and ''long long unsigned int'' [-Wsign-compare]\n 1244 |           if
+      (scanlinesize \u003e 0x0ffffffffULL) {\n      |                            ^\n\u003c/code\u003e\n
+      The RPM build log snippet indicates a compiler warning during the build process
+      of the ''tiffcrop.c'' file. The warning message specifically mentions a comparison
+      of two data types with different signedness in line 1244 of the file: ''tsize_t''
+      (a long int type) and ''long long unsigned int''. The compiler is advising that
+      such a comparison may result in unexpected behavior due to potential sign conversions.
+      The warning message concludes with the location of the issue in the code.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      913:\u003c/b\u003e \u003ccode\u003emake: *** [Makefile:561: all-recursive] Error
+      1\n\u003c/code\u003e\n The RPM build log snippet indicates an error occurred
+      during the \"make all-recursive\" step in the RPM package build process. Specifically,
+      the \"make\" command returned an error status code 1. There is no further information
+      provided in the log snippet regarding the nature of the error.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      914:\u003c/b\u003e \u003ccode\u003eerror: Bad exit status from /var/tmp/rpm-tmp.JH52lB
+      (%build)\n\u003c/code\u003e\n The RPM build process encountered an error during
+      the `%build` phase of the build. Specifically, there was a \"Bad exit status\"
+      from the build script located at `/var/tmp/rpm-tmp.JH52lB`. This indicates that
+      the commands executed within the `%build` script did not complete successfully,
+      resulting in an error. The cause of this error is not apparent from the given
+      log snippet and requires further investigation into the contents of the `%build`
+      script and build environment.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      915:\u003c/b\u003e \u003ccode\u003eRPM build errors:\n    Bad exit status from
+      /var/tmp/rpm-tmp.JH52lB (%build)\n\u003c/code\u003e\n The given RPM build log
+      snippet indicates that during the build process, an error occurred in the %build
+      phase. The error resulted in an unsuccessful exit status from the file location
+      ''/var/tmp/rpm-tmp.JH52lB''. No further information is provided in the log regarding
+      the nature of the error.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      918:\u003c/b\u003e \u003ccode\u003eEXCEPTION: [Error(\"Command failed: \\n #
+      bash --login -c ''/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec''\\n\",
+      1)]\n\u003c/code\u003e\n The log snippet indicates an error occurred during
+      the RPM build process using the `rpmbuild` command. The command being executed
+      is:\n\n`/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec`\n\nThe
+      error message reads ''Command failed'' and is accompanied by an exception. The
+      cause of the command failure is not explicitly stated in the provided log snippet.
+      The error is marked with a non-zero exit status of 1.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      919:\u003c/b\u003e \u003ccode\u003eTraceback (most recent call last):\n  File
+      \"/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py\", line 93,
+      in trace\n    result = func(*args, **kw)\n  File \"/usr/lib/python3.6/site-packages/mockbuild/util.py\",
+      line 612, in do_with_status\n    raise exception.Error(\"Command failed: \\n
+      # %s\\n%s\" % (cmd_pretty(command, env), output), child.returncode)\n\u003c/code\u003e\n
+      This log snippet is a Python traceback indicating an error during the execution
+      of an RPM build using the mockbuild tool. The error occurred at the line where
+      the command execution failed in the mockbuild utility file (do_with_status,
+      line 612). The specific error message states that a command failed with the
+      given error message and return code. The command and its environment variables
+      can be found in the cmd_pretty function call. No further information is provided
+      in the log snippet.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine 924:\u003c/b\u003e
+      \u003ccode\u003emockbuild.exception.Error: Command failed: \n # bash --login
+      -c ''/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec''\n\n\u003c/code\u003e\n
+      The build log snippet indicates an error occurred during the RPM build process
+      of the \"libtiff.spec\" file, using the x86\\_64 architecture. The command \"rpmbuild
+      -bb --noclean --target x86\\_64 --nodeps /builddir/build/SPECS/libtiff.spec\"
+      failed to execute successfully. This error is reported by Mockbuild, an RPM
+      testing framework. No further information about the nature of the command failure
+      is provided in the log.\n\u003c/li\u003e\n\n\u003c/ul\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eLogs\u003c/summary\u003e\n  \u003cp\u003e\n    Log
+      Detective analyzed the following logs files to provide an explanation:\n  \u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://gitlab.com/api/v4/projects/23667077/jobs/9789725965/artifacts/kojilogs/noarch-5653531/x86_64-5653534/build.log\"\u003ehttps://gitlab.com/api/v4/projects/23667077/jobs/9789725965/artifacts/kojilogs/noarch-5653531/x86_64-5653534/build.log\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\n  \u003cp\u003e\n    Additional
+      logs are available from:\n    \u003cul\u003e\n    \u003cli\u003e\u003ca href=\"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/jobs/9789725965/artifacts/download\"\u003eartifacts.zip\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n  \u003c/p\u003e\n\n  \u003cp\u003e\n    Please
+      know that these log files are automatically removed after some\n    time, so
+      you might need a backup.\n  \u003c/p\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eHelp\u003c/summary\u003e\n  \u003cp\u003eDon''t
+      hesitate to reach out.\u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective\"\u003eUpstream\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective/issues\"\u003eIssue tracker\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://redhat.enterprise.slack.com/archives/C06DWNVKKDE\"\u003eSlack\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://log-detective.com/documentation\"\u003eDocumentation\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\u003c/details\u003e\n\n\n---\nThis
+      comment was created by [Log Detective][log-detective].\n\nWas the provided feedback
+      accurate and helpful? \u003cbr\u003ePlease vote with :thumbsup:\nor :thumbsdown:
+      to help us improve.\u003cbr\u003e\n\n\n\n[log-detective]: https://log-detective.com/\n[contact]:
+      https://github.com/fedora-copr","author":{"id":27211590,"username":"group_8794173_bot_029d2e92d461920a3695e55137a87774","public_email":null,"name":"****","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/c16bbfef2c60f8447985835437fc6442310027fe3e08fca895081b06f089abce?s=80\u0026d=identicon","web_url":"https://gitlab.com/group_8794173_bot_029d2e92d461920a3695e55137a87774"},"created_at":"2025-04-23T14:02:31.332Z","updated_at":"2025-04-23T14:12:56.887Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-23T14:12:56.887Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}},{"id":2464747301,"type":"DiscussionNote","body":"unsuccessful
+      analysis:\nerror that caused failure:\n/usr/bin/ld: ../libtiff/.libs/libtiff.so:
+      undefined reference to `TIFFErrorExtR''\ncollect2: error: ld returned 1 exit
+      status\nmake[1]: *** [Makefile:653: tiffdither] Error 1\n\nprimary source of
+      that error:\ntif_getimage.c: In function ''TIFFReadRGBAStripExt'':\ntif_getimage.c:2948:13:
+      warning: implicit declaration of function ''TIFFErrorExtR''; did you mean ''TIFFErrorExt''?
+      [-Wimplicit-function-declaration]\n 2948 |             TIFFErrorExtR(tif, TIFFFileName(tif),\n      |             ^~~~~~~~~~~~~\n      |             TIFFErrorExt","author":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"created_at":"2025-04-23T14:12:56.320Z","updated_at":"2025-04-23T14:12:56.887Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-23T14:12:56.887Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}}]}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c78953eb0bba9f-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"23b1b755a58fd004e2846cb538b22eac"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-54-lb-gprd
+      gitlab-sv: gke-cny-api
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"be3614e0566fc8e384d003d6f451b0f6","version":"1"}'
+      x-request-id: be3614e0566fc8e384d003d6f451b0f6
+      x-runtime: '0.168868'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/discussions/91090f16d27d4ad053f39990c5a47a592565d38f
 - response:
     auto_calculate_content_length: false
     body: '{"id":2464715549,"type":"DiscussionNote","body":"The package libtiff failed
@@ -413,22 +735,22 @@ responses:
     content_type: application/json
     headers:
       CF-Cache-Status: MISS
-      CF-Ray: 93b8f6359bef255b-MXP
+      CF-Ray: 93c789582e30ba9f-MXP
       Cache-Control: max-age=0, private, must-revalidate
       ETag: W/"4300ea10b3d9f8472c79f7631e87fe00"
       Strict-Transport-Security: max-age=31536000
       Transfer-Encoding: chunked
       Vary: Origin, Accept-Encoding
       content-security-policy: default-src 'none'
-      gitlab-lb: haproxy-main-03-lb-gprd
-      gitlab-sv: api-gke-us-east1-d
+      gitlab-lb: haproxy-main-08-lb-gprd
+      gitlab-sv: api-gke-us-east1-c
       nel: '{"max_age": 0}'
       referrer-policy: strict-origin-when-cross-origin
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-gitlab-meta: '{"correlation_id":"67e613aeaf4ffc65bc53cec430b2c831","version":"1"}'
-      x-request-id: 67e613aeaf4ffc65bc53cec430b2c831
-      x-runtime: '0.121080'
+      x-gitlab-meta: '{"correlation_id":"aa91c23ae68b717977dd882dc454302b","version":"1"}'
+      x-request-id: aa91c23ae68b717977dd882dc454302b
+      x-runtime: '0.146028'
     method: GET
     status: 200
     url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549
@@ -439,7 +761,7 @@ responses:
     content_type: application/json
     headers:
       CF-Cache-Status: MISS
-      CF-Ray: 93b8f6378887255b-MXP
+      CF-Ray: 93c7895c39ccba9f-MXP
       Cache-Control: max-age=0, private, must-revalidate
       ETag: W/"f19fe711af9debb1837206f66dccbedd"
       Link: <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
@@ -449,19 +771,19 @@ responses:
       Transfer-Encoding: chunked
       Vary: Origin, Accept-Encoding
       content-security-policy: default-src 'none'
-      gitlab-lb: haproxy-main-42-lb-gprd
-      gitlab-sv: api-gke-us-east1-d
+      gitlab-lb: haproxy-main-02-lb-gprd
+      gitlab-sv: api-gke-us-east1-c
       nel: '{"max_age": 0}'
       referrer-policy: strict-origin-when-cross-origin
       x-content-type-options: nosniff
       x-frame-options: SAMEORIGIN
-      x-gitlab-meta: '{"correlation_id":"a4a9927f6ee400226aa1b7e2e475483b","version":"1"}'
+      x-gitlab-meta: '{"correlation_id":"28129aed923072390ae7a670f57780a3","version":"1"}'
       x-next-page: ''
       x-page: '1'
       x-per-page: '20'
       x-prev-page: ''
-      x-request-id: a4a9927f6ee400226aa1b7e2e475483b
-      x-runtime: '0.088779'
+      x-request-id: 28129aed923072390ae7a670f57780a3
+      x-runtime: '0.140458'
       x-total: '1'
       x-total-pages: '1'
     method: GET

--- a/tests/data/test_collect_emojis_for_mr.yaml
+++ b/tests/data/test_collect_emojis_for_mr.yaml
@@ -1,0 +1,469 @@
+responses:
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":23667077,"description":"The libtiff rpms","name":"libtiff","name_with_namespace":"Red
+      Hat / centos-stream / rpms / libtiff","path":"libtiff","path_with_namespace":"redhat/centos-stream/rpms/libtiff","created_at":"2021-01-14T13:33:43.455Z","default_branch":"c10s","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:redhat/centos-stream/rpms/libtiff.git","http_url_to_repo":"https://gitlab.com/redhat/centos-stream/rpms/libtiff.git","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff","readme_url":null,"forks_count":6,"avatar_url":null,"star_count":2,"last_activity_at":"2025-05-05T16:06:55.870Z","namespace":{"id":8794173,"name":"rpms","path":"rpms","kind":"group","full_path":"redhat/centos-stream/rpms","parent_id":8706831,"avatar_url":null,"web_url":"https://gitlab.com/groups/redhat/centos-stream/rpms"},"container_registry_image_prefix":"registry.gitlab.com/redhat/centos-stream/rpms/libtiff","_links":{"self":"https://gitlab.com/api/v4/projects/23667077","merge_requests":"https://gitlab.com/api/v4/projects/23667077/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/23667077/repository/branches","labels":"https://gitlab.com/api/v4/projects/23667077/labels","events":"https://gitlab.com/api/v4/projects/23667077/events","members":"https://gitlab.com/api/v4/projects/23667077/members","cluster_agents":"https://gitlab.com/api/v4/projects/23667077/cluster_agents"},"marked_for_deletion_at":null,"marked_for_deletion_on":null,"packages_enabled":false,"empty_repo":false,"archived":false,"visibility":"public","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-01-15T13:33:43.485Z"},"repository_object_format":"sha1","issues_enabled":false,"merge_requests_enabled":true,"wiki_enabled":false,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"can_create_merge_request_in":true,"issues_access_level":"disabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"disabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","analytics_access_level":"enabled","container_registry_access_level":"enabled","security_and_compliance_access_level":"private","releases_access_level":"enabled","environments_access_level":"disabled","feature_flags_access_level":"disabled","infrastructure_access_level":"disabled","monitor_access_level":"disabled","model_experiments_access_level":"enabled","model_registry_access_level":"enabled","emails_disabled":false,"emails_enabled":true,"shared_runners_enabled":true,"lfs_enabled":false,"creator_id":6007577,"import_status":"none","description_html":"\u003cp
+      data-sourcepos=\"1:1-1:16\" dir=\"auto\"\u003eThe libtiff rpms\u003c/p\u003e","updated_at":"2025-05-05T16:15:15.015Z","ci_config_path":"global-tasks.yml@redhat/centos-stream/ci-cd/dist-git-gating-tests","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"request_access_enabled":false,"only_allow_merge_if_all_discussions_are_resolved":true,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","merge_request_title_regex":null,"squash_option":"never","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"approvals_before_merge":0,"mirror":false,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"merge_requests_template":"","merge_pipelines_enabled":true,"merge_trains_enabled":true,"merge_trains_skip_train_allowed":false,"allow_pipeline_trigger_approve_deployment":false,"auto_duo_code_review_enabled":false,"permissions":{"project_access":null,"group_access":null}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93b8f6285b85255b-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"3dca2067a7699b0582f6e7971355b3d2"
+      Set-Cookie: _cfuvid=0P9_9IYZbQV0JVQBeMe3r_oFWvSfAe7YfeBfKRz.lz0-1746539583142-0.0.1.1-604800000;
+        path=/; domain=.gitlab.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-28-lb-gprd
+      gitlab-sv: api-gke-us-east1-b
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"17c1d2780a5e806910444ee093b6770c","version":"1"}'
+      x-request-id: 17c1d2780a5e806910444ee093b6770c
+      x-runtime: '0.217633'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":378085175,"iid":26,"project_id":23667077,"title":"Merge fix for RHEL-17337","description":"Merge
+      request for:\nissue RHEL-17337 - CVE-2023-52356 libtiff: Segment fault in libtiff  in
+      TIFFReadRGBATileExt() leading to denial of service [rhel-9]","state":"merged","created_at":"2025-04-22T14:59:54.425Z","updated_at":"2025-05-05T16:15:05.719Z","merged_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"merge_user":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"merged_at":"2025-05-05T16:15:05.741Z","closed_by":null,"closed_at":null,"target_branch":"c9s","source_branch":"c9s","user_notes_count":6,"upvotes":0,"downvotes":0,"author":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":61073452,"target_project_id":23667077,"labels":["target::latest"],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"can_be_merged","detailed_merge_status":"not_open","merge_after":null,"sha":"1d8f0e982d3beff79b63559640b7bd578109ceaf","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":"2025-04-22T14:59:59.635Z","allow_collaboration":false,"allow_maintainer_to_push":false,"reference":"!26","references":{"short":"!26","relative":"!26","full":"redhat/centos-stream/rpms/libtiff!26"},"web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/merge_requests/26","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":false,"squash_on_merge":false,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":false,"changes_count":"3","latest_build_started_at":"2025-05-05T15:17:22.392Z","latest_build_finished_at":"2025-05-05T16:07:40.651Z","first_deployed_to_production_at":null,"pipeline":{"id":1800983320,"iid":70,"project_id":23667077,"sha":"bf8b085aa0833394ab0ec10112e61521c6d169a0","ref":"refs/merge-requests/26/merge","status":"success","source":"merge_request_event","created_at":"2025-05-05T15:16:52.231Z","updated_at":"2025-05-05T16:07:40.669Z","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/pipelines/1800983320"},"head_pipeline":{"id":1800983320,"iid":70,"project_id":23667077,"sha":"bf8b085aa0833394ab0ec10112e61521c6d169a0","ref":"refs/merge-requests/26/merge","status":"success","source":"merge_request_event","created_at":"2025-05-05T15:16:52.231Z","updated_at":"2025-05-05T16:07:40.669Z","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/pipelines/1800983320","before_sha":"bf8b085aa0833394ab0ec10112e61521c6d169a0","tag":false,"yaml_errors":null,"user":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"started_at":"2025-05-05T15:17:22.392Z","finished_at":"2025-05-05T16:07:40.651Z","committed_at":null,"duration":2924,"queued_duration":30,"coverage":null,"detailed_status":{"icon":"status_success","text":"Passed","label":"passed","group":"success","tooltip":"passed","has_details":true,"details_path":"/redhat/centos-stream/rpms/libtiff/-/pipelines/1800983320","illustration":null,"favicon":"/assets/ci_favicons/favicon_status_success-8451333011eee8ce9f2ab25dc487fe24a8758c694827a582f17f42b0a90446a2.png"}},"diff_refs":{"base_sha":"3fc1a85f8a59af6101f675a1a02d95932ace85c8","head_sha":"1d8f0e982d3beff79b63559640b7bd578109ceaf","start_sha":"3fc1a85f8a59af6101f675a1a02d95932ace85c8"},"merge_error":null,"first_contribution":false,"user":{"can_merge":false}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93b8f62ad993255b-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"04cac7b091f4ff7c7038be61ce98e1f7"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-09-lb-gprd
+      gitlab-sv: api-gke-us-east1-d
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"aa12f43341b5022a2bfdda27503adb52","version":"1"}'
+      x-request-id: aa12f43341b5022a2bfdda27503adb52
+      x-runtime: '0.383058'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":2462509330,"type":"DiscussionNote","body":"The package libtiff failed
+      to build, here is a possible explanation why.\n\nPlease know that the explanation
+      was provided by AI and may be incorrect.\nIn this case, we are 99.71% certain
+      of the response :slight_smile:.\n\n Based on the provided log snippets, it appears
+      that there was a failure during the RPM build process for a package named \"libtiff\".
+      The exact cause of the failure cannot be determined from the given information
+      alone, but there are a few clues that suggest what the issue might be.\n\nThe
+      most significant indication of a problem is the error message at line [10] that
+      mentions \"RPM build errors: error: Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\". This error suggests that a necessary patch file
+      was missing during the build process. The patch file is identified as \"libtiff-4.4.0-CVE-2023-52356.patch\",
+      and it was expected to be located in the \"/builddir/build/SOURCES/\" directory.
+      However, this file could not be found, causing the build to fail.\n\nAnother
+      snippet (line [14]) shows that an exception was raised during the build process,
+      with the message \"Command failed: # bash --login -c ''/usr/bin/rpmbuild -bs
+      --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''\". This
+      error message confirms the failure of the \"rpmbuild\" command and indicates
+      that the issue was likely related to the missing patch file mentioned earlier.\n\nTo
+      resolve the issue, you should first ensure that all required patch files are
+      present in the correct location. Check the SPEC file for the \"libtiff\" package
+      to confirm that it specifies the correct patch file(s) and that their download
+      or extraction was successful during the build process. If necessary, manually
+      download and install the missing patch files in the expected directory. Once
+      all necessary patch files are present and accessible, try rebuilding the \"libtiff\"
+      package using the \"rpmbuild\" command to see if the issue is resolved. If the
+      issue persists, further investigation may be required to determine if there
+      are any other dependencies or issues that may be preventing the build from completing
+      successfully.\n\n\u003cdetails\u003e\n\u003cul\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      0:\u003c/b\u003e \u003ccode\u003eMock Version: 5.4\n\u003c/code\u003e\n The
+      given RPM build log snippet indicates the version of Mock being used during
+      the RPM build process. In this case, the version is 5.4.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      5:\u003c/b\u003e \u003ccode\u003eENTER [''do_with_status'']([''bash'', ''--login'',
+      ''-c'', ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''],
+      chrootPath=''/var/lib/mock/c9s-build-671467-759558/root''env={''TERM'': ''vt100'',
+      ''SHELL'': ''/bin/bash'', ''HOME'': ''/builddir'', ''HOSTNAME'': ''mock'', ''PATH'':
+      ''/usr/bin:/bin:/usr/sbin:/sbin'', ''PROMPT_COMMAND'': ''printf \"\\\\033]0;\u003cmock-chroot\u003e\\\\007\"'',
+      ''PS1'': ''\u003cmock-chroot\u003e \\\\s-\\\\v\\\\$ '', ''LANG'': ''C.UTF-8''}shell=Falselogger=\u003cmockbuild.trace_decorator.getLog
+      object at 0x7fff8ccaca58\u003etimeout=86400uid=989gid=135user=''mockbuild''nspawn_args=[]unshare_net=FalseprintOutput=False)\n\u003c/code\u003e\n
+      This snippet is a Python script that sets up a call to the RPM (Red Hat Package
+      Manager) build process. The script sets up an environment for RPM build in mock
+      chroot (mock-chroot), which is a feature that allows building RPM packages in
+      an isolated environment. The following are the key elements of the script:\n\n*
+      The script calls the `rpmbuild` command with the following arguments: `-bs`,
+      `--noclean`, `--target noarch`, `--nodeps`, and the path to the SPEC file `/builddir/build/SPECS/libtiff.spec`.
+      `-bs` flag means that the build process will be done in the background. `--noclean`
+      flag skips the clean target. `--target noarch` means that the built package
+      will be noarch (not architecture-specific). `--nodeps` flag skips the dependency
+      resolution.\n* `chrootPath` is the path to the mock chroot environment.\n* `env`
+      is a dictionary containing environment variables for the build process, including
+      `TERM`, `SHELL`, `HOME`, `HOSTNAME`, `PATH`, `PROMPT_COMMAND`, `PS1`, `LANG`,
+      `uid`, `gid`, `user`, and `nspawn_args`. These variables are used to set up
+      the environment for the build process.\n* `shell` is a boolean value indicating
+      whether to run the shell in the build process or not.\n* `logger` is an object
+      used for logging the build process.\n* `timeout` is the maximum build time in
+      seconds.\n* `uid` and `gid` are the user and group IDs to run the build process
+      as.\n* `user` is the username for the user running the build process.\n* `nspawn_args`
+      is an empty list of arguments for unshare network namespace.\n* `unshare_net`
+      is a boolean value indicating whether to use unshare network namespace or not.\n*
+      `printOutput` is a boolean value indicating whether to print the build output
+      or not.\n\nThe script sets up these variables and creates a call to the `rpmbuild`
+      command inside a mock chroot environment.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      6:\u003c/b\u003e \u003ccode\u003eExecuting command: [''bash'', ''--login'',
+      ''-c'', ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec'']
+      with env {''TERM'': ''vt100'', ''SHELL'': ''/bin/bash'', ''HOME'': ''/builddir'',
+      ''HOSTNAME'': ''mock'', ''PATH'': ''/usr/bin:/bin:/usr/sbin:/sbin'', ''PROMPT_COMMAND'':
+      ''printf \"\\\\033]0;\u003cmock-chroot\u003e\\\\007\"'', ''PS1'': ''\u003cmock-chroot\u003e
+      \\\\s-\\\\v\\\\$ '', ''LANG'': ''C.UTF-8''} and shell False\n\u003c/code\u003e\n
+      The given RPM build log snippet describes the execution of a command using RPM
+      build system. The command being executed is ''rpmbuild'' with specific build
+      options and no dependencies (-bs --noclean --target noarch --nodeps). The command
+      is being run in a ''mock'' environment, which is indicated by the ''mock-chroot''
+      in the PS1 variable. The environment variables for TERM, SHELL, HOME, HOSTNAME,
+      PATH, PROMPT_COMMAND, and LANG are also shown. The shell for the command is
+      set to ''False'', suggesting that an interpreter other than a shell, such as
+      a Perl or Python script, may be used to execute the RPM build command.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      7:\u003c/b\u003e \u003ccode\u003eBuilding target platforms: noarch\n\u003c/code\u003e\n
+      The RPM build log snippet indicates that the build process is currently working
+      on creating target platforms of type ''noarch''. Noarch is a common RPM target
+      architecture that stands for \"no architecture\" or \"noarchitecture\". It is
+      used for building packages that do not have any architecture-specific components
+      and can be installed on any system regardless of its hardware architecture.
+      Therefore, this log message implies that the RPM package builder is in the process
+      of creating a ''noarch'' variant of the RPM package being built.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      9:\u003c/b\u003e \u003ccode\u003esetting SOURCE_DATE_EPOCH=1745280000\n\u003c/code\u003e\n
+      This RPM build log snippet sets the SOURCE_DATE_EPOCH variable to the value
+      1745280000. This variable is used by RPM to preserve the build time of the source
+      code during the build process. The value is in the number of seconds since the
+      Unix epoch (January 1, 1970).\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      10:\u003c/b\u003e \u003ccode\u003eRPM build errors:\nerror: Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\n    Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\n\u003c/code\u003e\n The RPM build log indicates that
+      there were two build errors related to a patch file named \"libtiff-4.4.0-CVE-2023-52356.patch\".
+      The error message states that the file does not exist in the specified path
+      \"/builddir/build/SOURCES/\".\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      13:\u003c/b\u003e \u003ccode\u003eChild return code was: 1\n\u003c/code\u003e\n
+      The RPM build log snippet indicates that the child process during the RPM build
+      procedure returned an error code of 1. This is an indication that the build
+      process of the specified RPM package encountered an issue during execution.
+      The exact nature of the issue cannot be determined from this log snippet alone.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      14:\u003c/b\u003e \u003ccode\u003eEXCEPTION: [Error(\"Command failed: \\n #
+      bash --login -c ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''\\n\",
+      1)]\n\u003c/code\u003e\n This RPM build log snippet indicates that an exception
+      has occurred during the RPM build process. The exception message states that
+      the command \"rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec\"
+      has failed. The message is preceded by the number 14, which likely represents
+      the build number or sequence number of the build process. The failure of the
+      command is the only piece of information provided in this snippet. No further
+      details about the cause of the failure are given.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      15:\u003c/b\u003e \u003ccode\u003eTraceback (most recent call last):\n  File
+      \"/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py\", line 93,
+      in trace\n    result = func(*args, **kw)\n  File \"/usr/lib/python3.6/site-packages/mockbuild/util.py\",
+      line 612, in do_with_status\n    raise exception.Error(\"Command failed: \\n
+      # %s\\n%s\" % (cmd_pretty(command, env), output), child.returncode)\n\u003c/code\u003e\n
+      The snippet is an error message from a RPM build process using the Mockbuild
+      tool. The error indicates that a command executed during the build process has
+      failed. The specific error occurs in the \"do_with_status\" function, located
+      in the \"util.py\" file in the Mockbuild library.\n\nThe error message includes
+      a traceback, which shows that the error was raised by the \"Error\" exception
+      in the \"do_with_status\" function. The error message itself contains the command
+      that failed, indicated by `cmd_pretty(command, env)`, and the output of the
+      command. The return code of the command is also included in the error message.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      20:\u003c/b\u003e \u003ccode\u003emockbuild.exception.Error: Command failed:
+      \n # bash --login -c ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps
+      /builddir/build/SPECS/libtiff.spec''\n\n\u003c/code\u003e\n The log snippet
+      indicates that an error occurred during the RPM build process for the \"libtiff\"
+      package using mockbuild. Specifically, the command \"rpmbuild -bs --noclean
+      --target noarch --nodeps /builddir/build/SPECS/libtiff.spec\" failed. The error
+      message is not provided in the log snippet, only that the command failed.\n\u003c/li\u003e\n\n\u003c/ul\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eLogs\u003c/summary\u003e\n  \u003cp\u003e\n    Log
+      Detective analyzed the following logs files to provide an explanation:\n  \u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://gitlab.com/api/v4/projects/23667077/jobs/9789376408/artifacts/kojilogs/noarch-5653506/noarch-5653507/build.log\"\u003ehttps://gitlab.com/api/v4/projects/23667077/jobs/9789376408/artifacts/kojilogs/noarch-5653506/noarch-5653507/build.log\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\n  \u003cp\u003e\n    Additional
+      logs are available from:\n    \u003cul\u003e\n    \u003cli\u003e\u003ca href=\"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/jobs/9789376408/artifacts/download\"\u003eartifacts.zip\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n  \u003c/p\u003e\n\n  \u003cp\u003e\n    Please
+      know that these log files are automatically removed after some\n    time, so
+      you might need a backup.\n  \u003c/p\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eHelp\u003c/summary\u003e\n  \u003cp\u003eDon''t
+      hesitate to reach out.\u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective\"\u003eUpstream\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective/issues\"\u003eIssue tracker\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://redhat.enterprise.slack.com/archives/C06DWNVKKDE\"\u003eSlack\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://log-detective.com/documentation\"\u003eDocumentation\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\u003c/details\u003e\n\n\n---\nThis
+      comment was created by [Log Detective][log-detective].\n\nWas the provided feedback
+      accurate and helpful? \u003cbr\u003ePlease vote with :thumbsup:\nor :thumbsdown:
+      to help us improve.\u003cbr\u003e\n\n\n\n[log-detective]: https://log-detective.com/\n[contact]:
+      https://github.com/fedora-copr","author":{"id":27211590,"username":"group_8794173_bot_029d2e92d461920a3695e55137a87774","public_email":null,"name":"****","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/c16bbfef2c60f8447985835437fc6442310027fe3e08fca895081b06f089abce?s=80\u0026d=identicon","web_url":"https://gitlab.com/group_8794173_bot_029d2e92d461920a3695e55137a87774"},"created_at":"2025-04-22T15:05:38.431Z","updated_at":"2025-04-22T15:21:21.994Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-22T15:11:00.983Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93b8f62e6a6b255b-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"b3e02019edf96e96f09b413bd0961ca9"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-01-lb-gprd
+      gitlab-sv: api-gke-us-east1-b
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"9dc0a4afe1a2a92e854b122f2430c6ba","version":"1"}'
+      x-request-id: 9dc0a4afe1a2a92e854b122f2430c6ba
+      x-runtime: '0.173327'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330
+- response:
+    auto_calculate_content_length: false
+    body: '[{"id":34008518,"name":"thumbsup","user":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"created_at":"2025-04-22T15:21:21.992Z","updated_at":"2025-04-22T15:21:21.992Z","awardable_id":2462509330,"awardable_type":"Note","url":null}]'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93b8f630afd9255b-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"7da7fe52d08c291e201c0b9f7350e6a4"
+      Link: <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
+        rel="first", <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
+        rel="last"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-05-lb-gprd
+      gitlab-sv: api-gke-us-east1-c
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"e1b4c0f573832f0be3ff29331094fa07","version":"1"}'
+      x-next-page: ''
+      x-page: '1'
+      x-per-page: '20'
+      x-prev-page: ''
+      x-request-id: e1b4c0f573832f0be3ff29331094fa07
+      x-runtime: '0.099332'
+      x-total: '1'
+      x-total-pages: '1'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330/award_emoji
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":23667077,"description":"The libtiff rpms","name":"libtiff","name_with_namespace":"Red
+      Hat / centos-stream / rpms / libtiff","path":"libtiff","path_with_namespace":"redhat/centos-stream/rpms/libtiff","created_at":"2021-01-14T13:33:43.455Z","default_branch":"c10s","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:redhat/centos-stream/rpms/libtiff.git","http_url_to_repo":"https://gitlab.com/redhat/centos-stream/rpms/libtiff.git","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff","readme_url":null,"forks_count":6,"avatar_url":null,"star_count":2,"last_activity_at":"2025-05-05T16:06:55.870Z","namespace":{"id":8794173,"name":"rpms","path":"rpms","kind":"group","full_path":"redhat/centos-stream/rpms","parent_id":8706831,"avatar_url":null,"web_url":"https://gitlab.com/groups/redhat/centos-stream/rpms"},"container_registry_image_prefix":"registry.gitlab.com/redhat/centos-stream/rpms/libtiff","_links":{"self":"https://gitlab.com/api/v4/projects/23667077","merge_requests":"https://gitlab.com/api/v4/projects/23667077/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/23667077/repository/branches","labels":"https://gitlab.com/api/v4/projects/23667077/labels","events":"https://gitlab.com/api/v4/projects/23667077/events","members":"https://gitlab.com/api/v4/projects/23667077/members","cluster_agents":"https://gitlab.com/api/v4/projects/23667077/cluster_agents"},"marked_for_deletion_at":null,"marked_for_deletion_on":null,"packages_enabled":false,"empty_repo":false,"archived":false,"visibility":"public","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-01-15T13:33:43.485Z"},"repository_object_format":"sha1","issues_enabled":false,"merge_requests_enabled":true,"wiki_enabled":false,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"can_create_merge_request_in":true,"issues_access_level":"disabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"disabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","analytics_access_level":"enabled","container_registry_access_level":"enabled","security_and_compliance_access_level":"private","releases_access_level":"enabled","environments_access_level":"disabled","feature_flags_access_level":"disabled","infrastructure_access_level":"disabled","monitor_access_level":"disabled","model_experiments_access_level":"enabled","model_registry_access_level":"enabled","emails_disabled":false,"emails_enabled":true,"shared_runners_enabled":true,"lfs_enabled":false,"creator_id":6007577,"import_status":"none","description_html":"\u003cp
+      data-sourcepos=\"1:1-1:16\" dir=\"auto\"\u003eThe libtiff rpms\u003c/p\u003e","updated_at":"2025-05-05T16:15:15.015Z","ci_config_path":"global-tasks.yml@redhat/centos-stream/ci-cd/dist-git-gating-tests","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"request_access_enabled":false,"only_allow_merge_if_all_discussions_are_resolved":true,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","merge_request_title_regex":null,"squash_option":"never","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"approvals_before_merge":0,"mirror":false,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"merge_requests_template":"","merge_pipelines_enabled":true,"merge_trains_enabled":true,"merge_trains_skip_train_allowed":false,"allow_pipeline_trigger_approve_deployment":false,"auto_duo_code_review_enabled":false,"permissions":{"project_access":null,"group_access":null}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93b8f6328c67255b-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"3dca2067a7699b0582f6e7971355b3d2"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-60-lb-gprd
+      gitlab-sv: api-gke-us-east1-d
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"8f0d40e227d63928c730c3a5d851b995","version":"1"}'
+      x-request-id: 8f0d40e227d63928c730c3a5d851b995
+      x-runtime: '0.294620'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":2464715549,"type":"DiscussionNote","body":"The package libtiff failed
+      to build, here is a possible explanation why.\n\nPlease know that the explanation
+      was provided by AI and may be incorrect.\nIn this case, we are 99.49% certain
+      of the response :slight_smile:.\n\n The RPM build process of the \"libtiff.spec\"
+      package encountered an error during the `%build` phase. Specifically, the command
+      `/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec`
+      failed to execute successfully, as indicated by a non-zero exit status of 1.
+      This error was reported by Mockbuild, the RPM testing framework.\n\nThe log
+      snippets do not provide enough information to determine the exact cause of the
+      build failure. Potential issues could include missing or incompatible dependencies,
+      incorrect build variables, or compilation errors. It is recommended to review
+      the build script in `/builddir/build/SPECS/libtiff.spec` and the corresponding
+      source code to identify and resolve the cause of the build error. Additionally,
+      checking the RPM dependency tree and build environment variables may help identify
+      any missing dependencies or misconfigurations.\n\n\u003cdetails\u003e\n\u003cul\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      10:\u003c/b\u003e \u003ccode\u003eChild return code was: 0\n\u003c/code\u003e\n
+      This log snippet indicates that a child process, likely a sub-build or dependency
+      during the RPM build process, has completed with an exit status code of 0. An
+      exit status code of 0 typically signifies a successful execution.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      450:\u003c/b\u003e \u003ccode\u003emake[2]: Entering directory ''/builddir/build/BUILD/tiff-4.4.0/port''\n\u003c/code\u003e\n
+      This RPM build log snippet indicates that the make process (specifically make[2])
+      is entering the directory ''/builddir/build/BUILD/tiff-4.4.0/port''. The number
+      preceding the message (450) represents the line number in the build script where
+      this event occurs.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine 710:\u003c/b\u003e
+      \u003ccode\u003egcc -DHAVE_CONFIG_H -I. -I../config -I../libtiff -I../port  -I../libtiff
+      -I../port -DTIFF_DISABLE_DEPRECATED   -O2 -flto=auto -ffat-lto-objects -fexceptions
+      -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2
+      -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong
+      -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64-v2 -mtune=generic
+      -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-strict-aliasing
+      -Wall -W -c -o fax2tiff.o fax2tiff.c\n\u003c/code\u003e\n The RPM build log
+      snippet represents a gcc compilation command with various flags and options
+      for building the ''fax2tiff.o'' object file from ''fax2tiff.c''.\n\nThe command
+      includes:\n- Compiler: gcc\n- Preprocessor flags:\n  - Include directories:
+      ., ../config, ../libtiff, ../port\n  - Defines: HAVE_CONFIG_H, TIFF_DISABLE_DEPRECATED\n\n-
+      Optimization flags:\n  - Compiler optimization: -O2\n  - Link-time optimization:
+      -flto=auto -ffat-lto-objects\n\n- Exception handling: -fexceptions\n\n- Debugging
+      flags: -g -grecord-gcc-switches\n\n- Warnings: -Wall -Werror=format-security\n\n-
+      Security: -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS\n\n- Hardened build:
+      -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1\n\n- Stack protection: -fstack-protector-strong\n\n-
+      Code protection: -fcf-protection\n\n- Aliasing: -fno-strict-aliasing\n\n- Target
+      architecture: -m64 -march=x86-64-v2 -mtune=generic\n\n- Asynchronous unwind
+      tables: -fasynchronous-unwind-tables\n\n- Stack clash protection: -fstack-clash-protection.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      786:\u003c/b\u003e \u003ccode\u003ecollect2: error: ld returned 1 exit status\n\u003c/code\u003e\n
+      The RPM build log snippet indicates an error during the linking (ld) stage of
+      the build process. The linker returned an exit status of 1, which signifies
+      an unsuccessful linking attempt. The exact cause of the error is not provided
+      in the snippet, but potential issues could include missing or incompatible libraries,
+      incorrect library versions, or syntax errors in the linker script. Further investigation
+      is required to determine the specific cause and resolve the issue.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      787:\u003c/b\u003e \u003ccode\u003emake[1]: *** [Makefile:653: tiffdither] Error
+      1\n\u003c/code\u003e\n The RPM build log snippet indicates that there was an
+      error during the execution of the \"make\" command, specifically with the target
+      \"tiffdither\" mentioned in the Makefile on line 653. The error resulted in
+      the make process exiting with a status code of 1.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      905:\u003c/b\u003e \u003ccode\u003etiffcrop.c: In function ''writeBufferToSeparateStrips'':\ntiffcrop.c:1244:28:
+      warning: comparison of integer expressions of different signedness: ''tsize_t''
+      {aka ''long int''} and ''long long unsigned int'' [-Wsign-compare]\n 1244 |           if
+      (scanlinesize \u003e 0x0ffffffffULL) {\n      |                            ^\n\u003c/code\u003e\n
+      The RPM build log snippet indicates a compiler warning during the build process
+      of the ''tiffcrop.c'' file. The warning message specifically mentions a comparison
+      of two data types with different signedness in line 1244 of the file: ''tsize_t''
+      (a long int type) and ''long long unsigned int''. The compiler is advising that
+      such a comparison may result in unexpected behavior due to potential sign conversions.
+      The warning message concludes with the location of the issue in the code.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      913:\u003c/b\u003e \u003ccode\u003emake: *** [Makefile:561: all-recursive] Error
+      1\n\u003c/code\u003e\n The RPM build log snippet indicates an error occurred
+      during the \"make all-recursive\" step in the RPM package build process. Specifically,
+      the \"make\" command returned an error status code 1. There is no further information
+      provided in the log snippet regarding the nature of the error.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      914:\u003c/b\u003e \u003ccode\u003eerror: Bad exit status from /var/tmp/rpm-tmp.JH52lB
+      (%build)\n\u003c/code\u003e\n The RPM build process encountered an error during
+      the `%build` phase of the build. Specifically, there was a \"Bad exit status\"
+      from the build script located at `/var/tmp/rpm-tmp.JH52lB`. This indicates that
+      the commands executed within the `%build` script did not complete successfully,
+      resulting in an error. The cause of this error is not apparent from the given
+      log snippet and requires further investigation into the contents of the `%build`
+      script and build environment.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      915:\u003c/b\u003e \u003ccode\u003eRPM build errors:\n    Bad exit status from
+      /var/tmp/rpm-tmp.JH52lB (%build)\n\u003c/code\u003e\n The given RPM build log
+      snippet indicates that during the build process, an error occurred in the %build
+      phase. The error resulted in an unsuccessful exit status from the file location
+      ''/var/tmp/rpm-tmp.JH52lB''. No further information is provided in the log regarding
+      the nature of the error.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      918:\u003c/b\u003e \u003ccode\u003eEXCEPTION: [Error(\"Command failed: \\n #
+      bash --login -c ''/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec''\\n\",
+      1)]\n\u003c/code\u003e\n The log snippet indicates an error occurred during
+      the RPM build process using the `rpmbuild` command. The command being executed
+      is:\n\n`/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec`\n\nThe
+      error message reads ''Command failed'' and is accompanied by an exception. The
+      cause of the command failure is not explicitly stated in the provided log snippet.
+      The error is marked with a non-zero exit status of 1.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      919:\u003c/b\u003e \u003ccode\u003eTraceback (most recent call last):\n  File
+      \"/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py\", line 93,
+      in trace\n    result = func(*args, **kw)\n  File \"/usr/lib/python3.6/site-packages/mockbuild/util.py\",
+      line 612, in do_with_status\n    raise exception.Error(\"Command failed: \\n
+      # %s\\n%s\" % (cmd_pretty(command, env), output), child.returncode)\n\u003c/code\u003e\n
+      This log snippet is a Python traceback indicating an error during the execution
+      of an RPM build using the mockbuild tool. The error occurred at the line where
+      the command execution failed in the mockbuild utility file (do_with_status,
+      line 612). The specific error message states that a command failed with the
+      given error message and return code. The command and its environment variables
+      can be found in the cmd_pretty function call. No further information is provided
+      in the log snippet.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine 924:\u003c/b\u003e
+      \u003ccode\u003emockbuild.exception.Error: Command failed: \n # bash --login
+      -c ''/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec''\n\n\u003c/code\u003e\n
+      The build log snippet indicates an error occurred during the RPM build process
+      of the \"libtiff.spec\" file, using the x86\\_64 architecture. The command \"rpmbuild
+      -bb --noclean --target x86\\_64 --nodeps /builddir/build/SPECS/libtiff.spec\"
+      failed to execute successfully. This error is reported by Mockbuild, an RPM
+      testing framework. No further information about the nature of the command failure
+      is provided in the log.\n\u003c/li\u003e\n\n\u003c/ul\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eLogs\u003c/summary\u003e\n  \u003cp\u003e\n    Log
+      Detective analyzed the following logs files to provide an explanation:\n  \u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://gitlab.com/api/v4/projects/23667077/jobs/9789725965/artifacts/kojilogs/noarch-5653531/x86_64-5653534/build.log\"\u003ehttps://gitlab.com/api/v4/projects/23667077/jobs/9789725965/artifacts/kojilogs/noarch-5653531/x86_64-5653534/build.log\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\n  \u003cp\u003e\n    Additional
+      logs are available from:\n    \u003cul\u003e\n    \u003cli\u003e\u003ca href=\"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/jobs/9789725965/artifacts/download\"\u003eartifacts.zip\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n  \u003c/p\u003e\n\n  \u003cp\u003e\n    Please
+      know that these log files are automatically removed after some\n    time, so
+      you might need a backup.\n  \u003c/p\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eHelp\u003c/summary\u003e\n  \u003cp\u003eDon''t
+      hesitate to reach out.\u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective\"\u003eUpstream\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective/issues\"\u003eIssue tracker\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://redhat.enterprise.slack.com/archives/C06DWNVKKDE\"\u003eSlack\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://log-detective.com/documentation\"\u003eDocumentation\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\u003c/details\u003e\n\n\n---\nThis
+      comment was created by [Log Detective][log-detective].\n\nWas the provided feedback
+      accurate and helpful? \u003cbr\u003ePlease vote with :thumbsup:\nor :thumbsdown:
+      to help us improve.\u003cbr\u003e\n\n\n\n[log-detective]: https://log-detective.com/\n[contact]:
+      https://github.com/fedora-copr","author":{"id":27211590,"username":"group_8794173_bot_029d2e92d461920a3695e55137a87774","public_email":null,"name":"****","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/c16bbfef2c60f8447985835437fc6442310027fe3e08fca895081b06f089abce?s=80\u0026d=identicon","web_url":"https://gitlab.com/group_8794173_bot_029d2e92d461920a3695e55137a87774"},"created_at":"2025-04-23T14:02:31.332Z","updated_at":"2025-04-23T14:12:56.887Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-23T14:12:56.887Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93b8f6359bef255b-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"4300ea10b3d9f8472c79f7631e87fe00"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-03-lb-gprd
+      gitlab-sv: api-gke-us-east1-d
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"67e613aeaf4ffc65bc53cec430b2c831","version":"1"}'
+      x-request-id: 67e613aeaf4ffc65bc53cec430b2c831
+      x-runtime: '0.121080'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549
+- response:
+    auto_calculate_content_length: false
+    body: '[{"id":34038545,"name":"thumbsdown","user":{"id":737640,"username":"TomasTomecek","public_email":"","name":"Tomas
+      Tomecek","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/545461259a87a9b40ef14e381b4257d476bc183ab44b293f084084ada15a2dcc?s=80\u0026d=identicon","web_url":"https://gitlab.com/TomasTomecek"},"created_at":"2025-04-23T14:11:12.123Z","updated_at":"2025-04-23T14:11:12.123Z","awardable_id":2464715549,"awardable_type":"Note","url":null}]'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93b8f6378887255b-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"f19fe711af9debb1837206f66dccbedd"
+      Link: <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
+        rel="first", <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
+        rel="last"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-42-lb-gprd
+      gitlab-sv: api-gke-us-east1-d
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"a4a9927f6ee400226aa1b7e2e475483b","version":"1"}'
+      x-next-page: ''
+      x-page: '1'
+      x-per-page: '20'
+      x-prev-page: ''
+      x-request-id: a4a9927f6ee400226aa1b7e2e475483b
+      x-runtime: '0.088779'
+      x-total: '1'
+      x-total-pages: '1'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549/award_emoji

--- a/tests/data/test_emoji_removed.yaml
+++ b/tests/data/test_emoji_removed.yaml
@@ -1,0 +1,1582 @@
+responses:
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":23667077,"description":"The libtiff rpms","name":"libtiff","name_with_namespace":"Red
+      Hat / centos-stream / rpms / libtiff","path":"libtiff","path_with_namespace":"redhat/centos-stream/rpms/libtiff","created_at":"2021-01-14T13:33:43.455Z","default_branch":"c10s","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:redhat/centos-stream/rpms/libtiff.git","http_url_to_repo":"https://gitlab.com/redhat/centos-stream/rpms/libtiff.git","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff","readme_url":null,"forks_count":6,"avatar_url":null,"star_count":2,"last_activity_at":"2025-05-05T16:06:55.870Z","namespace":{"id":8794173,"name":"rpms","path":"rpms","kind":"group","full_path":"redhat/centos-stream/rpms","parent_id":8706831,"avatar_url":null,"web_url":"https://gitlab.com/groups/redhat/centos-stream/rpms"},"container_registry_image_prefix":"registry.gitlab.com/redhat/centos-stream/rpms/libtiff","_links":{"self":"https://gitlab.com/api/v4/projects/23667077","merge_requests":"https://gitlab.com/api/v4/projects/23667077/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/23667077/repository/branches","labels":"https://gitlab.com/api/v4/projects/23667077/labels","events":"https://gitlab.com/api/v4/projects/23667077/events","members":"https://gitlab.com/api/v4/projects/23667077/members","cluster_agents":"https://gitlab.com/api/v4/projects/23667077/cluster_agents"},"marked_for_deletion_at":null,"marked_for_deletion_on":null,"packages_enabled":false,"empty_repo":false,"archived":false,"visibility":"public","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-01-15T13:33:43.485Z"},"repository_object_format":"sha1","issues_enabled":false,"merge_requests_enabled":true,"wiki_enabled":false,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"can_create_merge_request_in":true,"issues_access_level":"disabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"disabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","analytics_access_level":"enabled","container_registry_access_level":"enabled","security_and_compliance_access_level":"private","releases_access_level":"enabled","environments_access_level":"disabled","feature_flags_access_level":"disabled","infrastructure_access_level":"disabled","monitor_access_level":"disabled","model_experiments_access_level":"enabled","model_registry_access_level":"enabled","emails_disabled":false,"emails_enabled":true,"shared_runners_enabled":true,"lfs_enabled":false,"creator_id":6007577,"import_status":"none","description_html":"\u003cp
+      data-sourcepos=\"1:1-1:16\" dir=\"auto\"\u003eThe libtiff rpms\u003c/p\u003e","updated_at":"2025-05-07T15:22:25.055Z","ci_config_path":"global-tasks.yml@redhat/centos-stream/ci-cd/dist-git-gating-tests","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"request_access_enabled":false,"only_allow_merge_if_all_discussions_are_resolved":true,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","merge_request_title_regex":null,"squash_option":"never","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"approvals_before_merge":0,"mirror":false,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"merge_requests_template":"","merge_pipelines_enabled":true,"merge_trains_enabled":true,"merge_trains_skip_train_allowed":false,"allow_pipeline_trigger_approve_deployment":false,"auto_duo_code_review_enabled":false,"permissions":{"project_access":null,"group_access":null}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c793ad8ddaee70-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"7bcd1b327972f0654df91402d94e9b70"
+      Set-Cookie: _cfuvid=6_Pb3kH5RE.wLRV1qFg1b9UpWBPkhJIlFbtxLBtHM_w-1746692835937-0.0.1.1-604800000;
+        path=/; domain=.gitlab.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-06-lb-gprd
+      gitlab-sv: api-gke-us-east1-d
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"0600fe08da42b366df0293584e7e8210","version":"1"}'
+      x-request-id: 0600fe08da42b366df0293584e7e8210
+      x-runtime: '0.125117'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":378085175,"iid":26,"project_id":23667077,"title":"Merge fix for RHEL-17337","description":"Merge
+      request for:\nissue RHEL-17337 - CVE-2023-52356 libtiff: Segment fault in libtiff  in
+      TIFFReadRGBATileExt() leading to denial of service [rhel-9]","state":"merged","created_at":"2025-04-22T14:59:54.425Z","updated_at":"2025-05-05T16:15:05.719Z","merged_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"merge_user":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"merged_at":"2025-05-05T16:15:05.741Z","closed_by":null,"closed_at":null,"target_branch":"c9s","source_branch":"c9s","user_notes_count":6,"upvotes":0,"downvotes":0,"author":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":61073452,"target_project_id":23667077,"labels":["target::latest"],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"can_be_merged","detailed_merge_status":"not_open","merge_after":null,"sha":"1d8f0e982d3beff79b63559640b7bd578109ceaf","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":"2025-04-22T14:59:59.635Z","allow_collaboration":false,"allow_maintainer_to_push":false,"reference":"!26","references":{"short":"!26","relative":"!26","full":"redhat/centos-stream/rpms/libtiff!26"},"web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/merge_requests/26","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":false,"squash_on_merge":false,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":false,"changes_count":"3","latest_build_started_at":"2025-05-05T15:17:22.392Z","latest_build_finished_at":"2025-05-05T16:07:40.651Z","first_deployed_to_production_at":null,"pipeline":{"id":1800983320,"iid":70,"project_id":23667077,"sha":"bf8b085aa0833394ab0ec10112e61521c6d169a0","ref":"refs/merge-requests/26/merge","status":"success","source":"merge_request_event","created_at":"2025-05-05T15:16:52.231Z","updated_at":"2025-05-05T16:07:40.669Z","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/pipelines/1800983320"},"head_pipeline":{"id":1800983320,"iid":70,"project_id":23667077,"sha":"bf8b085aa0833394ab0ec10112e61521c6d169a0","ref":"refs/merge-requests/26/merge","status":"success","source":"merge_request_event","created_at":"2025-05-05T15:16:52.231Z","updated_at":"2025-05-05T16:07:40.669Z","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/pipelines/1800983320","before_sha":"bf8b085aa0833394ab0ec10112e61521c6d169a0","tag":false,"yaml_errors":null,"user":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"started_at":"2025-05-05T15:17:22.392Z","finished_at":"2025-05-05T16:07:40.651Z","committed_at":null,"duration":2924,"queued_duration":30,"coverage":null,"detailed_status":{"icon":"status_success","text":"Passed","label":"passed","group":"success","tooltip":"passed","has_details":true,"details_path":"/redhat/centos-stream/rpms/libtiff/-/pipelines/1800983320","illustration":null,"favicon":"/assets/ci_favicons/favicon_status_success-8451333011eee8ce9f2ab25dc487fe24a8758c694827a582f17f42b0a90446a2.png"}},"diff_refs":{"base_sha":"3fc1a85f8a59af6101f675a1a02d95932ace85c8","head_sha":"1d8f0e982d3beff79b63559640b7bd578109ceaf","start_sha":"3fc1a85f8a59af6101f675a1a02d95932ace85c8"},"merge_error":null,"first_contribution":false,"user":{"can_merge":false}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c793b15d7cee70-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"04cac7b091f4ff7c7038be61ce98e1f7"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-15-lb-gprd
+      gitlab-sv: api-gke-us-east1-d
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"4b49916c379f78ac7b74a31084ada6bc","version":"1"}'
+      x-request-id: 4b49916c379f78ac7b74a31084ada6bc
+      x-runtime: '0.334111'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":"1ba1f46903f2b4e0573d514ed6d2cae29ab040f6","individual_note":false,"notes":[{"id":2462509330,"type":"DiscussionNote","body":"The
+      package libtiff failed to build, here is a possible explanation why.\n\nPlease
+      know that the explanation was provided by AI and may be incorrect.\nIn this
+      case, we are 99.71% certain of the response :slight_smile:.\n\n Based on the
+      provided log snippets, it appears that there was a failure during the RPM build
+      process for a package named \"libtiff\". The exact cause of the failure cannot
+      be determined from the given information alone, but there are a few clues that
+      suggest what the issue might be.\n\nThe most significant indication of a problem
+      is the error message at line [10] that mentions \"RPM build errors: error: Bad
+      file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch: No such file
+      or directory\". This error suggests that a necessary patch file was missing
+      during the build process. The patch file is identified as \"libtiff-4.4.0-CVE-2023-52356.patch\",
+      and it was expected to be located in the \"/builddir/build/SOURCES/\" directory.
+      However, this file could not be found, causing the build to fail.\n\nAnother
+      snippet (line [14]) shows that an exception was raised during the build process,
+      with the message \"Command failed: # bash --login -c ''/usr/bin/rpmbuild -bs
+      --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''\". This
+      error message confirms the failure of the \"rpmbuild\" command and indicates
+      that the issue was likely related to the missing patch file mentioned earlier.\n\nTo
+      resolve the issue, you should first ensure that all required patch files are
+      present in the correct location. Check the SPEC file for the \"libtiff\" package
+      to confirm that it specifies the correct patch file(s) and that their download
+      or extraction was successful during the build process. If necessary, manually
+      download and install the missing patch files in the expected directory. Once
+      all necessary patch files are present and accessible, try rebuilding the \"libtiff\"
+      package using the \"rpmbuild\" command to see if the issue is resolved. If the
+      issue persists, further investigation may be required to determine if there
+      are any other dependencies or issues that may be preventing the build from completing
+      successfully.\n\n\u003cdetails\u003e\n\u003cul\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      0:\u003c/b\u003e \u003ccode\u003eMock Version: 5.4\n\u003c/code\u003e\n The
+      given RPM build log snippet indicates the version of Mock being used during
+      the RPM build process. In this case, the version is 5.4.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      5:\u003c/b\u003e \u003ccode\u003eENTER [''do_with_status'']([''bash'', ''--login'',
+      ''-c'', ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''],
+      chrootPath=''/var/lib/mock/c9s-build-671467-759558/root''env={''TERM'': ''vt100'',
+      ''SHELL'': ''/bin/bash'', ''HOME'': ''/builddir'', ''HOSTNAME'': ''mock'', ''PATH'':
+      ''/usr/bin:/bin:/usr/sbin:/sbin'', ''PROMPT_COMMAND'': ''printf \"\\\\033]0;\u003cmock-chroot\u003e\\\\007\"'',
+      ''PS1'': ''\u003cmock-chroot\u003e \\\\s-\\\\v\\\\$ '', ''LANG'': ''C.UTF-8''}shell=Falselogger=\u003cmockbuild.trace_decorator.getLog
+      object at 0x7fff8ccaca58\u003etimeout=86400uid=989gid=135user=''mockbuild''nspawn_args=[]unshare_net=FalseprintOutput=False)\n\u003c/code\u003e\n
+      This snippet is a Python script that sets up a call to the RPM (Red Hat Package
+      Manager) build process. The script sets up an environment for RPM build in mock
+      chroot (mock-chroot), which is a feature that allows building RPM packages in
+      an isolated environment. The following are the key elements of the script:\n\n*
+      The script calls the `rpmbuild` command with the following arguments: `-bs`,
+      `--noclean`, `--target noarch`, `--nodeps`, and the path to the SPEC file `/builddir/build/SPECS/libtiff.spec`.
+      `-bs` flag means that the build process will be done in the background. `--noclean`
+      flag skips the clean target. `--target noarch` means that the built package
+      will be noarch (not architecture-specific). `--nodeps` flag skips the dependency
+      resolution.\n* `chrootPath` is the path to the mock chroot environment.\n* `env`
+      is a dictionary containing environment variables for the build process, including
+      `TERM`, `SHELL`, `HOME`, `HOSTNAME`, `PATH`, `PROMPT_COMMAND`, `PS1`, `LANG`,
+      `uid`, `gid`, `user`, and `nspawn_args`. These variables are used to set up
+      the environment for the build process.\n* `shell` is a boolean value indicating
+      whether to run the shell in the build process or not.\n* `logger` is an object
+      used for logging the build process.\n* `timeout` is the maximum build time in
+      seconds.\n* `uid` and `gid` are the user and group IDs to run the build process
+      as.\n* `user` is the username for the user running the build process.\n* `nspawn_args`
+      is an empty list of arguments for unshare network namespace.\n* `unshare_net`
+      is a boolean value indicating whether to use unshare network namespace or not.\n*
+      `printOutput` is a boolean value indicating whether to print the build output
+      or not.\n\nThe script sets up these variables and creates a call to the `rpmbuild`
+      command inside a mock chroot environment.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      6:\u003c/b\u003e \u003ccode\u003eExecuting command: [''bash'', ''--login'',
+      ''-c'', ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec'']
+      with env {''TERM'': ''vt100'', ''SHELL'': ''/bin/bash'', ''HOME'': ''/builddir'',
+      ''HOSTNAME'': ''mock'', ''PATH'': ''/usr/bin:/bin:/usr/sbin:/sbin'', ''PROMPT_COMMAND'':
+      ''printf \"\\\\033]0;\u003cmock-chroot\u003e\\\\007\"'', ''PS1'': ''\u003cmock-chroot\u003e
+      \\\\s-\\\\v\\\\$ '', ''LANG'': ''C.UTF-8''} and shell False\n\u003c/code\u003e\n
+      The given RPM build log snippet describes the execution of a command using RPM
+      build system. The command being executed is ''rpmbuild'' with specific build
+      options and no dependencies (-bs --noclean --target noarch --nodeps). The command
+      is being run in a ''mock'' environment, which is indicated by the ''mock-chroot''
+      in the PS1 variable. The environment variables for TERM, SHELL, HOME, HOSTNAME,
+      PATH, PROMPT_COMMAND, and LANG are also shown. The shell for the command is
+      set to ''False'', suggesting that an interpreter other than a shell, such as
+      a Perl or Python script, may be used to execute the RPM build command.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      7:\u003c/b\u003e \u003ccode\u003eBuilding target platforms: noarch\n\u003c/code\u003e\n
+      The RPM build log snippet indicates that the build process is currently working
+      on creating target platforms of type ''noarch''. Noarch is a common RPM target
+      architecture that stands for \"no architecture\" or \"noarchitecture\". It is
+      used for building packages that do not have any architecture-specific components
+      and can be installed on any system regardless of its hardware architecture.
+      Therefore, this log message implies that the RPM package builder is in the process
+      of creating a ''noarch'' variant of the RPM package being built.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      9:\u003c/b\u003e \u003ccode\u003esetting SOURCE_DATE_EPOCH=1745280000\n\u003c/code\u003e\n
+      This RPM build log snippet sets the SOURCE_DATE_EPOCH variable to the value
+      1745280000. This variable is used by RPM to preserve the build time of the source
+      code during the build process. The value is in the number of seconds since the
+      Unix epoch (January 1, 1970).\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      10:\u003c/b\u003e \u003ccode\u003eRPM build errors:\nerror: Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\n    Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\n\u003c/code\u003e\n The RPM build log indicates that
+      there were two build errors related to a patch file named \"libtiff-4.4.0-CVE-2023-52356.patch\".
+      The error message states that the file does not exist in the specified path
+      \"/builddir/build/SOURCES/\".\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      13:\u003c/b\u003e \u003ccode\u003eChild return code was: 1\n\u003c/code\u003e\n
+      The RPM build log snippet indicates that the child process during the RPM build
+      procedure returned an error code of 1. This is an indication that the build
+      process of the specified RPM package encountered an issue during execution.
+      The exact nature of the issue cannot be determined from this log snippet alone.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      14:\u003c/b\u003e \u003ccode\u003eEXCEPTION: [Error(\"Command failed: \\n #
+      bash --login -c ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''\\n\",
+      1)]\n\u003c/code\u003e\n This RPM build log snippet indicates that an exception
+      has occurred during the RPM build process. The exception message states that
+      the command \"rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec\"
+      has failed. The message is preceded by the number 14, which likely represents
+      the build number or sequence number of the build process. The failure of the
+      command is the only piece of information provided in this snippet. No further
+      details about the cause of the failure are given.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      15:\u003c/b\u003e \u003ccode\u003eTraceback (most recent call last):\n  File
+      \"/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py\", line 93,
+      in trace\n    result = func(*args, **kw)\n  File \"/usr/lib/python3.6/site-packages/mockbuild/util.py\",
+      line 612, in do_with_status\n    raise exception.Error(\"Command failed: \\n
+      # %s\\n%s\" % (cmd_pretty(command, env), output), child.returncode)\n\u003c/code\u003e\n
+      The snippet is an error message from a RPM build process using the Mockbuild
+      tool. The error indicates that a command executed during the build process has
+      failed. The specific error occurs in the \"do_with_status\" function, located
+      in the \"util.py\" file in the Mockbuild library.\n\nThe error message includes
+      a traceback, which shows that the error was raised by the \"Error\" exception
+      in the \"do_with_status\" function. The error message itself contains the command
+      that failed, indicated by `cmd_pretty(command, env)`, and the output of the
+      command. The return code of the command is also included in the error message.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      20:\u003c/b\u003e \u003ccode\u003emockbuild.exception.Error: Command failed:
+      \n # bash --login -c ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps
+      /builddir/build/SPECS/libtiff.spec''\n\n\u003c/code\u003e\n The log snippet
+      indicates that an error occurred during the RPM build process for the \"libtiff\"
+      package using mockbuild. Specifically, the command \"rpmbuild -bs --noclean
+      --target noarch --nodeps /builddir/build/SPECS/libtiff.spec\" failed. The error
+      message is not provided in the log snippet, only that the command failed.\n\u003c/li\u003e\n\n\u003c/ul\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eLogs\u003c/summary\u003e\n  \u003cp\u003e\n    Log
+      Detective analyzed the following logs files to provide an explanation:\n  \u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://gitlab.com/api/v4/projects/23667077/jobs/9789376408/artifacts/kojilogs/noarch-5653506/noarch-5653507/build.log\"\u003ehttps://gitlab.com/api/v4/projects/23667077/jobs/9789376408/artifacts/kojilogs/noarch-5653506/noarch-5653507/build.log\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\n  \u003cp\u003e\n    Additional
+      logs are available from:\n    \u003cul\u003e\n    \u003cli\u003e\u003ca href=\"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/jobs/9789376408/artifacts/download\"\u003eartifacts.zip\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n  \u003c/p\u003e\n\n  \u003cp\u003e\n    Please
+      know that these log files are automatically removed after some\n    time, so
+      you might need a backup.\n  \u003c/p\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eHelp\u003c/summary\u003e\n  \u003cp\u003eDon''t
+      hesitate to reach out.\u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective\"\u003eUpstream\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective/issues\"\u003eIssue tracker\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://redhat.enterprise.slack.com/archives/C06DWNVKKDE\"\u003eSlack\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://log-detective.com/documentation\"\u003eDocumentation\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\u003c/details\u003e\n\n\n---\nThis
+      comment was created by [Log Detective][log-detective].\n\nWas the provided feedback
+      accurate and helpful? \u003cbr\u003ePlease vote with :thumbsup:\nor :thumbsdown:
+      to help us improve.\u003cbr\u003e\n\n\n\n[log-detective]: https://log-detective.com/\n[contact]:
+      https://github.com/fedora-copr","author":{"id":27211590,"username":"group_8794173_bot_029d2e92d461920a3695e55137a87774","public_email":null,"name":"****","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/c16bbfef2c60f8447985835437fc6442310027fe3e08fca895081b06f089abce?s=80\u0026d=identicon","web_url":"https://gitlab.com/group_8794173_bot_029d2e92d461920a3695e55137a87774"},"created_at":"2025-04-22T15:05:38.431Z","updated_at":"2025-04-22T15:21:21.994Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-22T15:11:00.983Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}},{"id":2462523126,"type":"DiscussionNote","body":"correct
+      analysis, but a bit tl;dr","author":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"created_at":"2025-04-22T15:11:00.436Z","updated_at":"2025-04-22T15:11:00.983Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-22T15:11:00.983Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}}]}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c793b66dccee70-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"56c7b72183071ab15bae67a27b9cbd18"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-39-lb-gprd
+      gitlab-sv: api-gke-us-east1-d
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"1352b5b87e872e17564b8aa20d0a7240","version":"1"}'
+      x-request-id: 1352b5b87e872e17564b8aa20d0a7240
+      x-runtime: '0.127781'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/discussions/1ba1f46903f2b4e0573d514ed6d2cae29ab040f6
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":2462509330,"type":"DiscussionNote","body":"The package libtiff failed
+      to build, here is a possible explanation why.\n\nPlease know that the explanation
+      was provided by AI and may be incorrect.\nIn this case, we are 99.71% certain
+      of the response :slight_smile:.\n\n Based on the provided log snippets, it appears
+      that there was a failure during the RPM build process for a package named \"libtiff\".
+      The exact cause of the failure cannot be determined from the given information
+      alone, but there are a few clues that suggest what the issue might be.\n\nThe
+      most significant indication of a problem is the error message at line [10] that
+      mentions \"RPM build errors: error: Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\". This error suggests that a necessary patch file
+      was missing during the build process. The patch file is identified as \"libtiff-4.4.0-CVE-2023-52356.patch\",
+      and it was expected to be located in the \"/builddir/build/SOURCES/\" directory.
+      However, this file could not be found, causing the build to fail.\n\nAnother
+      snippet (line [14]) shows that an exception was raised during the build process,
+      with the message \"Command failed: # bash --login -c ''/usr/bin/rpmbuild -bs
+      --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''\". This
+      error message confirms the failure of the \"rpmbuild\" command and indicates
+      that the issue was likely related to the missing patch file mentioned earlier.\n\nTo
+      resolve the issue, you should first ensure that all required patch files are
+      present in the correct location. Check the SPEC file for the \"libtiff\" package
+      to confirm that it specifies the correct patch file(s) and that their download
+      or extraction was successful during the build process. If necessary, manually
+      download and install the missing patch files in the expected directory. Once
+      all necessary patch files are present and accessible, try rebuilding the \"libtiff\"
+      package using the \"rpmbuild\" command to see if the issue is resolved. If the
+      issue persists, further investigation may be required to determine if there
+      are any other dependencies or issues that may be preventing the build from completing
+      successfully.\n\n\u003cdetails\u003e\n\u003cul\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      0:\u003c/b\u003e \u003ccode\u003eMock Version: 5.4\n\u003c/code\u003e\n The
+      given RPM build log snippet indicates the version of Mock being used during
+      the RPM build process. In this case, the version is 5.4.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      5:\u003c/b\u003e \u003ccode\u003eENTER [''do_with_status'']([''bash'', ''--login'',
+      ''-c'', ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''],
+      chrootPath=''/var/lib/mock/c9s-build-671467-759558/root''env={''TERM'': ''vt100'',
+      ''SHELL'': ''/bin/bash'', ''HOME'': ''/builddir'', ''HOSTNAME'': ''mock'', ''PATH'':
+      ''/usr/bin:/bin:/usr/sbin:/sbin'', ''PROMPT_COMMAND'': ''printf \"\\\\033]0;\u003cmock-chroot\u003e\\\\007\"'',
+      ''PS1'': ''\u003cmock-chroot\u003e \\\\s-\\\\v\\\\$ '', ''LANG'': ''C.UTF-8''}shell=Falselogger=\u003cmockbuild.trace_decorator.getLog
+      object at 0x7fff8ccaca58\u003etimeout=86400uid=989gid=135user=''mockbuild''nspawn_args=[]unshare_net=FalseprintOutput=False)\n\u003c/code\u003e\n
+      This snippet is a Python script that sets up a call to the RPM (Red Hat Package
+      Manager) build process. The script sets up an environment for RPM build in mock
+      chroot (mock-chroot), which is a feature that allows building RPM packages in
+      an isolated environment. The following are the key elements of the script:\n\n*
+      The script calls the `rpmbuild` command with the following arguments: `-bs`,
+      `--noclean`, `--target noarch`, `--nodeps`, and the path to the SPEC file `/builddir/build/SPECS/libtiff.spec`.
+      `-bs` flag means that the build process will be done in the background. `--noclean`
+      flag skips the clean target. `--target noarch` means that the built package
+      will be noarch (not architecture-specific). `--nodeps` flag skips the dependency
+      resolution.\n* `chrootPath` is the path to the mock chroot environment.\n* `env`
+      is a dictionary containing environment variables for the build process, including
+      `TERM`, `SHELL`, `HOME`, `HOSTNAME`, `PATH`, `PROMPT_COMMAND`, `PS1`, `LANG`,
+      `uid`, `gid`, `user`, and `nspawn_args`. These variables are used to set up
+      the environment for the build process.\n* `shell` is a boolean value indicating
+      whether to run the shell in the build process or not.\n* `logger` is an object
+      used for logging the build process.\n* `timeout` is the maximum build time in
+      seconds.\n* `uid` and `gid` are the user and group IDs to run the build process
+      as.\n* `user` is the username for the user running the build process.\n* `nspawn_args`
+      is an empty list of arguments for unshare network namespace.\n* `unshare_net`
+      is a boolean value indicating whether to use unshare network namespace or not.\n*
+      `printOutput` is a boolean value indicating whether to print the build output
+      or not.\n\nThe script sets up these variables and creates a call to the `rpmbuild`
+      command inside a mock chroot environment.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      6:\u003c/b\u003e \u003ccode\u003eExecuting command: [''bash'', ''--login'',
+      ''-c'', ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec'']
+      with env {''TERM'': ''vt100'', ''SHELL'': ''/bin/bash'', ''HOME'': ''/builddir'',
+      ''HOSTNAME'': ''mock'', ''PATH'': ''/usr/bin:/bin:/usr/sbin:/sbin'', ''PROMPT_COMMAND'':
+      ''printf \"\\\\033]0;\u003cmock-chroot\u003e\\\\007\"'', ''PS1'': ''\u003cmock-chroot\u003e
+      \\\\s-\\\\v\\\\$ '', ''LANG'': ''C.UTF-8''} and shell False\n\u003c/code\u003e\n
+      The given RPM build log snippet describes the execution of a command using RPM
+      build system. The command being executed is ''rpmbuild'' with specific build
+      options and no dependencies (-bs --noclean --target noarch --nodeps). The command
+      is being run in a ''mock'' environment, which is indicated by the ''mock-chroot''
+      in the PS1 variable. The environment variables for TERM, SHELL, HOME, HOSTNAME,
+      PATH, PROMPT_COMMAND, and LANG are also shown. The shell for the command is
+      set to ''False'', suggesting that an interpreter other than a shell, such as
+      a Perl or Python script, may be used to execute the RPM build command.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      7:\u003c/b\u003e \u003ccode\u003eBuilding target platforms: noarch\n\u003c/code\u003e\n
+      The RPM build log snippet indicates that the build process is currently working
+      on creating target platforms of type ''noarch''. Noarch is a common RPM target
+      architecture that stands for \"no architecture\" or \"noarchitecture\". It is
+      used for building packages that do not have any architecture-specific components
+      and can be installed on any system regardless of its hardware architecture.
+      Therefore, this log message implies that the RPM package builder is in the process
+      of creating a ''noarch'' variant of the RPM package being built.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      9:\u003c/b\u003e \u003ccode\u003esetting SOURCE_DATE_EPOCH=1745280000\n\u003c/code\u003e\n
+      This RPM build log snippet sets the SOURCE_DATE_EPOCH variable to the value
+      1745280000. This variable is used by RPM to preserve the build time of the source
+      code during the build process. The value is in the number of seconds since the
+      Unix epoch (January 1, 1970).\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      10:\u003c/b\u003e \u003ccode\u003eRPM build errors:\nerror: Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\n    Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\n\u003c/code\u003e\n The RPM build log indicates that
+      there were two build errors related to a patch file named \"libtiff-4.4.0-CVE-2023-52356.patch\".
+      The error message states that the file does not exist in the specified path
+      \"/builddir/build/SOURCES/\".\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      13:\u003c/b\u003e \u003ccode\u003eChild return code was: 1\n\u003c/code\u003e\n
+      The RPM build log snippet indicates that the child process during the RPM build
+      procedure returned an error code of 1. This is an indication that the build
+      process of the specified RPM package encountered an issue during execution.
+      The exact nature of the issue cannot be determined from this log snippet alone.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      14:\u003c/b\u003e \u003ccode\u003eEXCEPTION: [Error(\"Command failed: \\n #
+      bash --login -c ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''\\n\",
+      1)]\n\u003c/code\u003e\n This RPM build log snippet indicates that an exception
+      has occurred during the RPM build process. The exception message states that
+      the command \"rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec\"
+      has failed. The message is preceded by the number 14, which likely represents
+      the build number or sequence number of the build process. The failure of the
+      command is the only piece of information provided in this snippet. No further
+      details about the cause of the failure are given.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      15:\u003c/b\u003e \u003ccode\u003eTraceback (most recent call last):\n  File
+      \"/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py\", line 93,
+      in trace\n    result = func(*args, **kw)\n  File \"/usr/lib/python3.6/site-packages/mockbuild/util.py\",
+      line 612, in do_with_status\n    raise exception.Error(\"Command failed: \\n
+      # %s\\n%s\" % (cmd_pretty(command, env), output), child.returncode)\n\u003c/code\u003e\n
+      The snippet is an error message from a RPM build process using the Mockbuild
+      tool. The error indicates that a command executed during the build process has
+      failed. The specific error occurs in the \"do_with_status\" function, located
+      in the \"util.py\" file in the Mockbuild library.\n\nThe error message includes
+      a traceback, which shows that the error was raised by the \"Error\" exception
+      in the \"do_with_status\" function. The error message itself contains the command
+      that failed, indicated by `cmd_pretty(command, env)`, and the output of the
+      command. The return code of the command is also included in the error message.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      20:\u003c/b\u003e \u003ccode\u003emockbuild.exception.Error: Command failed:
+      \n # bash --login -c ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps
+      /builddir/build/SPECS/libtiff.spec''\n\n\u003c/code\u003e\n The log snippet
+      indicates that an error occurred during the RPM build process for the \"libtiff\"
+      package using mockbuild. Specifically, the command \"rpmbuild -bs --noclean
+      --target noarch --nodeps /builddir/build/SPECS/libtiff.spec\" failed. The error
+      message is not provided in the log snippet, only that the command failed.\n\u003c/li\u003e\n\n\u003c/ul\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eLogs\u003c/summary\u003e\n  \u003cp\u003e\n    Log
+      Detective analyzed the following logs files to provide an explanation:\n  \u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://gitlab.com/api/v4/projects/23667077/jobs/9789376408/artifacts/kojilogs/noarch-5653506/noarch-5653507/build.log\"\u003ehttps://gitlab.com/api/v4/projects/23667077/jobs/9789376408/artifacts/kojilogs/noarch-5653506/noarch-5653507/build.log\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\n  \u003cp\u003e\n    Additional
+      logs are available from:\n    \u003cul\u003e\n    \u003cli\u003e\u003ca href=\"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/jobs/9789376408/artifacts/download\"\u003eartifacts.zip\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n  \u003c/p\u003e\n\n  \u003cp\u003e\n    Please
+      know that these log files are automatically removed after some\n    time, so
+      you might need a backup.\n  \u003c/p\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eHelp\u003c/summary\u003e\n  \u003cp\u003eDon''t
+      hesitate to reach out.\u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective\"\u003eUpstream\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective/issues\"\u003eIssue tracker\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://redhat.enterprise.slack.com/archives/C06DWNVKKDE\"\u003eSlack\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://log-detective.com/documentation\"\u003eDocumentation\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\u003c/details\u003e\n\n\n---\nThis
+      comment was created by [Log Detective][log-detective].\n\nWas the provided feedback
+      accurate and helpful? \u003cbr\u003ePlease vote with :thumbsup:\nor :thumbsdown:
+      to help us improve.\u003cbr\u003e\n\n\n\n[log-detective]: https://log-detective.com/\n[contact]:
+      https://github.com/fedora-copr","author":{"id":27211590,"username":"group_8794173_bot_029d2e92d461920a3695e55137a87774","public_email":null,"name":"****","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/c16bbfef2c60f8447985835437fc6442310027fe3e08fca895081b06f089abce?s=80\u0026d=identicon","web_url":"https://gitlab.com/group_8794173_bot_029d2e92d461920a3695e55137a87774"},"created_at":"2025-04-22T15:05:38.431Z","updated_at":"2025-04-22T15:21:21.994Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-22T15:11:00.983Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c793ba6b8dee70-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"b3e02019edf96e96f09b413bd0961ca9"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-52-lb-gprd
+      gitlab-sv: api-gke-us-east1-b
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"f1df236ff18aff222d2f65f37aad47a9","version":"1"}'
+      x-request-id: f1df236ff18aff222d2f65f37aad47a9
+      x-runtime: '0.112792'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330
+- response:
+    auto_calculate_content_length: false
+    body: '[{"id":34008518,"name":"thumbsup","user":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"created_at":"2025-04-22T15:21:21.992Z","updated_at":"2025-04-22T15:21:21.992Z","awardable_id":2462509330,"awardable_type":"Note","url":null}]'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c793be3abfee70-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"7da7fe52d08c291e201c0b9f7350e6a4"
+      Link: <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
+        rel="first", <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
+        rel="last"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-33-lb-gprd
+      gitlab-sv: api-gke-us-east1-d
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"2195c57c0303d8ac695a5bf186859a38","version":"1"}'
+      x-next-page: ''
+      x-page: '1'
+      x-per-page: '20'
+      x-prev-page: ''
+      x-request-id: 2195c57c0303d8ac695a5bf186859a38
+      x-runtime: '0.079569'
+      x-total: '1'
+      x-total-pages: '1'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330/award_emoji
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":23667077,"description":"The libtiff rpms","name":"libtiff","name_with_namespace":"Red
+      Hat / centos-stream / rpms / libtiff","path":"libtiff","path_with_namespace":"redhat/centos-stream/rpms/libtiff","created_at":"2021-01-14T13:33:43.455Z","default_branch":"c10s","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:redhat/centos-stream/rpms/libtiff.git","http_url_to_repo":"https://gitlab.com/redhat/centos-stream/rpms/libtiff.git","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff","readme_url":null,"forks_count":6,"avatar_url":null,"star_count":2,"last_activity_at":"2025-05-05T16:06:55.870Z","namespace":{"id":8794173,"name":"rpms","path":"rpms","kind":"group","full_path":"redhat/centos-stream/rpms","parent_id":8706831,"avatar_url":null,"web_url":"https://gitlab.com/groups/redhat/centos-stream/rpms"},"container_registry_image_prefix":"registry.gitlab.com/redhat/centos-stream/rpms/libtiff","_links":{"self":"https://gitlab.com/api/v4/projects/23667077","merge_requests":"https://gitlab.com/api/v4/projects/23667077/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/23667077/repository/branches","labels":"https://gitlab.com/api/v4/projects/23667077/labels","events":"https://gitlab.com/api/v4/projects/23667077/events","members":"https://gitlab.com/api/v4/projects/23667077/members","cluster_agents":"https://gitlab.com/api/v4/projects/23667077/cluster_agents"},"marked_for_deletion_at":null,"marked_for_deletion_on":null,"packages_enabled":false,"empty_repo":false,"archived":false,"visibility":"public","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-01-15T13:33:43.485Z"},"repository_object_format":"sha1","issues_enabled":false,"merge_requests_enabled":true,"wiki_enabled":false,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"can_create_merge_request_in":true,"issues_access_level":"disabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"disabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","analytics_access_level":"enabled","container_registry_access_level":"enabled","security_and_compliance_access_level":"private","releases_access_level":"enabled","environments_access_level":"disabled","feature_flags_access_level":"disabled","infrastructure_access_level":"disabled","monitor_access_level":"disabled","model_experiments_access_level":"enabled","model_registry_access_level":"enabled","emails_disabled":false,"emails_enabled":true,"shared_runners_enabled":true,"lfs_enabled":false,"creator_id":6007577,"import_status":"none","description_html":"\u003cp
+      data-sourcepos=\"1:1-1:16\" dir=\"auto\"\u003eThe libtiff rpms\u003c/p\u003e","updated_at":"2025-05-07T15:22:25.055Z","ci_config_path":"global-tasks.yml@redhat/centos-stream/ci-cd/dist-git-gating-tests","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"request_access_enabled":false,"only_allow_merge_if_all_discussions_are_resolved":true,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","merge_request_title_regex":null,"squash_option":"never","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"approvals_before_merge":0,"mirror":false,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"merge_requests_template":"","merge_pipelines_enabled":true,"merge_trains_enabled":true,"merge_trains_skip_train_allowed":false,"allow_pipeline_trigger_approve_deployment":false,"auto_duo_code_review_enabled":false,"permissions":{"project_access":null,"group_access":null}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c793c1e93fee70-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"7bcd1b327972f0654df91402d94e9b70"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-53-lb-gprd
+      gitlab-sv: api-gke-us-east1-c
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"0a3dbed88b23ccdf73a74f3c703d84ff","version":"1"}'
+      x-request-id: 0a3dbed88b23ccdf73a74f3c703d84ff
+      x-runtime: '0.121410'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":"91090f16d27d4ad053f39990c5a47a592565d38f","individual_note":false,"notes":[{"id":2464715549,"type":"DiscussionNote","body":"The
+      package libtiff failed to build, here is a possible explanation why.\n\nPlease
+      know that the explanation was provided by AI and may be incorrect.\nIn this
+      case, we are 99.49% certain of the response :slight_smile:.\n\n The RPM build
+      process of the \"libtiff.spec\" package encountered an error during the `%build`
+      phase. Specifically, the command `/usr/bin/rpmbuild -bb --noclean --target x86_64
+      --nodeps /builddir/build/SPECS/libtiff.spec` failed to execute successfully,
+      as indicated by a non-zero exit status of 1. This error was reported by Mockbuild,
+      the RPM testing framework.\n\nThe log snippets do not provide enough information
+      to determine the exact cause of the build failure. Potential issues could include
+      missing or incompatible dependencies, incorrect build variables, or compilation
+      errors. It is recommended to review the build script in `/builddir/build/SPECS/libtiff.spec`
+      and the corresponding source code to identify and resolve the cause of the build
+      error. Additionally, checking the RPM dependency tree and build environment
+      variables may help identify any missing dependencies or misconfigurations.\n\n\u003cdetails\u003e\n\u003cul\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      10:\u003c/b\u003e \u003ccode\u003eChild return code was: 0\n\u003c/code\u003e\n
+      This log snippet indicates that a child process, likely a sub-build or dependency
+      during the RPM build process, has completed with an exit status code of 0. An
+      exit status code of 0 typically signifies a successful execution.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      450:\u003c/b\u003e \u003ccode\u003emake[2]: Entering directory ''/builddir/build/BUILD/tiff-4.4.0/port''\n\u003c/code\u003e\n
+      This RPM build log snippet indicates that the make process (specifically make[2])
+      is entering the directory ''/builddir/build/BUILD/tiff-4.4.0/port''. The number
+      preceding the message (450) represents the line number in the build script where
+      this event occurs.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine 710:\u003c/b\u003e
+      \u003ccode\u003egcc -DHAVE_CONFIG_H -I. -I../config -I../libtiff -I../port  -I../libtiff
+      -I../port -DTIFF_DISABLE_DEPRECATED   -O2 -flto=auto -ffat-lto-objects -fexceptions
+      -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2
+      -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong
+      -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64-v2 -mtune=generic
+      -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-strict-aliasing
+      -Wall -W -c -o fax2tiff.o fax2tiff.c\n\u003c/code\u003e\n The RPM build log
+      snippet represents a gcc compilation command with various flags and options
+      for building the ''fax2tiff.o'' object file from ''fax2tiff.c''.\n\nThe command
+      includes:\n- Compiler: gcc\n- Preprocessor flags:\n  - Include directories:
+      ., ../config, ../libtiff, ../port\n  - Defines: HAVE_CONFIG_H, TIFF_DISABLE_DEPRECATED\n\n-
+      Optimization flags:\n  - Compiler optimization: -O2\n  - Link-time optimization:
+      -flto=auto -ffat-lto-objects\n\n- Exception handling: -fexceptions\n\n- Debugging
+      flags: -g -grecord-gcc-switches\n\n- Warnings: -Wall -Werror=format-security\n\n-
+      Security: -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS\n\n- Hardened build:
+      -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1\n\n- Stack protection: -fstack-protector-strong\n\n-
+      Code protection: -fcf-protection\n\n- Aliasing: -fno-strict-aliasing\n\n- Target
+      architecture: -m64 -march=x86-64-v2 -mtune=generic\n\n- Asynchronous unwind
+      tables: -fasynchronous-unwind-tables\n\n- Stack clash protection: -fstack-clash-protection.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      786:\u003c/b\u003e \u003ccode\u003ecollect2: error: ld returned 1 exit status\n\u003c/code\u003e\n
+      The RPM build log snippet indicates an error during the linking (ld) stage of
+      the build process. The linker returned an exit status of 1, which signifies
+      an unsuccessful linking attempt. The exact cause of the error is not provided
+      in the snippet, but potential issues could include missing or incompatible libraries,
+      incorrect library versions, or syntax errors in the linker script. Further investigation
+      is required to determine the specific cause and resolve the issue.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      787:\u003c/b\u003e \u003ccode\u003emake[1]: *** [Makefile:653: tiffdither] Error
+      1\n\u003c/code\u003e\n The RPM build log snippet indicates that there was an
+      error during the execution of the \"make\" command, specifically with the target
+      \"tiffdither\" mentioned in the Makefile on line 653. The error resulted in
+      the make process exiting with a status code of 1.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      905:\u003c/b\u003e \u003ccode\u003etiffcrop.c: In function ''writeBufferToSeparateStrips'':\ntiffcrop.c:1244:28:
+      warning: comparison of integer expressions of different signedness: ''tsize_t''
+      {aka ''long int''} and ''long long unsigned int'' [-Wsign-compare]\n 1244 |           if
+      (scanlinesize \u003e 0x0ffffffffULL) {\n      |                            ^\n\u003c/code\u003e\n
+      The RPM build log snippet indicates a compiler warning during the build process
+      of the ''tiffcrop.c'' file. The warning message specifically mentions a comparison
+      of two data types with different signedness in line 1244 of the file: ''tsize_t''
+      (a long int type) and ''long long unsigned int''. The compiler is advising that
+      such a comparison may result in unexpected behavior due to potential sign conversions.
+      The warning message concludes with the location of the issue in the code.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      913:\u003c/b\u003e \u003ccode\u003emake: *** [Makefile:561: all-recursive] Error
+      1\n\u003c/code\u003e\n The RPM build log snippet indicates an error occurred
+      during the \"make all-recursive\" step in the RPM package build process. Specifically,
+      the \"make\" command returned an error status code 1. There is no further information
+      provided in the log snippet regarding the nature of the error.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      914:\u003c/b\u003e \u003ccode\u003eerror: Bad exit status from /var/tmp/rpm-tmp.JH52lB
+      (%build)\n\u003c/code\u003e\n The RPM build process encountered an error during
+      the `%build` phase of the build. Specifically, there was a \"Bad exit status\"
+      from the build script located at `/var/tmp/rpm-tmp.JH52lB`. This indicates that
+      the commands executed within the `%build` script did not complete successfully,
+      resulting in an error. The cause of this error is not apparent from the given
+      log snippet and requires further investigation into the contents of the `%build`
+      script and build environment.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      915:\u003c/b\u003e \u003ccode\u003eRPM build errors:\n    Bad exit status from
+      /var/tmp/rpm-tmp.JH52lB (%build)\n\u003c/code\u003e\n The given RPM build log
+      snippet indicates that during the build process, an error occurred in the %build
+      phase. The error resulted in an unsuccessful exit status from the file location
+      ''/var/tmp/rpm-tmp.JH52lB''. No further information is provided in the log regarding
+      the nature of the error.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      918:\u003c/b\u003e \u003ccode\u003eEXCEPTION: [Error(\"Command failed: \\n #
+      bash --login -c ''/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec''\\n\",
+      1)]\n\u003c/code\u003e\n The log snippet indicates an error occurred during
+      the RPM build process using the `rpmbuild` command. The command being executed
+      is:\n\n`/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec`\n\nThe
+      error message reads ''Command failed'' and is accompanied by an exception. The
+      cause of the command failure is not explicitly stated in the provided log snippet.
+      The error is marked with a non-zero exit status of 1.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      919:\u003c/b\u003e \u003ccode\u003eTraceback (most recent call last):\n  File
+      \"/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py\", line 93,
+      in trace\n    result = func(*args, **kw)\n  File \"/usr/lib/python3.6/site-packages/mockbuild/util.py\",
+      line 612, in do_with_status\n    raise exception.Error(\"Command failed: \\n
+      # %s\\n%s\" % (cmd_pretty(command, env), output), child.returncode)\n\u003c/code\u003e\n
+      This log snippet is a Python traceback indicating an error during the execution
+      of an RPM build using the mockbuild tool. The error occurred at the line where
+      the command execution failed in the mockbuild utility file (do_with_status,
+      line 612). The specific error message states that a command failed with the
+      given error message and return code. The command and its environment variables
+      can be found in the cmd_pretty function call. No further information is provided
+      in the log snippet.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine 924:\u003c/b\u003e
+      \u003ccode\u003emockbuild.exception.Error: Command failed: \n # bash --login
+      -c ''/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec''\n\n\u003c/code\u003e\n
+      The build log snippet indicates an error occurred during the RPM build process
+      of the \"libtiff.spec\" file, using the x86\\_64 architecture. The command \"rpmbuild
+      -bb --noclean --target x86\\_64 --nodeps /builddir/build/SPECS/libtiff.spec\"
+      failed to execute successfully. This error is reported by Mockbuild, an RPM
+      testing framework. No further information about the nature of the command failure
+      is provided in the log.\n\u003c/li\u003e\n\n\u003c/ul\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eLogs\u003c/summary\u003e\n  \u003cp\u003e\n    Log
+      Detective analyzed the following logs files to provide an explanation:\n  \u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://gitlab.com/api/v4/projects/23667077/jobs/9789725965/artifacts/kojilogs/noarch-5653531/x86_64-5653534/build.log\"\u003ehttps://gitlab.com/api/v4/projects/23667077/jobs/9789725965/artifacts/kojilogs/noarch-5653531/x86_64-5653534/build.log\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\n  \u003cp\u003e\n    Additional
+      logs are available from:\n    \u003cul\u003e\n    \u003cli\u003e\u003ca href=\"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/jobs/9789725965/artifacts/download\"\u003eartifacts.zip\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n  \u003c/p\u003e\n\n  \u003cp\u003e\n    Please
+      know that these log files are automatically removed after some\n    time, so
+      you might need a backup.\n  \u003c/p\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eHelp\u003c/summary\u003e\n  \u003cp\u003eDon''t
+      hesitate to reach out.\u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective\"\u003eUpstream\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective/issues\"\u003eIssue tracker\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://redhat.enterprise.slack.com/archives/C06DWNVKKDE\"\u003eSlack\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://log-detective.com/documentation\"\u003eDocumentation\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\u003c/details\u003e\n\n\n---\nThis
+      comment was created by [Log Detective][log-detective].\n\nWas the provided feedback
+      accurate and helpful? \u003cbr\u003ePlease vote with :thumbsup:\nor :thumbsdown:
+      to help us improve.\u003cbr\u003e\n\n\n\n[log-detective]: https://log-detective.com/\n[contact]:
+      https://github.com/fedora-copr","author":{"id":27211590,"username":"group_8794173_bot_029d2e92d461920a3695e55137a87774","public_email":null,"name":"****","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/c16bbfef2c60f8447985835437fc6442310027fe3e08fca895081b06f089abce?s=80\u0026d=identicon","web_url":"https://gitlab.com/group_8794173_bot_029d2e92d461920a3695e55137a87774"},"created_at":"2025-04-23T14:02:31.332Z","updated_at":"2025-04-23T14:12:56.887Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-23T14:12:56.887Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}},{"id":2464747301,"type":"DiscussionNote","body":"unsuccessful
+      analysis:\nerror that caused failure:\n/usr/bin/ld: ../libtiff/.libs/libtiff.so:
+      undefined reference to `TIFFErrorExtR''\ncollect2: error: ld returned 1 exit
+      status\nmake[1]: *** [Makefile:653: tiffdither] Error 1\n\nprimary source of
+      that error:\ntif_getimage.c: In function ''TIFFReadRGBAStripExt'':\ntif_getimage.c:2948:13:
+      warning: implicit declaration of function ''TIFFErrorExtR''; did you mean ''TIFFErrorExt''?
+      [-Wimplicit-function-declaration]\n 2948 |             TIFFErrorExtR(tif, TIFFFileName(tif),\n      |             ^~~~~~~~~~~~~\n      |             TIFFErrorExt","author":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"created_at":"2025-04-23T14:12:56.320Z","updated_at":"2025-04-23T14:12:56.887Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-23T14:12:56.887Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}}]}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c793c48da1ee70-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"23b1b755a58fd004e2846cb538b22eac"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-32-lb-gprd
+      gitlab-sv: api-gke-us-east1-c
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"b26c46cea088c57572c60b10300fceec","version":"1"}'
+      x-request-id: b26c46cea088c57572c60b10300fceec
+      x-runtime: '0.150204'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/discussions/91090f16d27d4ad053f39990c5a47a592565d38f
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":2464715549,"type":"DiscussionNote","body":"The package libtiff failed
+      to build, here is a possible explanation why.\n\nPlease know that the explanation
+      was provided by AI and may be incorrect.\nIn this case, we are 99.49% certain
+      of the response :slight_smile:.\n\n The RPM build process of the \"libtiff.spec\"
+      package encountered an error during the `%build` phase. Specifically, the command
+      `/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec`
+      failed to execute successfully, as indicated by a non-zero exit status of 1.
+      This error was reported by Mockbuild, the RPM testing framework.\n\nThe log
+      snippets do not provide enough information to determine the exact cause of the
+      build failure. Potential issues could include missing or incompatible dependencies,
+      incorrect build variables, or compilation errors. It is recommended to review
+      the build script in `/builddir/build/SPECS/libtiff.spec` and the corresponding
+      source code to identify and resolve the cause of the build error. Additionally,
+      checking the RPM dependency tree and build environment variables may help identify
+      any missing dependencies or misconfigurations.\n\n\u003cdetails\u003e\n\u003cul\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      10:\u003c/b\u003e \u003ccode\u003eChild return code was: 0\n\u003c/code\u003e\n
+      This log snippet indicates that a child process, likely a sub-build or dependency
+      during the RPM build process, has completed with an exit status code of 0. An
+      exit status code of 0 typically signifies a successful execution.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      450:\u003c/b\u003e \u003ccode\u003emake[2]: Entering directory ''/builddir/build/BUILD/tiff-4.4.0/port''\n\u003c/code\u003e\n
+      This RPM build log snippet indicates that the make process (specifically make[2])
+      is entering the directory ''/builddir/build/BUILD/tiff-4.4.0/port''. The number
+      preceding the message (450) represents the line number in the build script where
+      this event occurs.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine 710:\u003c/b\u003e
+      \u003ccode\u003egcc -DHAVE_CONFIG_H -I. -I../config -I../libtiff -I../port  -I../libtiff
+      -I../port -DTIFF_DISABLE_DEPRECATED   -O2 -flto=auto -ffat-lto-objects -fexceptions
+      -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2
+      -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong
+      -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64-v2 -mtune=generic
+      -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-strict-aliasing
+      -Wall -W -c -o fax2tiff.o fax2tiff.c\n\u003c/code\u003e\n The RPM build log
+      snippet represents a gcc compilation command with various flags and options
+      for building the ''fax2tiff.o'' object file from ''fax2tiff.c''.\n\nThe command
+      includes:\n- Compiler: gcc\n- Preprocessor flags:\n  - Include directories:
+      ., ../config, ../libtiff, ../port\n  - Defines: HAVE_CONFIG_H, TIFF_DISABLE_DEPRECATED\n\n-
+      Optimization flags:\n  - Compiler optimization: -O2\n  - Link-time optimization:
+      -flto=auto -ffat-lto-objects\n\n- Exception handling: -fexceptions\n\n- Debugging
+      flags: -g -grecord-gcc-switches\n\n- Warnings: -Wall -Werror=format-security\n\n-
+      Security: -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS\n\n- Hardened build:
+      -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1\n\n- Stack protection: -fstack-protector-strong\n\n-
+      Code protection: -fcf-protection\n\n- Aliasing: -fno-strict-aliasing\n\n- Target
+      architecture: -m64 -march=x86-64-v2 -mtune=generic\n\n- Asynchronous unwind
+      tables: -fasynchronous-unwind-tables\n\n- Stack clash protection: -fstack-clash-protection.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      786:\u003c/b\u003e \u003ccode\u003ecollect2: error: ld returned 1 exit status\n\u003c/code\u003e\n
+      The RPM build log snippet indicates an error during the linking (ld) stage of
+      the build process. The linker returned an exit status of 1, which signifies
+      an unsuccessful linking attempt. The exact cause of the error is not provided
+      in the snippet, but potential issues could include missing or incompatible libraries,
+      incorrect library versions, or syntax errors in the linker script. Further investigation
+      is required to determine the specific cause and resolve the issue.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      787:\u003c/b\u003e \u003ccode\u003emake[1]: *** [Makefile:653: tiffdither] Error
+      1\n\u003c/code\u003e\n The RPM build log snippet indicates that there was an
+      error during the execution of the \"make\" command, specifically with the target
+      \"tiffdither\" mentioned in the Makefile on line 653. The error resulted in
+      the make process exiting with a status code of 1.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      905:\u003c/b\u003e \u003ccode\u003etiffcrop.c: In function ''writeBufferToSeparateStrips'':\ntiffcrop.c:1244:28:
+      warning: comparison of integer expressions of different signedness: ''tsize_t''
+      {aka ''long int''} and ''long long unsigned int'' [-Wsign-compare]\n 1244 |           if
+      (scanlinesize \u003e 0x0ffffffffULL) {\n      |                            ^\n\u003c/code\u003e\n
+      The RPM build log snippet indicates a compiler warning during the build process
+      of the ''tiffcrop.c'' file. The warning message specifically mentions a comparison
+      of two data types with different signedness in line 1244 of the file: ''tsize_t''
+      (a long int type) and ''long long unsigned int''. The compiler is advising that
+      such a comparison may result in unexpected behavior due to potential sign conversions.
+      The warning message concludes with the location of the issue in the code.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      913:\u003c/b\u003e \u003ccode\u003emake: *** [Makefile:561: all-recursive] Error
+      1\n\u003c/code\u003e\n The RPM build log snippet indicates an error occurred
+      during the \"make all-recursive\" step in the RPM package build process. Specifically,
+      the \"make\" command returned an error status code 1. There is no further information
+      provided in the log snippet regarding the nature of the error.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      914:\u003c/b\u003e \u003ccode\u003eerror: Bad exit status from /var/tmp/rpm-tmp.JH52lB
+      (%build)\n\u003c/code\u003e\n The RPM build process encountered an error during
+      the `%build` phase of the build. Specifically, there was a \"Bad exit status\"
+      from the build script located at `/var/tmp/rpm-tmp.JH52lB`. This indicates that
+      the commands executed within the `%build` script did not complete successfully,
+      resulting in an error. The cause of this error is not apparent from the given
+      log snippet and requires further investigation into the contents of the `%build`
+      script and build environment.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      915:\u003c/b\u003e \u003ccode\u003eRPM build errors:\n    Bad exit status from
+      /var/tmp/rpm-tmp.JH52lB (%build)\n\u003c/code\u003e\n The given RPM build log
+      snippet indicates that during the build process, an error occurred in the %build
+      phase. The error resulted in an unsuccessful exit status from the file location
+      ''/var/tmp/rpm-tmp.JH52lB''. No further information is provided in the log regarding
+      the nature of the error.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      918:\u003c/b\u003e \u003ccode\u003eEXCEPTION: [Error(\"Command failed: \\n #
+      bash --login -c ''/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec''\\n\",
+      1)]\n\u003c/code\u003e\n The log snippet indicates an error occurred during
+      the RPM build process using the `rpmbuild` command. The command being executed
+      is:\n\n`/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec`\n\nThe
+      error message reads ''Command failed'' and is accompanied by an exception. The
+      cause of the command failure is not explicitly stated in the provided log snippet.
+      The error is marked with a non-zero exit status of 1.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      919:\u003c/b\u003e \u003ccode\u003eTraceback (most recent call last):\n  File
+      \"/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py\", line 93,
+      in trace\n    result = func(*args, **kw)\n  File \"/usr/lib/python3.6/site-packages/mockbuild/util.py\",
+      line 612, in do_with_status\n    raise exception.Error(\"Command failed: \\n
+      # %s\\n%s\" % (cmd_pretty(command, env), output), child.returncode)\n\u003c/code\u003e\n
+      This log snippet is a Python traceback indicating an error during the execution
+      of an RPM build using the mockbuild tool. The error occurred at the line where
+      the command execution failed in the mockbuild utility file (do_with_status,
+      line 612). The specific error message states that a command failed with the
+      given error message and return code. The command and its environment variables
+      can be found in the cmd_pretty function call. No further information is provided
+      in the log snippet.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine 924:\u003c/b\u003e
+      \u003ccode\u003emockbuild.exception.Error: Command failed: \n # bash --login
+      -c ''/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec''\n\n\u003c/code\u003e\n
+      The build log snippet indicates an error occurred during the RPM build process
+      of the \"libtiff.spec\" file, using the x86\\_64 architecture. The command \"rpmbuild
+      -bb --noclean --target x86\\_64 --nodeps /builddir/build/SPECS/libtiff.spec\"
+      failed to execute successfully. This error is reported by Mockbuild, an RPM
+      testing framework. No further information about the nature of the command failure
+      is provided in the log.\n\u003c/li\u003e\n\n\u003c/ul\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eLogs\u003c/summary\u003e\n  \u003cp\u003e\n    Log
+      Detective analyzed the following logs files to provide an explanation:\n  \u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://gitlab.com/api/v4/projects/23667077/jobs/9789725965/artifacts/kojilogs/noarch-5653531/x86_64-5653534/build.log\"\u003ehttps://gitlab.com/api/v4/projects/23667077/jobs/9789725965/artifacts/kojilogs/noarch-5653531/x86_64-5653534/build.log\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\n  \u003cp\u003e\n    Additional
+      logs are available from:\n    \u003cul\u003e\n    \u003cli\u003e\u003ca href=\"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/jobs/9789725965/artifacts/download\"\u003eartifacts.zip\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n  \u003c/p\u003e\n\n  \u003cp\u003e\n    Please
+      know that these log files are automatically removed after some\n    time, so
+      you might need a backup.\n  \u003c/p\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eHelp\u003c/summary\u003e\n  \u003cp\u003eDon''t
+      hesitate to reach out.\u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective\"\u003eUpstream\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective/issues\"\u003eIssue tracker\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://redhat.enterprise.slack.com/archives/C06DWNVKKDE\"\u003eSlack\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://log-detective.com/documentation\"\u003eDocumentation\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\u003c/details\u003e\n\n\n---\nThis
+      comment was created by [Log Detective][log-detective].\n\nWas the provided feedback
+      accurate and helpful? \u003cbr\u003ePlease vote with :thumbsup:\nor :thumbsdown:
+      to help us improve.\u003cbr\u003e\n\n\n\n[log-detective]: https://log-detective.com/\n[contact]:
+      https://github.com/fedora-copr","author":{"id":27211590,"username":"group_8794173_bot_029d2e92d461920a3695e55137a87774","public_email":null,"name":"****","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/c16bbfef2c60f8447985835437fc6442310027fe3e08fca895081b06f089abce?s=80\u0026d=identicon","web_url":"https://gitlab.com/group_8794173_bot_029d2e92d461920a3695e55137a87774"},"created_at":"2025-04-23T14:02:31.332Z","updated_at":"2025-04-23T14:12:56.887Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-23T14:12:56.887Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c793c97e8aee70-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"4300ea10b3d9f8472c79f7631e87fe00"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-22-lb-gprd
+      gitlab-sv: api-gke-us-east1-b
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"c2d9f1367734f787de78bd9a813db745","version":"1"}'
+      x-request-id: c2d9f1367734f787de78bd9a813db745
+      x-runtime: '0.111268'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549
+- response:
+    auto_calculate_content_length: false
+    body: '[{"id":34038545,"name":"thumbsdown","user":{"id":737640,"username":"TomasTomecek","public_email":"","name":"Tomas
+      Tomecek","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/545461259a87a9b40ef14e381b4257d476bc183ab44b293f084084ada15a2dcc?s=80\u0026d=identicon","web_url":"https://gitlab.com/TomasTomecek"},"created_at":"2025-04-23T14:11:12.123Z","updated_at":"2025-04-23T14:11:12.123Z","awardable_id":2464715549,"awardable_type":"Note","url":null}]'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c793cdfe6eee70-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"f19fe711af9debb1837206f66dccbedd"
+      Link: <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
+        rel="first", <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
+        rel="last"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-26-lb-gprd
+      gitlab-sv: api-gke-us-east1-c
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"6ddafa503bedf92bf08cedaf8089f0fb","version":"1"}'
+      x-next-page: ''
+      x-page: '1'
+      x-per-page: '20'
+      x-prev-page: ''
+      x-request-id: 6ddafa503bedf92bf08cedaf8089f0fb
+      x-runtime: '0.090691'
+      x-total: '1'
+      x-total-pages: '1'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549/award_emoji
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":23667077,"description":"The libtiff rpms","name":"libtiff","name_with_namespace":"Red
+      Hat / centos-stream / rpms / libtiff","path":"libtiff","path_with_namespace":"redhat/centos-stream/rpms/libtiff","created_at":"2021-01-14T13:33:43.455Z","default_branch":"c10s","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:redhat/centos-stream/rpms/libtiff.git","http_url_to_repo":"https://gitlab.com/redhat/centos-stream/rpms/libtiff.git","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff","readme_url":null,"forks_count":6,"avatar_url":null,"star_count":2,"last_activity_at":"2025-05-05T16:06:55.870Z","namespace":{"id":8794173,"name":"rpms","path":"rpms","kind":"group","full_path":"redhat/centos-stream/rpms","parent_id":8706831,"avatar_url":null,"web_url":"https://gitlab.com/groups/redhat/centos-stream/rpms"},"container_registry_image_prefix":"registry.gitlab.com/redhat/centos-stream/rpms/libtiff","_links":{"self":"https://gitlab.com/api/v4/projects/23667077","merge_requests":"https://gitlab.com/api/v4/projects/23667077/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/23667077/repository/branches","labels":"https://gitlab.com/api/v4/projects/23667077/labels","events":"https://gitlab.com/api/v4/projects/23667077/events","members":"https://gitlab.com/api/v4/projects/23667077/members","cluster_agents":"https://gitlab.com/api/v4/projects/23667077/cluster_agents"},"marked_for_deletion_at":null,"marked_for_deletion_on":null,"packages_enabled":false,"empty_repo":false,"archived":false,"visibility":"public","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-01-15T13:33:43.485Z"},"repository_object_format":"sha1","issues_enabled":false,"merge_requests_enabled":true,"wiki_enabled":false,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"can_create_merge_request_in":true,"issues_access_level":"disabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"disabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","analytics_access_level":"enabled","container_registry_access_level":"enabled","security_and_compliance_access_level":"private","releases_access_level":"enabled","environments_access_level":"disabled","feature_flags_access_level":"disabled","infrastructure_access_level":"disabled","monitor_access_level":"disabled","model_experiments_access_level":"enabled","model_registry_access_level":"enabled","emails_disabled":false,"emails_enabled":true,"shared_runners_enabled":true,"lfs_enabled":false,"creator_id":6007577,"import_status":"none","description_html":"\u003cp
+      data-sourcepos=\"1:1-1:16\" dir=\"auto\"\u003eThe libtiff rpms\u003c/p\u003e","updated_at":"2025-05-07T15:22:25.055Z","ci_config_path":"global-tasks.yml@redhat/centos-stream/ci-cd/dist-git-gating-tests","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"request_access_enabled":false,"only_allow_merge_if_all_discussions_are_resolved":true,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","merge_request_title_regex":null,"squash_option":"never","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"approvals_before_merge":0,"mirror":false,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"merge_requests_template":"","merge_pipelines_enabled":true,"merge_trains_enabled":true,"merge_trains_skip_train_allowed":false,"allow_pipeline_trigger_approve_deployment":false,"auto_duo_code_review_enabled":false,"permissions":{"project_access":null,"group_access":null}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c793dcb83bee70-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"7bcd1b327972f0654df91402d94e9b70"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-57-lb-gprd
+      gitlab-sv: gke-cny-api
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"0e5a38790abddd660a58e082cea601b9","version":"1"}'
+      x-request-id: 0e5a38790abddd660a58e082cea601b9
+      x-runtime: '0.159509'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":378085175,"iid":26,"project_id":23667077,"title":"Merge fix for RHEL-17337","description":"Merge
+      request for:\nissue RHEL-17337 - CVE-2023-52356 libtiff: Segment fault in libtiff  in
+      TIFFReadRGBATileExt() leading to denial of service [rhel-9]","state":"merged","created_at":"2025-04-22T14:59:54.425Z","updated_at":"2025-05-05T16:15:05.719Z","merged_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"merge_user":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"merged_at":"2025-05-05T16:15:05.741Z","closed_by":null,"closed_at":null,"target_branch":"c9s","source_branch":"c9s","user_notes_count":6,"upvotes":0,"downvotes":0,"author":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":61073452,"target_project_id":23667077,"labels":["target::latest"],"draft":false,"imported":false,"imported_from":"none","work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"can_be_merged","detailed_merge_status":"not_open","merge_after":null,"sha":"1d8f0e982d3beff79b63559640b7bd578109ceaf","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"prepared_at":"2025-04-22T14:59:59.635Z","allow_collaboration":false,"allow_maintainer_to_push":false,"reference":"!26","references":{"short":"!26","relative":"!26","full":"redhat/centos-stream/rpms/libtiff!26"},"web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/merge_requests/26","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":false,"squash_on_merge":false,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":false,"changes_count":"3","latest_build_started_at":"2025-05-05T15:17:22.392Z","latest_build_finished_at":"2025-05-05T16:07:40.651Z","first_deployed_to_production_at":null,"pipeline":{"id":1800983320,"iid":70,"project_id":23667077,"sha":"bf8b085aa0833394ab0ec10112e61521c6d169a0","ref":"refs/merge-requests/26/merge","status":"success","source":"merge_request_event","created_at":"2025-05-05T15:16:52.231Z","updated_at":"2025-05-05T16:07:40.669Z","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/pipelines/1800983320"},"head_pipeline":{"id":1800983320,"iid":70,"project_id":23667077,"sha":"bf8b085aa0833394ab0ec10112e61521c6d169a0","ref":"refs/merge-requests/26/merge","status":"success","source":"merge_request_event","created_at":"2025-05-05T15:16:52.231Z","updated_at":"2025-05-05T16:07:40.669Z","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/pipelines/1800983320","before_sha":"bf8b085aa0833394ab0ec10112e61521c6d169a0","tag":false,"yaml_errors":null,"user":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"started_at":"2025-05-05T15:17:22.392Z","finished_at":"2025-05-05T16:07:40.651Z","committed_at":null,"duration":2924,"queued_duration":30,"coverage":null,"detailed_status":{"icon":"status_success","text":"Passed","label":"passed","group":"success","tooltip":"passed","has_details":true,"details_path":"/redhat/centos-stream/rpms/libtiff/-/pipelines/1800983320","illustration":null,"favicon":"/assets/ci_favicons/favicon_status_success-8451333011eee8ce9f2ab25dc487fe24a8758c694827a582f17f42b0a90446a2.png"}},"diff_refs":{"base_sha":"3fc1a85f8a59af6101f675a1a02d95932ace85c8","head_sha":"1d8f0e982d3beff79b63559640b7bd578109ceaf","start_sha":"3fc1a85f8a59af6101f675a1a02d95932ace85c8"},"merge_error":null,"first_contribution":false,"user":{"can_merge":false}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c793e14fbcee70-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"04cac7b091f4ff7c7038be61ce98e1f7"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-44-lb-gprd
+      gitlab-sv: api-gke-us-east1-c
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"af05d0e95dd1018907de6f1ebdf0cfda","version":"1"}'
+      x-request-id: af05d0e95dd1018907de6f1ebdf0cfda
+      x-runtime: '0.283868'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":"1ba1f46903f2b4e0573d514ed6d2cae29ab040f6","individual_note":false,"notes":[{"id":2462509330,"type":"DiscussionNote","body":"The
+      package libtiff failed to build, here is a possible explanation why.\n\nPlease
+      know that the explanation was provided by AI and may be incorrect.\nIn this
+      case, we are 99.71% certain of the response :slight_smile:.\n\n Based on the
+      provided log snippets, it appears that there was a failure during the RPM build
+      process for a package named \"libtiff\". The exact cause of the failure cannot
+      be determined from the given information alone, but there are a few clues that
+      suggest what the issue might be.\n\nThe most significant indication of a problem
+      is the error message at line [10] that mentions \"RPM build errors: error: Bad
+      file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch: No such file
+      or directory\". This error suggests that a necessary patch file was missing
+      during the build process. The patch file is identified as \"libtiff-4.4.0-CVE-2023-52356.patch\",
+      and it was expected to be located in the \"/builddir/build/SOURCES/\" directory.
+      However, this file could not be found, causing the build to fail.\n\nAnother
+      snippet (line [14]) shows that an exception was raised during the build process,
+      with the message \"Command failed: # bash --login -c ''/usr/bin/rpmbuild -bs
+      --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''\". This
+      error message confirms the failure of the \"rpmbuild\" command and indicates
+      that the issue was likely related to the missing patch file mentioned earlier.\n\nTo
+      resolve the issue, you should first ensure that all required patch files are
+      present in the correct location. Check the SPEC file for the \"libtiff\" package
+      to confirm that it specifies the correct patch file(s) and that their download
+      or extraction was successful during the build process. If necessary, manually
+      download and install the missing patch files in the expected directory. Once
+      all necessary patch files are present and accessible, try rebuilding the \"libtiff\"
+      package using the \"rpmbuild\" command to see if the issue is resolved. If the
+      issue persists, further investigation may be required to determine if there
+      are any other dependencies or issues that may be preventing the build from completing
+      successfully.\n\n\u003cdetails\u003e\n\u003cul\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      0:\u003c/b\u003e \u003ccode\u003eMock Version: 5.4\n\u003c/code\u003e\n The
+      given RPM build log snippet indicates the version of Mock being used during
+      the RPM build process. In this case, the version is 5.4.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      5:\u003c/b\u003e \u003ccode\u003eENTER [''do_with_status'']([''bash'', ''--login'',
+      ''-c'', ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''],
+      chrootPath=''/var/lib/mock/c9s-build-671467-759558/root''env={''TERM'': ''vt100'',
+      ''SHELL'': ''/bin/bash'', ''HOME'': ''/builddir'', ''HOSTNAME'': ''mock'', ''PATH'':
+      ''/usr/bin:/bin:/usr/sbin:/sbin'', ''PROMPT_COMMAND'': ''printf \"\\\\033]0;\u003cmock-chroot\u003e\\\\007\"'',
+      ''PS1'': ''\u003cmock-chroot\u003e \\\\s-\\\\v\\\\$ '', ''LANG'': ''C.UTF-8''}shell=Falselogger=\u003cmockbuild.trace_decorator.getLog
+      object at 0x7fff8ccaca58\u003etimeout=86400uid=989gid=135user=''mockbuild''nspawn_args=[]unshare_net=FalseprintOutput=False)\n\u003c/code\u003e\n
+      This snippet is a Python script that sets up a call to the RPM (Red Hat Package
+      Manager) build process. The script sets up an environment for RPM build in mock
+      chroot (mock-chroot), which is a feature that allows building RPM packages in
+      an isolated environment. The following are the key elements of the script:\n\n*
+      The script calls the `rpmbuild` command with the following arguments: `-bs`,
+      `--noclean`, `--target noarch`, `--nodeps`, and the path to the SPEC file `/builddir/build/SPECS/libtiff.spec`.
+      `-bs` flag means that the build process will be done in the background. `--noclean`
+      flag skips the clean target. `--target noarch` means that the built package
+      will be noarch (not architecture-specific). `--nodeps` flag skips the dependency
+      resolution.\n* `chrootPath` is the path to the mock chroot environment.\n* `env`
+      is a dictionary containing environment variables for the build process, including
+      `TERM`, `SHELL`, `HOME`, `HOSTNAME`, `PATH`, `PROMPT_COMMAND`, `PS1`, `LANG`,
+      `uid`, `gid`, `user`, and `nspawn_args`. These variables are used to set up
+      the environment for the build process.\n* `shell` is a boolean value indicating
+      whether to run the shell in the build process or not.\n* `logger` is an object
+      used for logging the build process.\n* `timeout` is the maximum build time in
+      seconds.\n* `uid` and `gid` are the user and group IDs to run the build process
+      as.\n* `user` is the username for the user running the build process.\n* `nspawn_args`
+      is an empty list of arguments for unshare network namespace.\n* `unshare_net`
+      is a boolean value indicating whether to use unshare network namespace or not.\n*
+      `printOutput` is a boolean value indicating whether to print the build output
+      or not.\n\nThe script sets up these variables and creates a call to the `rpmbuild`
+      command inside a mock chroot environment.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      6:\u003c/b\u003e \u003ccode\u003eExecuting command: [''bash'', ''--login'',
+      ''-c'', ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec'']
+      with env {''TERM'': ''vt100'', ''SHELL'': ''/bin/bash'', ''HOME'': ''/builddir'',
+      ''HOSTNAME'': ''mock'', ''PATH'': ''/usr/bin:/bin:/usr/sbin:/sbin'', ''PROMPT_COMMAND'':
+      ''printf \"\\\\033]0;\u003cmock-chroot\u003e\\\\007\"'', ''PS1'': ''\u003cmock-chroot\u003e
+      \\\\s-\\\\v\\\\$ '', ''LANG'': ''C.UTF-8''} and shell False\n\u003c/code\u003e\n
+      The given RPM build log snippet describes the execution of a command using RPM
+      build system. The command being executed is ''rpmbuild'' with specific build
+      options and no dependencies (-bs --noclean --target noarch --nodeps). The command
+      is being run in a ''mock'' environment, which is indicated by the ''mock-chroot''
+      in the PS1 variable. The environment variables for TERM, SHELL, HOME, HOSTNAME,
+      PATH, PROMPT_COMMAND, and LANG are also shown. The shell for the command is
+      set to ''False'', suggesting that an interpreter other than a shell, such as
+      a Perl or Python script, may be used to execute the RPM build command.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      7:\u003c/b\u003e \u003ccode\u003eBuilding target platforms: noarch\n\u003c/code\u003e\n
+      The RPM build log snippet indicates that the build process is currently working
+      on creating target platforms of type ''noarch''. Noarch is a common RPM target
+      architecture that stands for \"no architecture\" or \"noarchitecture\". It is
+      used for building packages that do not have any architecture-specific components
+      and can be installed on any system regardless of its hardware architecture.
+      Therefore, this log message implies that the RPM package builder is in the process
+      of creating a ''noarch'' variant of the RPM package being built.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      9:\u003c/b\u003e \u003ccode\u003esetting SOURCE_DATE_EPOCH=1745280000\n\u003c/code\u003e\n
+      This RPM build log snippet sets the SOURCE_DATE_EPOCH variable to the value
+      1745280000. This variable is used by RPM to preserve the build time of the source
+      code during the build process. The value is in the number of seconds since the
+      Unix epoch (January 1, 1970).\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      10:\u003c/b\u003e \u003ccode\u003eRPM build errors:\nerror: Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\n    Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\n\u003c/code\u003e\n The RPM build log indicates that
+      there were two build errors related to a patch file named \"libtiff-4.4.0-CVE-2023-52356.patch\".
+      The error message states that the file does not exist in the specified path
+      \"/builddir/build/SOURCES/\".\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      13:\u003c/b\u003e \u003ccode\u003eChild return code was: 1\n\u003c/code\u003e\n
+      The RPM build log snippet indicates that the child process during the RPM build
+      procedure returned an error code of 1. This is an indication that the build
+      process of the specified RPM package encountered an issue during execution.
+      The exact nature of the issue cannot be determined from this log snippet alone.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      14:\u003c/b\u003e \u003ccode\u003eEXCEPTION: [Error(\"Command failed: \\n #
+      bash --login -c ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''\\n\",
+      1)]\n\u003c/code\u003e\n This RPM build log snippet indicates that an exception
+      has occurred during the RPM build process. The exception message states that
+      the command \"rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec\"
+      has failed. The message is preceded by the number 14, which likely represents
+      the build number or sequence number of the build process. The failure of the
+      command is the only piece of information provided in this snippet. No further
+      details about the cause of the failure are given.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      15:\u003c/b\u003e \u003ccode\u003eTraceback (most recent call last):\n  File
+      \"/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py\", line 93,
+      in trace\n    result = func(*args, **kw)\n  File \"/usr/lib/python3.6/site-packages/mockbuild/util.py\",
+      line 612, in do_with_status\n    raise exception.Error(\"Command failed: \\n
+      # %s\\n%s\" % (cmd_pretty(command, env), output), child.returncode)\n\u003c/code\u003e\n
+      The snippet is an error message from a RPM build process using the Mockbuild
+      tool. The error indicates that a command executed during the build process has
+      failed. The specific error occurs in the \"do_with_status\" function, located
+      in the \"util.py\" file in the Mockbuild library.\n\nThe error message includes
+      a traceback, which shows that the error was raised by the \"Error\" exception
+      in the \"do_with_status\" function. The error message itself contains the command
+      that failed, indicated by `cmd_pretty(command, env)`, and the output of the
+      command. The return code of the command is also included in the error message.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      20:\u003c/b\u003e \u003ccode\u003emockbuild.exception.Error: Command failed:
+      \n # bash --login -c ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps
+      /builddir/build/SPECS/libtiff.spec''\n\n\u003c/code\u003e\n The log snippet
+      indicates that an error occurred during the RPM build process for the \"libtiff\"
+      package using mockbuild. Specifically, the command \"rpmbuild -bs --noclean
+      --target noarch --nodeps /builddir/build/SPECS/libtiff.spec\" failed. The error
+      message is not provided in the log snippet, only that the command failed.\n\u003c/li\u003e\n\n\u003c/ul\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eLogs\u003c/summary\u003e\n  \u003cp\u003e\n    Log
+      Detective analyzed the following logs files to provide an explanation:\n  \u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://gitlab.com/api/v4/projects/23667077/jobs/9789376408/artifacts/kojilogs/noarch-5653506/noarch-5653507/build.log\"\u003ehttps://gitlab.com/api/v4/projects/23667077/jobs/9789376408/artifacts/kojilogs/noarch-5653506/noarch-5653507/build.log\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\n  \u003cp\u003e\n    Additional
+      logs are available from:\n    \u003cul\u003e\n    \u003cli\u003e\u003ca href=\"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/jobs/9789376408/artifacts/download\"\u003eartifacts.zip\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n  \u003c/p\u003e\n\n  \u003cp\u003e\n    Please
+      know that these log files are automatically removed after some\n    time, so
+      you might need a backup.\n  \u003c/p\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eHelp\u003c/summary\u003e\n  \u003cp\u003eDon''t
+      hesitate to reach out.\u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective\"\u003eUpstream\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective/issues\"\u003eIssue tracker\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://redhat.enterprise.slack.com/archives/C06DWNVKKDE\"\u003eSlack\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://log-detective.com/documentation\"\u003eDocumentation\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\u003c/details\u003e\n\n\n---\nThis
+      comment was created by [Log Detective][log-detective].\n\nWas the provided feedback
+      accurate and helpful? \u003cbr\u003ePlease vote with :thumbsup:\nor :thumbsdown:
+      to help us improve.\u003cbr\u003e\n\n\n\n[log-detective]: https://log-detective.com/\n[contact]:
+      https://github.com/fedora-copr","author":{"id":27211590,"username":"group_8794173_bot_029d2e92d461920a3695e55137a87774","public_email":null,"name":"****","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/c16bbfef2c60f8447985835437fc6442310027fe3e08fca895081b06f089abce?s=80\u0026d=identicon","web_url":"https://gitlab.com/group_8794173_bot_029d2e92d461920a3695e55137a87774"},"created_at":"2025-04-22T15:05:38.431Z","updated_at":"2025-04-22T15:21:21.994Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-22T15:11:00.983Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}},{"id":2462523126,"type":"DiscussionNote","body":"correct
+      analysis, but a bit tl;dr","author":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"created_at":"2025-04-22T15:11:00.436Z","updated_at":"2025-04-22T15:11:00.983Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-22T15:11:00.983Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}}]}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c793e4fd44ee70-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"56c7b72183071ab15bae67a27b9cbd18"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-13-lb-gprd
+      gitlab-sv: api-gke-us-east1-b
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"f63e14f293e81f9abc5a820375e69ebb","version":"1"}'
+      x-request-id: f63e14f293e81f9abc5a820375e69ebb
+      x-runtime: '0.173789'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/discussions/1ba1f46903f2b4e0573d514ed6d2cae29ab040f6
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":2462509330,"type":"DiscussionNote","body":"The package libtiff failed
+      to build, here is a possible explanation why.\n\nPlease know that the explanation
+      was provided by AI and may be incorrect.\nIn this case, we are 99.71% certain
+      of the response :slight_smile:.\n\n Based on the provided log snippets, it appears
+      that there was a failure during the RPM build process for a package named \"libtiff\".
+      The exact cause of the failure cannot be determined from the given information
+      alone, but there are a few clues that suggest what the issue might be.\n\nThe
+      most significant indication of a problem is the error message at line [10] that
+      mentions \"RPM build errors: error: Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\". This error suggests that a necessary patch file
+      was missing during the build process. The patch file is identified as \"libtiff-4.4.0-CVE-2023-52356.patch\",
+      and it was expected to be located in the \"/builddir/build/SOURCES/\" directory.
+      However, this file could not be found, causing the build to fail.\n\nAnother
+      snippet (line [14]) shows that an exception was raised during the build process,
+      with the message \"Command failed: # bash --login -c ''/usr/bin/rpmbuild -bs
+      --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''\". This
+      error message confirms the failure of the \"rpmbuild\" command and indicates
+      that the issue was likely related to the missing patch file mentioned earlier.\n\nTo
+      resolve the issue, you should first ensure that all required patch files are
+      present in the correct location. Check the SPEC file for the \"libtiff\" package
+      to confirm that it specifies the correct patch file(s) and that their download
+      or extraction was successful during the build process. If necessary, manually
+      download and install the missing patch files in the expected directory. Once
+      all necessary patch files are present and accessible, try rebuilding the \"libtiff\"
+      package using the \"rpmbuild\" command to see if the issue is resolved. If the
+      issue persists, further investigation may be required to determine if there
+      are any other dependencies or issues that may be preventing the build from completing
+      successfully.\n\n\u003cdetails\u003e\n\u003cul\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      0:\u003c/b\u003e \u003ccode\u003eMock Version: 5.4\n\u003c/code\u003e\n The
+      given RPM build log snippet indicates the version of Mock being used during
+      the RPM build process. In this case, the version is 5.4.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      5:\u003c/b\u003e \u003ccode\u003eENTER [''do_with_status'']([''bash'', ''--login'',
+      ''-c'', ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''],
+      chrootPath=''/var/lib/mock/c9s-build-671467-759558/root''env={''TERM'': ''vt100'',
+      ''SHELL'': ''/bin/bash'', ''HOME'': ''/builddir'', ''HOSTNAME'': ''mock'', ''PATH'':
+      ''/usr/bin:/bin:/usr/sbin:/sbin'', ''PROMPT_COMMAND'': ''printf \"\\\\033]0;\u003cmock-chroot\u003e\\\\007\"'',
+      ''PS1'': ''\u003cmock-chroot\u003e \\\\s-\\\\v\\\\$ '', ''LANG'': ''C.UTF-8''}shell=Falselogger=\u003cmockbuild.trace_decorator.getLog
+      object at 0x7fff8ccaca58\u003etimeout=86400uid=989gid=135user=''mockbuild''nspawn_args=[]unshare_net=FalseprintOutput=False)\n\u003c/code\u003e\n
+      This snippet is a Python script that sets up a call to the RPM (Red Hat Package
+      Manager) build process. The script sets up an environment for RPM build in mock
+      chroot (mock-chroot), which is a feature that allows building RPM packages in
+      an isolated environment. The following are the key elements of the script:\n\n*
+      The script calls the `rpmbuild` command with the following arguments: `-bs`,
+      `--noclean`, `--target noarch`, `--nodeps`, and the path to the SPEC file `/builddir/build/SPECS/libtiff.spec`.
+      `-bs` flag means that the build process will be done in the background. `--noclean`
+      flag skips the clean target. `--target noarch` means that the built package
+      will be noarch (not architecture-specific). `--nodeps` flag skips the dependency
+      resolution.\n* `chrootPath` is the path to the mock chroot environment.\n* `env`
+      is a dictionary containing environment variables for the build process, including
+      `TERM`, `SHELL`, `HOME`, `HOSTNAME`, `PATH`, `PROMPT_COMMAND`, `PS1`, `LANG`,
+      `uid`, `gid`, `user`, and `nspawn_args`. These variables are used to set up
+      the environment for the build process.\n* `shell` is a boolean value indicating
+      whether to run the shell in the build process or not.\n* `logger` is an object
+      used for logging the build process.\n* `timeout` is the maximum build time in
+      seconds.\n* `uid` and `gid` are the user and group IDs to run the build process
+      as.\n* `user` is the username for the user running the build process.\n* `nspawn_args`
+      is an empty list of arguments for unshare network namespace.\n* `unshare_net`
+      is a boolean value indicating whether to use unshare network namespace or not.\n*
+      `printOutput` is a boolean value indicating whether to print the build output
+      or not.\n\nThe script sets up these variables and creates a call to the `rpmbuild`
+      command inside a mock chroot environment.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      6:\u003c/b\u003e \u003ccode\u003eExecuting command: [''bash'', ''--login'',
+      ''-c'', ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec'']
+      with env {''TERM'': ''vt100'', ''SHELL'': ''/bin/bash'', ''HOME'': ''/builddir'',
+      ''HOSTNAME'': ''mock'', ''PATH'': ''/usr/bin:/bin:/usr/sbin:/sbin'', ''PROMPT_COMMAND'':
+      ''printf \"\\\\033]0;\u003cmock-chroot\u003e\\\\007\"'', ''PS1'': ''\u003cmock-chroot\u003e
+      \\\\s-\\\\v\\\\$ '', ''LANG'': ''C.UTF-8''} and shell False\n\u003c/code\u003e\n
+      The given RPM build log snippet describes the execution of a command using RPM
+      build system. The command being executed is ''rpmbuild'' with specific build
+      options and no dependencies (-bs --noclean --target noarch --nodeps). The command
+      is being run in a ''mock'' environment, which is indicated by the ''mock-chroot''
+      in the PS1 variable. The environment variables for TERM, SHELL, HOME, HOSTNAME,
+      PATH, PROMPT_COMMAND, and LANG are also shown. The shell for the command is
+      set to ''False'', suggesting that an interpreter other than a shell, such as
+      a Perl or Python script, may be used to execute the RPM build command.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      7:\u003c/b\u003e \u003ccode\u003eBuilding target platforms: noarch\n\u003c/code\u003e\n
+      The RPM build log snippet indicates that the build process is currently working
+      on creating target platforms of type ''noarch''. Noarch is a common RPM target
+      architecture that stands for \"no architecture\" or \"noarchitecture\". It is
+      used for building packages that do not have any architecture-specific components
+      and can be installed on any system regardless of its hardware architecture.
+      Therefore, this log message implies that the RPM package builder is in the process
+      of creating a ''noarch'' variant of the RPM package being built.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      9:\u003c/b\u003e \u003ccode\u003esetting SOURCE_DATE_EPOCH=1745280000\n\u003c/code\u003e\n
+      This RPM build log snippet sets the SOURCE_DATE_EPOCH variable to the value
+      1745280000. This variable is used by RPM to preserve the build time of the source
+      code during the build process. The value is in the number of seconds since the
+      Unix epoch (January 1, 1970).\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      10:\u003c/b\u003e \u003ccode\u003eRPM build errors:\nerror: Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\n    Bad file: /builddir/build/SOURCES/libtiff-4.4.0-CVE-2023-52356.patch:
+      No such file or directory\n\u003c/code\u003e\n The RPM build log indicates that
+      there were two build errors related to a patch file named \"libtiff-4.4.0-CVE-2023-52356.patch\".
+      The error message states that the file does not exist in the specified path
+      \"/builddir/build/SOURCES/\".\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      13:\u003c/b\u003e \u003ccode\u003eChild return code was: 1\n\u003c/code\u003e\n
+      The RPM build log snippet indicates that the child process during the RPM build
+      procedure returned an error code of 1. This is an indication that the build
+      process of the specified RPM package encountered an issue during execution.
+      The exact nature of the issue cannot be determined from this log snippet alone.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      14:\u003c/b\u003e \u003ccode\u003eEXCEPTION: [Error(\"Command failed: \\n #
+      bash --login -c ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec''\\n\",
+      1)]\n\u003c/code\u003e\n This RPM build log snippet indicates that an exception
+      has occurred during the RPM build process. The exception message states that
+      the command \"rpmbuild -bs --noclean --target noarch --nodeps /builddir/build/SPECS/libtiff.spec\"
+      has failed. The message is preceded by the number 14, which likely represents
+      the build number or sequence number of the build process. The failure of the
+      command is the only piece of information provided in this snippet. No further
+      details about the cause of the failure are given.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      15:\u003c/b\u003e \u003ccode\u003eTraceback (most recent call last):\n  File
+      \"/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py\", line 93,
+      in trace\n    result = func(*args, **kw)\n  File \"/usr/lib/python3.6/site-packages/mockbuild/util.py\",
+      line 612, in do_with_status\n    raise exception.Error(\"Command failed: \\n
+      # %s\\n%s\" % (cmd_pretty(command, env), output), child.returncode)\n\u003c/code\u003e\n
+      The snippet is an error message from a RPM build process using the Mockbuild
+      tool. The error indicates that a command executed during the build process has
+      failed. The specific error occurs in the \"do_with_status\" function, located
+      in the \"util.py\" file in the Mockbuild library.\n\nThe error message includes
+      a traceback, which shows that the error was raised by the \"Error\" exception
+      in the \"do_with_status\" function. The error message itself contains the command
+      that failed, indicated by `cmd_pretty(command, env)`, and the output of the
+      command. The return code of the command is also included in the error message.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      20:\u003c/b\u003e \u003ccode\u003emockbuild.exception.Error: Command failed:
+      \n # bash --login -c ''/usr/bin/rpmbuild -bs --noclean --target noarch --nodeps
+      /builddir/build/SPECS/libtiff.spec''\n\n\u003c/code\u003e\n The log snippet
+      indicates that an error occurred during the RPM build process for the \"libtiff\"
+      package using mockbuild. Specifically, the command \"rpmbuild -bs --noclean
+      --target noarch --nodeps /builddir/build/SPECS/libtiff.spec\" failed. The error
+      message is not provided in the log snippet, only that the command failed.\n\u003c/li\u003e\n\n\u003c/ul\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eLogs\u003c/summary\u003e\n  \u003cp\u003e\n    Log
+      Detective analyzed the following logs files to provide an explanation:\n  \u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://gitlab.com/api/v4/projects/23667077/jobs/9789376408/artifacts/kojilogs/noarch-5653506/noarch-5653507/build.log\"\u003ehttps://gitlab.com/api/v4/projects/23667077/jobs/9789376408/artifacts/kojilogs/noarch-5653506/noarch-5653507/build.log\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\n  \u003cp\u003e\n    Additional
+      logs are available from:\n    \u003cul\u003e\n    \u003cli\u003e\u003ca href=\"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/jobs/9789376408/artifacts/download\"\u003eartifacts.zip\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n  \u003c/p\u003e\n\n  \u003cp\u003e\n    Please
+      know that these log files are automatically removed after some\n    time, so
+      you might need a backup.\n  \u003c/p\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eHelp\u003c/summary\u003e\n  \u003cp\u003eDon''t
+      hesitate to reach out.\u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective\"\u003eUpstream\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective/issues\"\u003eIssue tracker\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://redhat.enterprise.slack.com/archives/C06DWNVKKDE\"\u003eSlack\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://log-detective.com/documentation\"\u003eDocumentation\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\u003c/details\u003e\n\n\n---\nThis
+      comment was created by [Log Detective][log-detective].\n\nWas the provided feedback
+      accurate and helpful? \u003cbr\u003ePlease vote with :thumbsup:\nor :thumbsdown:
+      to help us improve.\u003cbr\u003e\n\n\n\n[log-detective]: https://log-detective.com/\n[contact]:
+      https://github.com/fedora-copr","author":{"id":27211590,"username":"group_8794173_bot_029d2e92d461920a3695e55137a87774","public_email":null,"name":"****","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/c16bbfef2c60f8447985835437fc6442310027fe3e08fca895081b06f089abce?s=80\u0026d=identicon","web_url":"https://gitlab.com/group_8794173_bot_029d2e92d461920a3695e55137a87774"},"created_at":"2025-04-22T15:05:38.431Z","updated_at":"2025-04-22T15:21:21.994Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-22T15:11:00.983Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c793e92ba7ee70-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"b3e02019edf96e96f09b413bd0961ca9"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-52-lb-gprd
+      gitlab-sv: api-gke-us-east1-b
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"19d5ca3929f96c7d4246fafabe0b40eb","version":"1"}'
+      x-request-id: 19d5ca3929f96c7d4246fafabe0b40eb
+      x-runtime: '0.093378'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330
+- response:
+    auto_calculate_content_length: false
+    body: '[{"id":34008518,"name":"thumbsup","user":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"created_at":"2025-04-22T15:21:21.992Z","updated_at":"2025-04-22T15:21:21.992Z","awardable_id":2462509330,"awardable_type":"Note","url":null}]'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c793eb6f0bee70-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"7da7fe52d08c291e201c0b9f7350e6a4"
+      Link: <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
+        rel="first", <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
+        rel="last"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-59-lb-gprd
+      gitlab-sv: api-gke-us-east1-c
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"d9c583184741a0fb9e6124bafd4409e8","version":"1"}'
+      x-next-page: ''
+      x-page: '1'
+      x-per-page: '20'
+      x-prev-page: ''
+      x-request-id: d9c583184741a0fb9e6124bafd4409e8
+      x-runtime: '0.102920'
+      x-total: '1'
+      x-total-pages: '1'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2462509330/award_emoji
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":23667077,"description":"The libtiff rpms","name":"libtiff","name_with_namespace":"Red
+      Hat / centos-stream / rpms / libtiff","path":"libtiff","path_with_namespace":"redhat/centos-stream/rpms/libtiff","created_at":"2021-01-14T13:33:43.455Z","default_branch":"c10s","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:redhat/centos-stream/rpms/libtiff.git","http_url_to_repo":"https://gitlab.com/redhat/centos-stream/rpms/libtiff.git","web_url":"https://gitlab.com/redhat/centos-stream/rpms/libtiff","readme_url":null,"forks_count":6,"avatar_url":null,"star_count":2,"last_activity_at":"2025-05-05T16:06:55.870Z","namespace":{"id":8794173,"name":"rpms","path":"rpms","kind":"group","full_path":"redhat/centos-stream/rpms","parent_id":8706831,"avatar_url":null,"web_url":"https://gitlab.com/groups/redhat/centos-stream/rpms"},"container_registry_image_prefix":"registry.gitlab.com/redhat/centos-stream/rpms/libtiff","_links":{"self":"https://gitlab.com/api/v4/projects/23667077","merge_requests":"https://gitlab.com/api/v4/projects/23667077/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/23667077/repository/branches","labels":"https://gitlab.com/api/v4/projects/23667077/labels","events":"https://gitlab.com/api/v4/projects/23667077/events","members":"https://gitlab.com/api/v4/projects/23667077/members","cluster_agents":"https://gitlab.com/api/v4/projects/23667077/cluster_agents"},"marked_for_deletion_at":null,"marked_for_deletion_on":null,"packages_enabled":false,"empty_repo":false,"archived":false,"visibility":"public","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-01-15T13:33:43.485Z"},"repository_object_format":"sha1","issues_enabled":false,"merge_requests_enabled":true,"wiki_enabled":false,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"can_create_merge_request_in":true,"issues_access_level":"disabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"disabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","analytics_access_level":"enabled","container_registry_access_level":"enabled","security_and_compliance_access_level":"private","releases_access_level":"enabled","environments_access_level":"disabled","feature_flags_access_level":"disabled","infrastructure_access_level":"disabled","monitor_access_level":"disabled","model_experiments_access_level":"enabled","model_registry_access_level":"enabled","emails_disabled":false,"emails_enabled":true,"shared_runners_enabled":true,"lfs_enabled":false,"creator_id":6007577,"import_status":"none","description_html":"\u003cp
+      data-sourcepos=\"1:1-1:16\" dir=\"auto\"\u003eThe libtiff rpms\u003c/p\u003e","updated_at":"2025-05-07T15:22:25.055Z","ci_config_path":"global-tasks.yml@redhat/centos-stream/ci-cd/dist-git-gating-tests","public_jobs":true,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"request_access_enabled":false,"only_allow_merge_if_all_discussions_are_resolved":true,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"ff","merge_request_title_regex":null,"squash_option":"never","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"issue_branch_template":null,"warn_about_potentially_unwanted_characters":true,"autoclose_referenced_issues":true,"max_artifacts_size":null,"approvals_before_merge":0,"mirror":false,"external_authorization_classification_label":"","requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":false,"compliance_frameworks":[],"merge_requests_template":"","merge_pipelines_enabled":true,"merge_trains_enabled":true,"merge_trains_skip_train_allowed":false,"allow_pipeline_trigger_approve_deployment":false,"auto_duo_code_review_enabled":false,"permissions":{"project_access":null,"group_access":null}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c793ee8bfeee70-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"7bcd1b327972f0654df91402d94e9b70"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-02-lb-gprd
+      gitlab-sv: api-gke-us-east1-c
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"311d3aac523e042a4b553823b4eab4fd","version":"1"}'
+      x-request-id: 311d3aac523e042a4b553823b4eab4fd
+      x-runtime: '0.132673'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":"91090f16d27d4ad053f39990c5a47a592565d38f","individual_note":false,"notes":[{"id":2464715549,"type":"DiscussionNote","body":"The
+      package libtiff failed to build, here is a possible explanation why.\n\nPlease
+      know that the explanation was provided by AI and may be incorrect.\nIn this
+      case, we are 99.49% certain of the response :slight_smile:.\n\n The RPM build
+      process of the \"libtiff.spec\" package encountered an error during the `%build`
+      phase. Specifically, the command `/usr/bin/rpmbuild -bb --noclean --target x86_64
+      --nodeps /builddir/build/SPECS/libtiff.spec` failed to execute successfully,
+      as indicated by a non-zero exit status of 1. This error was reported by Mockbuild,
+      the RPM testing framework.\n\nThe log snippets do not provide enough information
+      to determine the exact cause of the build failure. Potential issues could include
+      missing or incompatible dependencies, incorrect build variables, or compilation
+      errors. It is recommended to review the build script in `/builddir/build/SPECS/libtiff.spec`
+      and the corresponding source code to identify and resolve the cause of the build
+      error. Additionally, checking the RPM dependency tree and build environment
+      variables may help identify any missing dependencies or misconfigurations.\n\n\u003cdetails\u003e\n\u003cul\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      10:\u003c/b\u003e \u003ccode\u003eChild return code was: 0\n\u003c/code\u003e\n
+      This log snippet indicates that a child process, likely a sub-build or dependency
+      during the RPM build process, has completed with an exit status code of 0. An
+      exit status code of 0 typically signifies a successful execution.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      450:\u003c/b\u003e \u003ccode\u003emake[2]: Entering directory ''/builddir/build/BUILD/tiff-4.4.0/port''\n\u003c/code\u003e\n
+      This RPM build log snippet indicates that the make process (specifically make[2])
+      is entering the directory ''/builddir/build/BUILD/tiff-4.4.0/port''. The number
+      preceding the message (450) represents the line number in the build script where
+      this event occurs.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine 710:\u003c/b\u003e
+      \u003ccode\u003egcc -DHAVE_CONFIG_H -I. -I../config -I../libtiff -I../port  -I../libtiff
+      -I../port -DTIFF_DISABLE_DEPRECATED   -O2 -flto=auto -ffat-lto-objects -fexceptions
+      -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2
+      -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong
+      -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64-v2 -mtune=generic
+      -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-strict-aliasing
+      -Wall -W -c -o fax2tiff.o fax2tiff.c\n\u003c/code\u003e\n The RPM build log
+      snippet represents a gcc compilation command with various flags and options
+      for building the ''fax2tiff.o'' object file from ''fax2tiff.c''.\n\nThe command
+      includes:\n- Compiler: gcc\n- Preprocessor flags:\n  - Include directories:
+      ., ../config, ../libtiff, ../port\n  - Defines: HAVE_CONFIG_H, TIFF_DISABLE_DEPRECATED\n\n-
+      Optimization flags:\n  - Compiler optimization: -O2\n  - Link-time optimization:
+      -flto=auto -ffat-lto-objects\n\n- Exception handling: -fexceptions\n\n- Debugging
+      flags: -g -grecord-gcc-switches\n\n- Warnings: -Wall -Werror=format-security\n\n-
+      Security: -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS\n\n- Hardened build:
+      -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1\n\n- Stack protection: -fstack-protector-strong\n\n-
+      Code protection: -fcf-protection\n\n- Aliasing: -fno-strict-aliasing\n\n- Target
+      architecture: -m64 -march=x86-64-v2 -mtune=generic\n\n- Asynchronous unwind
+      tables: -fasynchronous-unwind-tables\n\n- Stack clash protection: -fstack-clash-protection.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      786:\u003c/b\u003e \u003ccode\u003ecollect2: error: ld returned 1 exit status\n\u003c/code\u003e\n
+      The RPM build log snippet indicates an error during the linking (ld) stage of
+      the build process. The linker returned an exit status of 1, which signifies
+      an unsuccessful linking attempt. The exact cause of the error is not provided
+      in the snippet, but potential issues could include missing or incompatible libraries,
+      incorrect library versions, or syntax errors in the linker script. Further investigation
+      is required to determine the specific cause and resolve the issue.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      787:\u003c/b\u003e \u003ccode\u003emake[1]: *** [Makefile:653: tiffdither] Error
+      1\n\u003c/code\u003e\n The RPM build log snippet indicates that there was an
+      error during the execution of the \"make\" command, specifically with the target
+      \"tiffdither\" mentioned in the Makefile on line 653. The error resulted in
+      the make process exiting with a status code of 1.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      905:\u003c/b\u003e \u003ccode\u003etiffcrop.c: In function ''writeBufferToSeparateStrips'':\ntiffcrop.c:1244:28:
+      warning: comparison of integer expressions of different signedness: ''tsize_t''
+      {aka ''long int''} and ''long long unsigned int'' [-Wsign-compare]\n 1244 |           if
+      (scanlinesize \u003e 0x0ffffffffULL) {\n      |                            ^\n\u003c/code\u003e\n
+      The RPM build log snippet indicates a compiler warning during the build process
+      of the ''tiffcrop.c'' file. The warning message specifically mentions a comparison
+      of two data types with different signedness in line 1244 of the file: ''tsize_t''
+      (a long int type) and ''long long unsigned int''. The compiler is advising that
+      such a comparison may result in unexpected behavior due to potential sign conversions.
+      The warning message concludes with the location of the issue in the code.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      913:\u003c/b\u003e \u003ccode\u003emake: *** [Makefile:561: all-recursive] Error
+      1\n\u003c/code\u003e\n The RPM build log snippet indicates an error occurred
+      during the \"make all-recursive\" step in the RPM package build process. Specifically,
+      the \"make\" command returned an error status code 1. There is no further information
+      provided in the log snippet regarding the nature of the error.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      914:\u003c/b\u003e \u003ccode\u003eerror: Bad exit status from /var/tmp/rpm-tmp.JH52lB
+      (%build)\n\u003c/code\u003e\n The RPM build process encountered an error during
+      the `%build` phase of the build. Specifically, there was a \"Bad exit status\"
+      from the build script located at `/var/tmp/rpm-tmp.JH52lB`. This indicates that
+      the commands executed within the `%build` script did not complete successfully,
+      resulting in an error. The cause of this error is not apparent from the given
+      log snippet and requires further investigation into the contents of the `%build`
+      script and build environment.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      915:\u003c/b\u003e \u003ccode\u003eRPM build errors:\n    Bad exit status from
+      /var/tmp/rpm-tmp.JH52lB (%build)\n\u003c/code\u003e\n The given RPM build log
+      snippet indicates that during the build process, an error occurred in the %build
+      phase. The error resulted in an unsuccessful exit status from the file location
+      ''/var/tmp/rpm-tmp.JH52lB''. No further information is provided in the log regarding
+      the nature of the error.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      918:\u003c/b\u003e \u003ccode\u003eEXCEPTION: [Error(\"Command failed: \\n #
+      bash --login -c ''/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec''\\n\",
+      1)]\n\u003c/code\u003e\n The log snippet indicates an error occurred during
+      the RPM build process using the `rpmbuild` command. The command being executed
+      is:\n\n`/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec`\n\nThe
+      error message reads ''Command failed'' and is accompanied by an exception. The
+      cause of the command failure is not explicitly stated in the provided log snippet.
+      The error is marked with a non-zero exit status of 1.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      919:\u003c/b\u003e \u003ccode\u003eTraceback (most recent call last):\n  File
+      \"/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py\", line 93,
+      in trace\n    result = func(*args, **kw)\n  File \"/usr/lib/python3.6/site-packages/mockbuild/util.py\",
+      line 612, in do_with_status\n    raise exception.Error(\"Command failed: \\n
+      # %s\\n%s\" % (cmd_pretty(command, env), output), child.returncode)\n\u003c/code\u003e\n
+      This log snippet is a Python traceback indicating an error during the execution
+      of an RPM build using the mockbuild tool. The error occurred at the line where
+      the command execution failed in the mockbuild utility file (do_with_status,
+      line 612). The specific error message states that a command failed with the
+      given error message and return code. The command and its environment variables
+      can be found in the cmd_pretty function call. No further information is provided
+      in the log snippet.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine 924:\u003c/b\u003e
+      \u003ccode\u003emockbuild.exception.Error: Command failed: \n # bash --login
+      -c ''/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec''\n\n\u003c/code\u003e\n
+      The build log snippet indicates an error occurred during the RPM build process
+      of the \"libtiff.spec\" file, using the x86\\_64 architecture. The command \"rpmbuild
+      -bb --noclean --target x86\\_64 --nodeps /builddir/build/SPECS/libtiff.spec\"
+      failed to execute successfully. This error is reported by Mockbuild, an RPM
+      testing framework. No further information about the nature of the command failure
+      is provided in the log.\n\u003c/li\u003e\n\n\u003c/ul\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eLogs\u003c/summary\u003e\n  \u003cp\u003e\n    Log
+      Detective analyzed the following logs files to provide an explanation:\n  \u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://gitlab.com/api/v4/projects/23667077/jobs/9789725965/artifacts/kojilogs/noarch-5653531/x86_64-5653534/build.log\"\u003ehttps://gitlab.com/api/v4/projects/23667077/jobs/9789725965/artifacts/kojilogs/noarch-5653531/x86_64-5653534/build.log\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\n  \u003cp\u003e\n    Additional
+      logs are available from:\n    \u003cul\u003e\n    \u003cli\u003e\u003ca href=\"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/jobs/9789725965/artifacts/download\"\u003eartifacts.zip\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n  \u003c/p\u003e\n\n  \u003cp\u003e\n    Please
+      know that these log files are automatically removed after some\n    time, so
+      you might need a backup.\n  \u003c/p\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eHelp\u003c/summary\u003e\n  \u003cp\u003eDon''t
+      hesitate to reach out.\u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective\"\u003eUpstream\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective/issues\"\u003eIssue tracker\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://redhat.enterprise.slack.com/archives/C06DWNVKKDE\"\u003eSlack\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://log-detective.com/documentation\"\u003eDocumentation\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\u003c/details\u003e\n\n\n---\nThis
+      comment was created by [Log Detective][log-detective].\n\nWas the provided feedback
+      accurate and helpful? \u003cbr\u003ePlease vote with :thumbsup:\nor :thumbsdown:
+      to help us improve.\u003cbr\u003e\n\n\n\n[log-detective]: https://log-detective.com/\n[contact]:
+      https://github.com/fedora-copr","author":{"id":27211590,"username":"group_8794173_bot_029d2e92d461920a3695e55137a87774","public_email":null,"name":"****","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/c16bbfef2c60f8447985835437fc6442310027fe3e08fca895081b06f089abce?s=80\u0026d=identicon","web_url":"https://gitlab.com/group_8794173_bot_029d2e92d461920a3695e55137a87774"},"created_at":"2025-04-23T14:02:31.332Z","updated_at":"2025-04-23T14:12:56.887Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-23T14:12:56.887Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}},{"id":2464747301,"type":"DiscussionNote","body":"unsuccessful
+      analysis:\nerror that caused failure:\n/usr/bin/ld: ../libtiff/.libs/libtiff.so:
+      undefined reference to `TIFFErrorExtR''\ncollect2: error: ld returned 1 exit
+      status\nmake[1]: *** [Makefile:653: tiffdither] Error 1\n\nprimary source of
+      that error:\ntif_getimage.c: In function ''TIFFReadRGBAStripExt'':\ntif_getimage.c:2948:13:
+      warning: implicit declaration of function ''TIFFErrorExtR''; did you mean ''TIFFErrorExt''?
+      [-Wimplicit-function-declaration]\n 2948 |             TIFFErrorExtR(tif, TIFFFileName(tif),\n      |             ^~~~~~~~~~~~~\n      |             TIFFErrorExt","author":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"created_at":"2025-04-23T14:12:56.320Z","updated_at":"2025-04-23T14:12:56.887Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-23T14:12:56.887Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}}]}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c793f1fa01ee70-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"23b1b755a58fd004e2846cb538b22eac"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-43-lb-gprd
+      gitlab-sv: api-gke-us-east1-b
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"200bfe67d8fc9cc512e48f6c94bb3105","version":"1"}'
+      x-request-id: 200bfe67d8fc9cc512e48f6c94bb3105
+      x-runtime: '0.179788'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/discussions/91090f16d27d4ad053f39990c5a47a592565d38f
+- response:
+    auto_calculate_content_length: false
+    body: '{"id":2464715549,"type":"DiscussionNote","body":"The package libtiff failed
+      to build, here is a possible explanation why.\n\nPlease know that the explanation
+      was provided by AI and may be incorrect.\nIn this case, we are 99.49% certain
+      of the response :slight_smile:.\n\n The RPM build process of the \"libtiff.spec\"
+      package encountered an error during the `%build` phase. Specifically, the command
+      `/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec`
+      failed to execute successfully, as indicated by a non-zero exit status of 1.
+      This error was reported by Mockbuild, the RPM testing framework.\n\nThe log
+      snippets do not provide enough information to determine the exact cause of the
+      build failure. Potential issues could include missing or incompatible dependencies,
+      incorrect build variables, or compilation errors. It is recommended to review
+      the build script in `/builddir/build/SPECS/libtiff.spec` and the corresponding
+      source code to identify and resolve the cause of the build error. Additionally,
+      checking the RPM dependency tree and build environment variables may help identify
+      any missing dependencies or misconfigurations.\n\n\u003cdetails\u003e\n\u003cul\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      10:\u003c/b\u003e \u003ccode\u003eChild return code was: 0\n\u003c/code\u003e\n
+      This log snippet indicates that a child process, likely a sub-build or dependency
+      during the RPM build process, has completed with an exit status code of 0. An
+      exit status code of 0 typically signifies a successful execution.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      450:\u003c/b\u003e \u003ccode\u003emake[2]: Entering directory ''/builddir/build/BUILD/tiff-4.4.0/port''\n\u003c/code\u003e\n
+      This RPM build log snippet indicates that the make process (specifically make[2])
+      is entering the directory ''/builddir/build/BUILD/tiff-4.4.0/port''. The number
+      preceding the message (450) represents the line number in the build script where
+      this event occurs.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine 710:\u003c/b\u003e
+      \u003ccode\u003egcc -DHAVE_CONFIG_H -I. -I../config -I../libtiff -I../port  -I../libtiff
+      -I../port -DTIFF_DISABLE_DEPRECATED   -O2 -flto=auto -ffat-lto-objects -fexceptions
+      -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2
+      -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong
+      -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64-v2 -mtune=generic
+      -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-strict-aliasing
+      -Wall -W -c -o fax2tiff.o fax2tiff.c\n\u003c/code\u003e\n The RPM build log
+      snippet represents a gcc compilation command with various flags and options
+      for building the ''fax2tiff.o'' object file from ''fax2tiff.c''.\n\nThe command
+      includes:\n- Compiler: gcc\n- Preprocessor flags:\n  - Include directories:
+      ., ../config, ../libtiff, ../port\n  - Defines: HAVE_CONFIG_H, TIFF_DISABLE_DEPRECATED\n\n-
+      Optimization flags:\n  - Compiler optimization: -O2\n  - Link-time optimization:
+      -flto=auto -ffat-lto-objects\n\n- Exception handling: -fexceptions\n\n- Debugging
+      flags: -g -grecord-gcc-switches\n\n- Warnings: -Wall -Werror=format-security\n\n-
+      Security: -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS\n\n- Hardened build:
+      -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1\n\n- Stack protection: -fstack-protector-strong\n\n-
+      Code protection: -fcf-protection\n\n- Aliasing: -fno-strict-aliasing\n\n- Target
+      architecture: -m64 -march=x86-64-v2 -mtune=generic\n\n- Asynchronous unwind
+      tables: -fasynchronous-unwind-tables\n\n- Stack clash protection: -fstack-clash-protection.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      786:\u003c/b\u003e \u003ccode\u003ecollect2: error: ld returned 1 exit status\n\u003c/code\u003e\n
+      The RPM build log snippet indicates an error during the linking (ld) stage of
+      the build process. The linker returned an exit status of 1, which signifies
+      an unsuccessful linking attempt. The exact cause of the error is not provided
+      in the snippet, but potential issues could include missing or incompatible libraries,
+      incorrect library versions, or syntax errors in the linker script. Further investigation
+      is required to determine the specific cause and resolve the issue.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      787:\u003c/b\u003e \u003ccode\u003emake[1]: *** [Makefile:653: tiffdither] Error
+      1\n\u003c/code\u003e\n The RPM build log snippet indicates that there was an
+      error during the execution of the \"make\" command, specifically with the target
+      \"tiffdither\" mentioned in the Makefile on line 653. The error resulted in
+      the make process exiting with a status code of 1.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      905:\u003c/b\u003e \u003ccode\u003etiffcrop.c: In function ''writeBufferToSeparateStrips'':\ntiffcrop.c:1244:28:
+      warning: comparison of integer expressions of different signedness: ''tsize_t''
+      {aka ''long int''} and ''long long unsigned int'' [-Wsign-compare]\n 1244 |           if
+      (scanlinesize \u003e 0x0ffffffffULL) {\n      |                            ^\n\u003c/code\u003e\n
+      The RPM build log snippet indicates a compiler warning during the build process
+      of the ''tiffcrop.c'' file. The warning message specifically mentions a comparison
+      of two data types with different signedness in line 1244 of the file: ''tsize_t''
+      (a long int type) and ''long long unsigned int''. The compiler is advising that
+      such a comparison may result in unexpected behavior due to potential sign conversions.
+      The warning message concludes with the location of the issue in the code.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      913:\u003c/b\u003e \u003ccode\u003emake: *** [Makefile:561: all-recursive] Error
+      1\n\u003c/code\u003e\n The RPM build log snippet indicates an error occurred
+      during the \"make all-recursive\" step in the RPM package build process. Specifically,
+      the \"make\" command returned an error status code 1. There is no further information
+      provided in the log snippet regarding the nature of the error.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      914:\u003c/b\u003e \u003ccode\u003eerror: Bad exit status from /var/tmp/rpm-tmp.JH52lB
+      (%build)\n\u003c/code\u003e\n The RPM build process encountered an error during
+      the `%build` phase of the build. Specifically, there was a \"Bad exit status\"
+      from the build script located at `/var/tmp/rpm-tmp.JH52lB`. This indicates that
+      the commands executed within the `%build` script did not complete successfully,
+      resulting in an error. The cause of this error is not apparent from the given
+      log snippet and requires further investigation into the contents of the `%build`
+      script and build environment.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      915:\u003c/b\u003e \u003ccode\u003eRPM build errors:\n    Bad exit status from
+      /var/tmp/rpm-tmp.JH52lB (%build)\n\u003c/code\u003e\n The given RPM build log
+      snippet indicates that during the build process, an error occurred in the %build
+      phase. The error resulted in an unsuccessful exit status from the file location
+      ''/var/tmp/rpm-tmp.JH52lB''. No further information is provided in the log regarding
+      the nature of the error.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      918:\u003c/b\u003e \u003ccode\u003eEXCEPTION: [Error(\"Command failed: \\n #
+      bash --login -c ''/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec''\\n\",
+      1)]\n\u003c/code\u003e\n The log snippet indicates an error occurred during
+      the RPM build process using the `rpmbuild` command. The command being executed
+      is:\n\n`/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec`\n\nThe
+      error message reads ''Command failed'' and is accompanied by an exception. The
+      cause of the command failure is not explicitly stated in the provided log snippet.
+      The error is marked with a non-zero exit status of 1.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine
+      919:\u003c/b\u003e \u003ccode\u003eTraceback (most recent call last):\n  File
+      \"/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py\", line 93,
+      in trace\n    result = func(*args, **kw)\n  File \"/usr/lib/python3.6/site-packages/mockbuild/util.py\",
+      line 612, in do_with_status\n    raise exception.Error(\"Command failed: \\n
+      # %s\\n%s\" % (cmd_pretty(command, env), output), child.returncode)\n\u003c/code\u003e\n
+      This log snippet is a Python traceback indicating an error during the execution
+      of an RPM build using the mockbuild tool. The error occurred at the line where
+      the command execution failed in the mockbuild utility file (do_with_status,
+      line 612). The specific error message states that a command failed with the
+      given error message and return code. The command and its environment variables
+      can be found in the cmd_pretty function call. No further information is provided
+      in the log snippet.\n\u003c/li\u003e\n\n\u003cli\u003e\n\u003cb\u003eLine 924:\u003c/b\u003e
+      \u003ccode\u003emockbuild.exception.Error: Command failed: \n # bash --login
+      -c ''/usr/bin/rpmbuild -bb --noclean --target x86_64 --nodeps /builddir/build/SPECS/libtiff.spec''\n\n\u003c/code\u003e\n
+      The build log snippet indicates an error occurred during the RPM build process
+      of the \"libtiff.spec\" file, using the x86\\_64 architecture. The command \"rpmbuild
+      -bb --noclean --target x86\\_64 --nodeps /builddir/build/SPECS/libtiff.spec\"
+      failed to execute successfully. This error is reported by Mockbuild, an RPM
+      testing framework. No further information about the nature of the command failure
+      is provided in the log.\n\u003c/li\u003e\n\n\u003c/ul\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eLogs\u003c/summary\u003e\n  \u003cp\u003e\n    Log
+      Detective analyzed the following logs files to provide an explanation:\n  \u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://gitlab.com/api/v4/projects/23667077/jobs/9789725965/artifacts/kojilogs/noarch-5653531/x86_64-5653534/build.log\"\u003ehttps://gitlab.com/api/v4/projects/23667077/jobs/9789725965/artifacts/kojilogs/noarch-5653531/x86_64-5653534/build.log\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\n  \u003cp\u003e\n    Additional
+      logs are available from:\n    \u003cul\u003e\n    \u003cli\u003e\u003ca href=\"https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/jobs/9789725965/artifacts/download\"\u003eartifacts.zip\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n  \u003c/p\u003e\n\n  \u003cp\u003e\n    Please
+      know that these log files are automatically removed after some\n    time, so
+      you might need a backup.\n  \u003c/p\u003e\n\u003c/details\u003e\n\n\u003cdetails\u003e\n  \u003csummary\u003eHelp\u003c/summary\u003e\n  \u003cp\u003eDon''t
+      hesitate to reach out.\u003c/p\u003e\n\n  \u003cul\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective\"\u003eUpstream\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://github.com/fedora-copr/logdetective/issues\"\u003eIssue tracker\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://redhat.enterprise.slack.com/archives/C06DWNVKKDE\"\u003eSlack\u003c/a\u003e\u003c/li\u003e\n    \u003cli\u003e\u003ca
+      href=\"https://log-detective.com/documentation\"\u003eDocumentation\u003c/a\u003e\u003c/li\u003e\n  \u003c/ul\u003e\n\u003c/details\u003e\n\n\n---\nThis
+      comment was created by [Log Detective][log-detective].\n\nWas the provided feedback
+      accurate and helpful? \u003cbr\u003ePlease vote with :thumbsup:\nor :thumbsdown:
+      to help us improve.\u003cbr\u003e\n\n\n\n[log-detective]: https://log-detective.com/\n[contact]:
+      https://github.com/fedora-copr","author":{"id":27211590,"username":"group_8794173_bot_029d2e92d461920a3695e55137a87774","public_email":null,"name":"****","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/c16bbfef2c60f8447985835437fc6442310027fe3e08fca895081b06f089abce?s=80\u0026d=identicon","web_url":"https://gitlab.com/group_8794173_bot_029d2e92d461920a3695e55137a87774"},"created_at":"2025-04-23T14:02:31.332Z","updated_at":"2025-04-23T14:12:56.887Z","system":false,"noteable_id":378085175,"noteable_type":"MergeRequest","project_id":23667077,"resolvable":true,"resolved":true,"resolved_by":{"id":8918302,"username":"mhlavink","public_email":"","name":"mhlavink","state":"active","locked":false,"avatar_url":"https://secure.gravatar.com/avatar/6a3d36db2ed39394904df2a56731f61ffcc55b153ecab0b42cf22ea63e83b9ca?s=80\u0026d=identicon","web_url":"https://gitlab.com/mhlavink"},"resolved_at":"2025-04-23T14:12:56.887Z","confidential":false,"internal":false,"imported":false,"imported_from":"none","noteable_iid":26,"commands_changes":{}}'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c793f6396fee70-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"4300ea10b3d9f8472c79f7631e87fe00"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-28-lb-gprd
+      gitlab-sv: api-gke-us-east1-b
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"37ec87060c58068a325d72655160ed83","version":"1"}'
+      x-request-id: 37ec87060c58068a325d72655160ed83
+      x-runtime: '0.111809'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549
+- response:
+    auto_calculate_content_length: false
+    body: '[]'
+    content_type: application/json
+    headers:
+      CF-Cache-Status: MISS
+      CF-Ray: 93c793fa2f9fee70-MXP
+      Cache-Control: max-age=0, private, must-revalidate
+      ETag: W/"f19fe711af9debb1837206f66dccbedd"
+      Link: <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
+        rel="first", <https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549/award_emoji?id=23667077&merge_request_iid=26&page=1&per_page=20>;
+        rel="last"
+      Strict-Transport-Security: max-age=31536000
+      Transfer-Encoding: chunked
+      Vary: Origin, Accept-Encoding
+      content-security-policy: default-src 'none'
+      gitlab-lb: haproxy-main-38-lb-gprd
+      gitlab-sv: api-gke-us-east1-c
+      nel: '{"max_age": 0}'
+      referrer-policy: strict-origin-when-cross-origin
+      x-content-type-options: nosniff
+      x-frame-options: SAMEORIGIN
+      x-gitlab-meta: '{"correlation_id":"9b1076578028474ab15a647131dd4b99","version":"1"}'
+      x-next-page: ''
+      x-page: '1'
+      x-per-page: '20'
+      x-prev-page: ''
+      x-request-id: 9b1076578028474ab15a647131dd4b99
+      x-runtime: '0.086870'
+      x-total: '1'
+      x-total-pages: '1'
+    method: GET
+    status: 200
+    url: https://gitlab.com/api/v4/projects/23667077/merge_requests/26/notes/2464715549/award_emoji

--- a/tests/full.fmf
+++ b/tests/full.fmf
@@ -12,3 +12,5 @@ component:
 test: pytest-3 -vv .
 
 duration: 30m
+
+path: /

--- a/tests/test_database_models_metrics.py
+++ b/tests/test_database_models_metrics.py
@@ -7,7 +7,7 @@ from test_helpers import (
     PopulateDatabase,
 )
 
-from logdetective.server.remote_log import RemoteLog
+from logdetective.server.compressors import RemoteLogCompressor
 from logdetective.server.database.models import (
     AnalyzeRequestMetrics,
     EndpointType,
@@ -20,7 +20,7 @@ def test_create_and_update_AnalyzeRequestMetrics():
         remote_log_content = "Some log for a failed build"
         metrics_id = AnalyzeRequestMetrics.create(
             endpoint=EndpointType.ANALYZE,
-            compressed_log=RemoteLog.zip_text(remote_log_content),
+            compressed_log=RemoteLogCompressor.zip_text(remote_log_content),
         )
         assert metrics_id == 1
         AnalyzeRequestMetrics.update(
@@ -41,7 +41,7 @@ def test_create_and_update_AnalyzeRequestMetrics():
         assert metrics is not None
         assert metrics.response_length == 0
         assert metrics.response_certainty == 37.7
-        assert RemoteLog.unzip(metrics.compressed_log) == remote_log_content
+        assert RemoteLogCompressor.unzip(metrics.compressed_log) == remote_log_content
 
         # link metrics to a mr job
         metrics.add_mr_job(Forge.gitlab_com, 123, 456, "789")

--- a/tests/test_emojis.py
+++ b/tests/test_emojis.py
@@ -1,0 +1,106 @@
+import os
+import asyncio
+import datetime
+
+import gitlab
+import responses
+from responses import _recorder
+
+from test_helpers import (
+    DatabaseFactory,
+)
+
+from logdetective.server.models import TimePeriod
+from logdetective.server.database.models import (
+    GitlabMergeRequestJobs,
+    Comments,
+    Reactions,
+    Forge,
+)
+
+from logdetective.server.emoji import collect_emojis
+
+# the token is needed only when registering responses
+# export your own private token to be able to re-register responses
+gitlab_conn = gitlab.Gitlab(
+    url="https://gitlab.com/", private_token=os.environ.get("LOGDETECTIVE_TOKEN")
+)
+
+COLLECT_EMOJIS_RESPONSES = "tests/data/test_collect_emojis.yaml"
+
+
+def populate_db_with_comments_for_libtiff_mr_26():
+    """Mock db using data related with the following MR
+    https://gitlab.com/redhat/centos-stream/rpms/libtiff/-/merge_requests/26
+    """
+    with DatabaseFactory().make_new_db() as session_factory:
+        with session_factory() as db_session:
+            db_session.add(
+                GitlabMergeRequestJobs(
+                    id=11,
+                    forge=Forge.gitlab_com,
+                    project_id=23667077,
+                    mr_iid=26,
+                    job_id=1,
+                )
+            )
+            db_session.commit()
+            db_session.add(
+                Comments(
+                    forge=Forge.gitlab_com,
+                    merge_request_job_id=11,
+                    comment_id=2462509330,
+                    created_at=datetime.datetime.now(datetime.timezone.utc),
+                )
+            )
+            db_session.commit()
+
+            db_session.add(
+                GitlabMergeRequestJobs(
+                    id=12,
+                    forge=Forge.gitlab_com,
+                    project_id=23667077,
+                    mr_iid=26,
+                    job_id=2,
+                )
+            )
+            db_session.commit()
+            db_session.add(
+                Comments(
+                    forge=Forge.gitlab_com,
+                    merge_request_job_id=12,
+                    comment_id=2464715549,
+                    created_at=datetime.datetime.now(datetime.timezone.utc),
+                )
+            )
+            db_session.commit()
+
+            yield db_session
+
+
+def _test_collect_emojis():
+    for db_session in populate_db_with_comments_for_libtiff_mr_26():
+        asyncio.run(collect_emojis(gitlab_conn, TimePeriod(hours=1)))
+        reactions = db_session.query(Reactions).all()
+        assert len(reactions) == 2
+        types = [reaction.reaction_type for reaction in reactions]
+        assert "thumbsup" in types
+        assert "thumbsdown" in types
+
+
+@_recorder.record(file_path=COLLECT_EMOJIS_RESPONSES)
+def record_responses_for_collect_emojis():
+    _test_collect_emojis()
+
+
+@responses.activate
+def test_collect_emojis():
+    responses._add_from_file(file_path=COLLECT_EMOJIS_RESPONSES)
+    _test_collect_emojis()
+
+
+if __name__ == "__main__":
+    # call the module to re-record responses for tests
+    # responses are recorded with the wrong content-type
+    # substitute text/plain with application/json
+    record_responses_for_collect_emojis()

--- a/tests/test_emojis.py
+++ b/tests/test_emojis.py
@@ -104,7 +104,7 @@ def test_collect_emojis():
 def _test_collect_emojis_for_mr():
     for db_session in populate_db_with_comments_for_libtiff_mr_26():
         asyncio.run(
-            collect_emojis_for_mr(23667077, 26, gitlab_conn, TimePeriod(hours=1))
+            collect_emojis_for_mr(23667077, 26, gitlab_conn)
         )
         reactions = db_session.query(Reactions).all()
         assert len(reactions) == 2

--- a/tests/test_emojis.py
+++ b/tests/test_emojis.py
@@ -50,7 +50,7 @@ def populate_db_with_comments_for_libtiff_mr_26():
                 Comments(
                     forge=Forge.gitlab_com,
                     merge_request_job_id=11,
-                    comment_id=2462509330,
+                    comment_id="1ba1f46903f2b4e0573d514ed6d2cae29ab040f6",  # note id 2462509330
                     created_at=datetime.datetime.now(datetime.timezone.utc),
                 )
             )
@@ -70,7 +70,7 @@ def populate_db_with_comments_for_libtiff_mr_26():
                 Comments(
                     forge=Forge.gitlab_com,
                     merge_request_job_id=12,
-                    comment_id=2464715549,
+                    comment_id="91090f16d27d4ad053f39990c5a47a592565d38f",  # note id 2464715549
                     created_at=datetime.datetime.now(datetime.timezone.utc),
                 )
             )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -9,10 +9,9 @@ from flexmock import flexmock
 
 from logdetective.server.models import Response, Explanation
 from logdetective.server.database import base
-from logdetective.server.remote_log import RemoteLog
 from logdetective.server.database.base import init, destroy
 from logdetective.server.database.models import AnalyzeRequestMetrics, EndpointType
-from logdetective.server.compressors import LLMResponseCompressor
+from logdetective.server.compressors import LLMResponseCompressor, RemoteLogCompressor
 
 
 class DatabaseFactory:  # pylint: disable=too-few-public-methods
@@ -61,7 +60,9 @@ class PopulateDatabase:  # pylint: disable=too-few-public-methods
             while current_time < end_time:
                 id_ = AnalyzeRequestMetrics.create(
                     endpoint=endpoint_type,
-                    compressed_log=RemoteLog.zip_text("Some log for a failed build"),
+                    compressed_log=RemoteLogCompressor.zip_text(
+                        "Some log for a failed build"
+                    ),
                     request_received_at=current_time,
                 )
                 response_time = current_time + datetime.timedelta(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,13 +5,13 @@ import aiohttp
 import aioresponses
 import pytest
 
-from logdetective.server.server import (
+from logdetective.server.config import SERVER_CONFIG
+from logdetective.server.llm import (
     submit_to_llm_endpoint,
     submit_text_chat_completions,
-    SERVER_CONFIG
 )
-from logdetective.server.remote_log import RemoteLog
-from logdetective.server.utils import load_server_config
+from logdetective.remote_log import RemoteLog
+from logdetective.server.config import load_server_config
 
 
 def test_loading_config():
@@ -130,13 +130,10 @@ async def test_submit_text_chat_completions():
     mock_response = b"123"
     SERVER_CONFIG.inference.url = "http://localhost:8080"
     with aioresponses.aioresponses() as mock:
-        mock.post('http://localhost:8080/v1/chat/completions', status=200, body=mock_response)
+        mock.post(
+            "http://localhost:8080/v1/chat/completions", status=200, body=mock_response
+        )
         async with aiohttp.ClientSession() as http:
-            response = await submit_text_chat_completions(
-                http,
-                "asd",
-                {},
-                stream=True
-            )
+            response = await submit_text_chat_completions(http, "asd", {}, stream=True)
             async for x in response.content:
                 assert x == mock_response

--- a/tests/test_server_remote_log.py
+++ b/tests/test_server_remote_log.py
@@ -2,7 +2,8 @@ import pytest
 import aiohttp
 import aioresponses
 
-from logdetective.server.remote_log import RemoteLog
+from logdetective.remote_log import RemoteLog
+from logdetective.server.compressors import RemoteLogCompressor
 
 
 @pytest.mark.asyncio
@@ -16,10 +17,11 @@ async def test_server_remote_log():
         )
 
         remote_log = RemoteLog("https://example.com/logs/123", http_session)
+        compressor = RemoteLogCompressor(remote_log)
         content = await remote_log.content
         assert content
         assert mock_response in content
-        zip_data = await remote_log.zip_content()
-        url_text = remote_log.unzip(zip_data)
+        zip_data = await compressor.zip_content()
+        url_text = compressor.unzip(zip_data)
         assert url_text
         assert mock_response in url_text

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,9 +9,9 @@ from logdetective.utils import (
     format_snippets,
     load_prompts,
 )
-from logdetective.server.utils import format_analyzed_snippets
+from logdetective.server.llm import format_analyzed_snippets
 from logdetective.server.models import AnalyzedSnippet, Explanation
-from logdetective.server.remote_log import RemoteLog
+from logdetective.remote_log import RemoteLog
 from logdetective.models import PromptConfig
 from logdetective import constants
 
@@ -72,7 +72,10 @@ def test_load_prompts_wrong_path():
     assert prompts_config.prompt_template == constants.PROMPT_TEMPLATE
     assert prompts_config.snippet_prompt_template == constants.SNIPPET_PROMPT_TEMPLATE
     assert prompts_config.prompt_template_staged == constants.PROMPT_TEMPLATE_STAGED
-    assert prompts_config.summarization_prompt_template == constants.SUMMARIZATION_PROMPT_TEMPLATE
+    assert (
+        prompts_config.summarization_prompt_template
+        == constants.SUMMARIZATION_PROMPT_TEMPLATE  # noqa: W503 flake vs lint
+    )
 
 
 def test_load_prompts_correct_path():
@@ -88,14 +91,17 @@ def test_load_prompts_correct_path():
     assert prompts_config.prompt_template == "This is basic template."
     assert prompts_config.snippet_prompt_template == "This is template for snippets."
     assert prompts_config.prompt_template_staged == constants.PROMPT_TEMPLATE_STAGED
-    assert prompts_config.summarization_prompt_template == constants.SUMMARIZATION_PROMPT_TEMPLATE
+    assert (
+        prompts_config.summarization_prompt_template
+        == constants.SUMMARIZATION_PROMPT_TEMPLATE  # noqa: W503 flake vs lint
+    )
 
 
 @pytest.mark.asyncio
 async def test_get_url_content():
     mock_response = "123"
     with aioresponses.aioresponses() as mock:
-        mock.get('http://localhost:8999/', status=200, body=mock_response)
+        mock.get("http://localhost:8999/", status=200, body=mock_response)
         async with aiohttp.ClientSession() as http:
             url_output_cr = RemoteLog("http://localhost:8999/", http).get_url_content()
             url_output = await url_output_cr


### PR DESCRIPTION
This will listen for webhook notifications from Gitlab and trigger a re-read of all emojis associated with a merge request.

It's based atop #254 and #255 

Note: there appear to be bugs in #254 related to removing emojis (possibly only related to removing the last instance of a particular emoji). I need to do more tests tomorrow with the help of another logged-in user.