### PR TITLE
Substitute backoff.expo with backoff.constant

### DIFF
--- a/logdetective/server/llm.py
+++ b/logdetective/server/llm.py
@@ -115,7 +115,7 @@ def we_give_up(details: backoff._typing.Details):
 
 
 @backoff.on_exception(
-    backoff.expo,
+    lambda: backoff.constant([10, 30, 120]),
     aiohttp.ClientResponseError,
     max_tries=3,
     giveup=should_we_giveup,


### PR DESCRIPTION
On production server the llm takes 30 seconds on avarage to give a response.
If llm is not responding wait twice the response time, then 4 times and then 10 times.