### PR TITLE
add excluded_packages to the GeneralConfig

### DIFF
--- a/logdetective/server/gitlab.py
+++ b/logdetective/server/gitlab.py
@@ -118,7 +118,7 @@ def is_eligible_package(project_name: str):
     # First check the allow-list. If it's not allowed, we deny.
     allowed = False
     for pattern in SERVER_CONFIG.general.packages:
-        print(f"include {pattern}")
+        LOG.debug("include %s", pattern)
         if re.search(pattern, project_name):
             allowed = True
             break
@@ -128,7 +128,7 @@ def is_eligible_package(project_name: str):
 
     # Next, check the deny-list. If it was allowed before, but denied here, we deny.
     for pattern in SERVER_CONFIG.general.excluded_packages:
-        print(f"Exclude {pattern}")
+        LOG.debug("exclude %s", pattern)
         if re.search(pattern, project_name):
             return False
 

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -254,6 +254,7 @@ class GeneralConfig(BaseModel):
     """General config options for Log Detective"""
 
     packages: List[str] = None
+    excluded_packages: List[str] = None
     devmode: bool = False
     sentry_dsn: HttpUrl | None = None
 
@@ -263,6 +264,7 @@ class GeneralConfig(BaseModel):
             return
 
         self.packages = data.get("packages", [])
+        self.excluded_packages = data.get("excluded_packages", [])
         self.devmode = data.get("devmode", False)
         self.sentry_dsn = data.get("sentry_dsn")
 


### PR DESCRIPTION
Fixes
```
  File "/src/logdetective/server/gitlab.py", line 130, in is_eligible_package
    for pattern in SERVER_CONFIG.general.excluded_packages:
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/pydantic/main.py", line 891, in __getattr__
    raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')
AttributeError: 'GeneralConfig' object has no attribute 'excluded_packages'
include .*
```