### PR TITLE
Allow running of snippet analysis on separate endpoints.

### DIFF
--- a/logdetective/server/llm.py
+++ b/logdetective/server/llm.py
@@ -245,8 +245,8 @@ async def perform_staged_analysis(
         submit_text(
             http,
             PROMPT_CONFIG.snippet_prompt_template.format(s),
-            model=SERVER_CONFIG.inference.model,
-            max_tokens=SERVER_CONFIG.inference.max_tokens,
+            model=SERVER_CONFIG.snippet_inference.model,
+            max_tokens=SERVER_CONFIG.snippet_inference.max_tokens,
         )
         for s in log_summary
     ]

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -288,6 +288,7 @@ class Config(BaseModel):
 
     log: LogConfig = LogConfig()
     inference: InferenceConfig = InferenceConfig()
+    snippet_inference: InferenceConfig = InferenceConfig()
     extractor: ExtractorConfig = ExtractorConfig()
     gitlab: GitLabConfig = GitLabConfig()
     general: GeneralConfig = GeneralConfig()
@@ -303,6 +304,11 @@ class Config(BaseModel):
         self.extractor = ExtractorConfig(data.get("extractor"))
         self.gitlab = GitLabConfig(data.get("gitlab"))
         self.general = GeneralConfig(data.get("general"))
+
+        if snippet_inference := data.get("snippet_inference", None):
+            self.snippet_inference = InferenceConfig(snippet_inference)
+        else:
+            self.snippet_inference = self.inference
 
 
 class TimePeriod(BaseModel):

--- a/server/config.yml
+++ b/server/config.yml
@@ -9,6 +9,13 @@ inference:
   # url: https://mistral-7b-instruct-v0-3--apicast-production.apps.int.stc.ai.prod.us-east-1.aws.paas.redhat.com/
   api_token: ""
   requests_per_minute: 6
+# Separate LLM endpoint for snippet analysis, optional
+# snippet_inference:
+#   max_tokens: -1
+#   log_probs: 1
+#   url: http://llama-cpp-server:8000
+#   api_token: ""
+#   requests_per_minute: 6
 extractor:
   context: true
   max_clusters: 25


### PR DESCRIPTION
If no inference endpoint for snippets is provided, the general inference endpoint is used instead, thus preserving the existing behavior.