### PR TITLE
Refactoring to use OpenAI library

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -22,7 +22,7 @@ RUN dnf install -y \
     python3-sentry-sdk+fastapi \
     && dnf clean all
 # the newest 0.2.86 fails to build, it seems vendored llama-cpp is missing in the archive
-RUN pip3 install aiolimiter llama_cpp_python==0.2.85 sse-starlette starlette-context \
+RUN pip3 install aiolimiter llama_cpp_python==0.2.85 sse-starlette starlette-context openai==1.82.1 \
     && mkdir /src
 
 # uncomment below if you need to download the model, otherwise just bindmount your local

--- a/logdetective/server/config.py
+++ b/logdetective/server/config.py
@@ -1,8 +1,10 @@
 import os
 import logging
 import yaml
+from openai import AsyncOpenAI
+
 from logdetective.utils import load_prompts
-from logdetective.server.models import Config
+from logdetective.server.models import Config, InferenceConfig
 
 
 def load_server_config(path: str | None) -> Config:
@@ -49,6 +51,14 @@ def get_log(config: Config):
     return log
 
 
+def get_openai_api_client(ineference_config: InferenceConfig):
+    """Set up AsyncOpenAI client with default configuration.
+    """
+    return AsyncOpenAI(
+        api_key=ineference_config.api_token,
+        base_url=ineference_config.url)
+
+
 SERVER_CONFIG_PATH = os.environ.get("LOGDETECTIVE_SERVER_CONF", None)
 SERVER_PROMPT_PATH = os.environ.get("LOGDETECTIVE_PROMPTS", None)
 
@@ -56,3 +66,5 @@ SERVER_CONFIG = load_server_config(SERVER_CONFIG_PATH)
 PROMPT_CONFIG = load_prompts(SERVER_PROMPT_PATH)
 
 LOG = get_log(SERVER_CONFIG)
+
+CLIENT = get_openai_api_client(SERVER_CONFIG.inference)

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -136,7 +136,9 @@ class InferenceConfig(BaseModel):  # pylint: disable=too-many-instance-attribute
     max_tokens: int = -1
     log_probs: bool = True
     url: str = ""
-    api_token: str = ""
+    # OpenAI client library requires a string to be specified for API token
+    # even if it is not checked on the server side
+    api_token: str = "None"
     model: str = ""
     temperature: NonNegativeFloat = DEFAULT_TEMPERATURE
     max_queue_size: int = LLM_DEFAULT_MAX_QUEUE_SIZE
@@ -153,7 +155,7 @@ class InferenceConfig(BaseModel):  # pylint: disable=too-many-instance-attribute
         self.log_probs = data.get("log_probs", True)
         self.url = data.get("url", "")
         self.http_timeout = data.get("http_timeout", 5.0)
-        self.api_token = data.get("api_token", "")
+        self.api_token = data.get("api_token", "None")
         self.model = data.get("model", "default-model")
         self.temperature = data.get("temperature", DEFAULT_TEMPERATURE)
         self.max_queue_size = data.get("max_queue_size", LLM_DEFAULT_MAX_QUEUE_SIZE)

--- a/poetry.lock
+++ b/poetry.lock
@@ -456,6 +456,17 @@ files = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+description = "Distro - an OS platform information API"
+optional = true
+python-versions = ">=3.6"
+files = [
+    {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
+    {file = "distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"},
+]
+
+[[package]]
 name = "drain3"
 version = "0.9.11"
 description = "Persistent & streaming log template miner"
@@ -803,6 +814,17 @@ docs = ["Sphinx", "furo"]
 test = ["objgraph", "psutil"]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
+    {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.1.0"
 description = ""
@@ -821,6 +843,51 @@ files = [
 
 [package.extras]
 tests = ["pytest"]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+description = "A minimal low-level HTTP client."
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.16"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+description = "The next generation HTTP client."
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+httpcore = "==1.*"
+idna = "*"
+
+[package.extras]
+brotli = ["brotli", "brotlicffi"]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "huggingface-hub"
@@ -888,6 +955,92 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "jiter"
+version = "0.10.0"
+description = "Fast iterable JSON parser."
+optional = true
+python-versions = ">=3.9"
+files = [
+    {file = "jiter-0.10.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:cd2fb72b02478f06a900a5782de2ef47e0396b3e1f7d5aba30daeb1fce66f303"},
+    {file = "jiter-0.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:32bb468e3af278f095d3fa5b90314728a6916d89ba3d0ffb726dd9bf7367285e"},
+    {file = "jiter-0.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa8b3e0068c26ddedc7abc6fac37da2d0af16b921e288a5a613f4b86f050354f"},
+    {file = "jiter-0.10.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:286299b74cc49e25cd42eea19b72aa82c515d2f2ee12d11392c56d8701f52224"},
+    {file = "jiter-0.10.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ed5649ceeaeffc28d87fb012d25a4cd356dcd53eff5acff1f0466b831dda2a7"},
+    {file = "jiter-0.10.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b2ab0051160cb758a70716448908ef14ad476c3774bd03ddce075f3c1f90a3d6"},
+    {file = "jiter-0.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03997d2f37f6b67d2f5c475da4412be584e1cec273c1cfc03d642c46db43f8cf"},
+    {file = "jiter-0.10.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c404a99352d839fed80d6afd6c1d66071f3bacaaa5c4268983fc10f769112e90"},
+    {file = "jiter-0.10.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:66e989410b6666d3ddb27a74c7e50d0829704ede652fd4c858e91f8d64b403d0"},
+    {file = "jiter-0.10.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b532d3af9ef4f6374609a3bcb5e05a1951d3bf6190dc6b176fdb277c9bbf15ee"},
+    {file = "jiter-0.10.0-cp310-cp310-win32.whl", hash = "sha256:da9be20b333970e28b72edc4dff63d4fec3398e05770fb3205f7fb460eb48dd4"},
+    {file = "jiter-0.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:f59e533afed0c5b0ac3eba20d2548c4a550336d8282ee69eb07b37ea526ee4e5"},
+    {file = "jiter-0.10.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3bebe0c558e19902c96e99217e0b8e8b17d570906e72ed8a87170bc290b1e978"},
+    {file = "jiter-0.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:558cc7e44fd8e507a236bee6a02fa17199ba752874400a0ca6cd6e2196cdb7dc"},
+    {file = "jiter-0.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d613e4b379a07d7c8453c5712ce7014e86c6ac93d990a0b8e7377e18505e98d"},
+    {file = "jiter-0.10.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f62cf8ba0618eda841b9bf61797f21c5ebd15a7a1e19daab76e4e4b498d515b2"},
+    {file = "jiter-0.10.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:919d139cdfa8ae8945112398511cb7fca58a77382617d279556b344867a37e61"},
+    {file = "jiter-0.10.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:13ddbc6ae311175a3b03bd8994881bc4635c923754932918e18da841632349db"},
+    {file = "jiter-0.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c440ea003ad10927a30521a9062ce10b5479592e8a70da27f21eeb457b4a9c5"},
+    {file = "jiter-0.10.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dc347c87944983481e138dea467c0551080c86b9d21de6ea9306efb12ca8f606"},
+    {file = "jiter-0.10.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:13252b58c1f4d8c5b63ab103c03d909e8e1e7842d302473f482915d95fefd605"},
+    {file = "jiter-0.10.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7d1bbf3c465de4a24ab12fb7766a0003f6f9bce48b8b6a886158c4d569452dc5"},
+    {file = "jiter-0.10.0-cp311-cp311-win32.whl", hash = "sha256:db16e4848b7e826edca4ccdd5b145939758dadf0dc06e7007ad0e9cfb5928ae7"},
+    {file = "jiter-0.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:9c9c1d5f10e18909e993f9641f12fe1c77b3e9b533ee94ffa970acc14ded3812"},
+    {file = "jiter-0.10.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:1e274728e4a5345a6dde2d343c8da018b9d4bd4350f5a472fa91f66fda44911b"},
+    {file = "jiter-0.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7202ae396446c988cb2a5feb33a543ab2165b786ac97f53b59aafb803fef0744"},
+    {file = "jiter-0.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:23ba7722d6748b6920ed02a8f1726fb4b33e0fd2f3f621816a8b486c66410ab2"},
+    {file = "jiter-0.10.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:371eab43c0a288537d30e1f0b193bc4eca90439fc08a022dd83e5e07500ed026"},
+    {file = "jiter-0.10.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c675736059020365cebc845a820214765162728b51ab1e03a1b7b3abb70f74c"},
+    {file = "jiter-0.10.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0c5867d40ab716e4684858e4887489685968a47e3ba222e44cde6e4a2154f959"},
+    {file = "jiter-0.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395bb9a26111b60141757d874d27fdea01b17e8fac958b91c20128ba8f4acc8a"},
+    {file = "jiter-0.10.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6842184aed5cdb07e0c7e20e5bdcfafe33515ee1741a6835353bb45fe5d1bd95"},
+    {file = "jiter-0.10.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:62755d1bcea9876770d4df713d82606c8c1a3dca88ff39046b85a048566d56ea"},
+    {file = "jiter-0.10.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:533efbce2cacec78d5ba73a41756beff8431dfa1694b6346ce7af3a12c42202b"},
+    {file = "jiter-0.10.0-cp312-cp312-win32.whl", hash = "sha256:8be921f0cadd245e981b964dfbcd6fd4bc4e254cdc069490416dd7a2632ecc01"},
+    {file = "jiter-0.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:a7c7d785ae9dda68c2678532a5a1581347e9c15362ae9f6e68f3fdbfb64f2e49"},
+    {file = "jiter-0.10.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:e0588107ec8e11b6f5ef0e0d656fb2803ac6cf94a96b2b9fc675c0e3ab5e8644"},
+    {file = "jiter-0.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cafc4628b616dc32530c20ee53d71589816cf385dd9449633e910d596b1f5c8a"},
+    {file = "jiter-0.10.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:520ef6d981172693786a49ff5b09eda72a42e539f14788124a07530f785c3ad6"},
+    {file = "jiter-0.10.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:554dedfd05937f8fc45d17ebdf298fe7e0c77458232bcb73d9fbbf4c6455f5b3"},
+    {file = "jiter-0.10.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5bc299da7789deacf95f64052d97f75c16d4fc8c4c214a22bf8d859a4288a1c2"},
+    {file = "jiter-0.10.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5161e201172de298a8a1baad95eb85db4fb90e902353b1f6a41d64ea64644e25"},
+    {file = "jiter-0.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e2227db6ba93cb3e2bf67c87e594adde0609f146344e8207e8730364db27041"},
+    {file = "jiter-0.10.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:15acb267ea5e2c64515574b06a8bf393fbfee6a50eb1673614aa45f4613c0cca"},
+    {file = "jiter-0.10.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:901b92f2e2947dc6dfcb52fd624453862e16665ea909a08398dde19c0731b7f4"},
+    {file = "jiter-0.10.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d0cb9a125d5a3ec971a094a845eadde2db0de85b33c9f13eb94a0c63d463879e"},
+    {file = "jiter-0.10.0-cp313-cp313-win32.whl", hash = "sha256:48a403277ad1ee208fb930bdf91745e4d2d6e47253eedc96e2559d1e6527006d"},
+    {file = "jiter-0.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:75f9eb72ecb640619c29bf714e78c9c46c9c4eaafd644bf78577ede459f330d4"},
+    {file = "jiter-0.10.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:28ed2a4c05a1f32ef0e1d24c2611330219fed727dae01789f4a335617634b1ca"},
+    {file = "jiter-0.10.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14a4c418b1ec86a195f1ca69da8b23e8926c752b685af665ce30777233dfe070"},
+    {file = "jiter-0.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:d7bfed2fe1fe0e4dda6ef682cee888ba444b21e7a6553e03252e4feb6cf0adca"},
+    {file = "jiter-0.10.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:5e9251a5e83fab8d87799d3e1a46cb4b7f2919b895c6f4483629ed2446f66522"},
+    {file = "jiter-0.10.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:023aa0204126fe5b87ccbcd75c8a0d0261b9abdbbf46d55e7ae9f8e22424eeb8"},
+    {file = "jiter-0.10.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c189c4f1779c05f75fc17c0c1267594ed918996a231593a21a5ca5438445216"},
+    {file = "jiter-0.10.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:15720084d90d1098ca0229352607cd68256c76991f6b374af96f36920eae13c4"},
+    {file = "jiter-0.10.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e4f2fb68e5f1cfee30e2b2a09549a00683e0fde4c6a2ab88c94072fc33cb7426"},
+    {file = "jiter-0.10.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce541693355fc6da424c08b7edf39a2895f58d6ea17d92cc2b168d20907dee12"},
+    {file = "jiter-0.10.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31c50c40272e189d50006ad5c73883caabb73d4e9748a688b216e85a9a9ca3b9"},
+    {file = "jiter-0.10.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fa3402a2ff9815960e0372a47b75c76979d74402448509ccd49a275fa983ef8a"},
+    {file = "jiter-0.10.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:1956f934dca32d7bb647ea21d06d93ca40868b505c228556d3373cbd255ce853"},
+    {file = "jiter-0.10.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:fcedb049bdfc555e261d6f65a6abe1d5ad68825b7202ccb9692636c70fcced86"},
+    {file = "jiter-0.10.0-cp314-cp314-win32.whl", hash = "sha256:ac509f7eccca54b2a29daeb516fb95b6f0bd0d0d8084efaf8ed5dfc7b9f0b357"},
+    {file = "jiter-0.10.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5ed975b83a2b8639356151cef5c0d597c68376fc4922b45d0eb384ac058cfa00"},
+    {file = "jiter-0.10.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3aa96f2abba33dc77f79b4cf791840230375f9534e5fac927ccceb58c5e604a5"},
+    {file = "jiter-0.10.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:bd6292a43c0fc09ce7c154ec0fa646a536b877d1e8f2f96c19707f65355b5a4d"},
+    {file = "jiter-0.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:39de429dcaeb6808d75ffe9effefe96a4903c6a4b376b2f6d08d77c1aaee2f18"},
+    {file = "jiter-0.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:52ce124f13a7a616fad3bb723f2bfb537d78239d1f7f219566dc52b6f2a9e48d"},
+    {file = "jiter-0.10.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:166f3606f11920f9a1746b2eea84fa2c0a5d50fd313c38bdea4edc072000b0af"},
+    {file = "jiter-0.10.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:28dcecbb4ba402916034fc14eba7709f250c4d24b0c43fc94d187ee0580af181"},
+    {file = "jiter-0.10.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86c5aa6910f9bebcc7bc4f8bc461aff68504388b43bfe5e5c0bd21efa33b52f4"},
+    {file = "jiter-0.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ceeb52d242b315d7f1f74b441b6a167f78cea801ad7c11c36da77ff2d42e8a28"},
+    {file = "jiter-0.10.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ff76d8887c8c8ee1e772274fcf8cc1071c2c58590d13e33bd12d02dc9a560397"},
+    {file = "jiter-0.10.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:a9be4d0fa2b79f7222a88aa488bd89e2ae0a0a5b189462a12def6ece2faa45f1"},
+    {file = "jiter-0.10.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9ab7fd8738094139b6c1ab1822d6f2000ebe41515c537235fd45dabe13ec9324"},
+    {file = "jiter-0.10.0-cp39-cp39-win32.whl", hash = "sha256:5f51e048540dd27f204ff4a87f5d79294ea0aa3aa552aca34934588cf27023cf"},
+    {file = "jiter-0.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:1b28302349dc65703a9e4ead16f163b1c339efffbe1049c30a44b001a2a4fff9"},
+    {file = "jiter-0.10.0.tar.gz", hash = "sha256:07a7142c38aacc85194391108dc91b5b57093c978a9932bd86a36862759d9500"},
+]
 
 [[package]]
 name = "jsonpickle"
@@ -1338,6 +1491,32 @@ files = [
     {file = "numpy-2.2.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d2e3bdadaba0e040d1e7ab39db73e0afe2c74ae277f5614dad53eadbecbbb169"},
     {file = "numpy-2.2.5.tar.gz", hash = "sha256:a9c0d994680cd991b1cb772e8b297340085466a6fe964bc9d4e80f5e2f43c291"},
 ]
+
+[[package]]
+name = "openai"
+version = "1.82.1"
+description = "The official Python library for the openai API"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "openai-1.82.1-py3-none-any.whl", hash = "sha256:334eb5006edf59aa464c9e932b9d137468d810b2659e5daea9b3a8c39d052395"},
+    {file = "openai-1.82.1.tar.gz", hash = "sha256:ffc529680018e0417acac85f926f92aa0bbcbc26e82e2621087303c66bc7f95d"},
+]
+
+[package.dependencies]
+anyio = ">=3.5.0,<5"
+distro = ">=1.7.0,<2"
+httpx = ">=0.23.0,<1"
+jiter = ">=0.4.0,<1"
+pydantic = ">=1.9.0,<3"
+sniffio = "*"
+tqdm = ">4"
+typing-extensions = ">=4.11,<5"
+
+[package.extras]
+datalib = ["numpy (>=1)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)"]
+realtime = ["websockets (>=13,<16)"]
+voice-helpers = ["numpy (>=2.0.2)", "sounddevice (>=0.5.1)"]
 
 [[package]]
 name = "packaging"
@@ -2302,10 +2481,10 @@ multidict = ">=4.0"
 propcache = ">=0.2.1"
 
 [extras]
-server = ["aiolimiter", "alembic", "backoff", "fastapi", "matplotlib", "psycopg2", "sentry-sdk", "sqlalchemy"]
-server-testing = ["alembic", "backoff", "fastapi", "matplotlib", "psycopg2-binary", "sentry-sdk", "sqlalchemy"]
+server = ["aiolimiter", "alembic", "backoff", "fastapi", "matplotlib", "openai", "psycopg2", "sentry-sdk", "sqlalchemy"]
+server-testing = ["alembic", "backoff", "fastapi", "matplotlib", "openai", "psycopg2-binary", "sentry-sdk", "sqlalchemy"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "3011928f5fcf6bf94d87d7015d0001fe8c3e90c975d25eea7863b4ad7403cdbf"
+content-hash = "3bb73fb7bb5cdea12f37bf7edd774764e56bea486ac9793e0c2c1b0bc7a1d5e8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,10 +52,11 @@ alembic = {version = "^1.13.3", optional = true }
 matplotlib = {version = "^3.8.4", optional = true }
 backoff = {version = "2.2.1", optional = true }
 sentry-sdk = {version = "^2.17.0", optional = true, extras = ["fastapi"]}
+openai = {version = "^1.82.1", optional = true}
 
 [tool.poetry.extras]
-server = ["fastapi", "sqlalchemy", "psycopg2", "alembic", "matplotlib", "backoff", "aiolimiter", "sentry-sdk"]
-server-testing = ["fastapi", "sqlalchemy", "psycopg2-binary", "alembic", "matplotlib", "backoff", "pytest-asyncio", "sentry-sdk"]
+server = ["fastapi", "sqlalchemy", "psycopg2", "alembic", "matplotlib", "backoff", "aiolimiter", "sentry-sdk", "openai"]
+server-testing = ["fastapi", "sqlalchemy", "psycopg2-binary", "alembic", "matplotlib", "backoff", "pytest-asyncio", "sentry-sdk", "openai"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -1,6 +1,4 @@
-import json
 from pathlib import Path
-from packaging.version import Version
 
 import aiohttp
 import aioresponses

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -11,7 +11,6 @@ from fastapi import HTTPException
 from logdetective.server.config import SERVER_CONFIG
 from logdetective.server.llm import (
     perform_staged_analysis,
-    submit_to_llm_endpoint,
     submit_text,
 )
 from logdetective.remote_log import RemoteLog
@@ -28,121 +27,6 @@ async def test_loading_config():
     repo_root = Path(__file__).parent.parent
     config_file = repo_root / "server" / "config.yml"
     assert load_server_config(str(config_file))
-
-
-@pytest.mark.skipif(
-    Version(aioresponses.__version__) < Version("0.7.8"),
-    reason="aioresponses lacks support for base_url",
-)
-@pytest.mark.asyncio
-async def test_submit_to_llm():
-    """Test async communication with an OpenAI compat inference server"""
-
-    # Create InferenceConfig
-    inference_cfg = InferenceConfig(
-        data={
-            "max_tokens": 1000,
-            "log_probs": True,
-            "url": "http://localhost:8080",
-            "api_token": "",
-            "model": "stories260K.gguf",
-            "temperature": 0.8,
-            "max_queue_size": 50,
-            "requests_per_minute": 60,
-        }
-    )
-
-    mock_response = {
-        "choices": [
-            {
-                "finish_reason": "length",
-                "index": 0,
-                "message": {"role": "assistant", "content": "So she was very..."},
-                "logprobs": {
-                    "content": [
-                        {
-                            "id": 437,
-                            "token": "S",
-                            "bytes": [83],
-                            "logprob": -3.2835686206817627,
-                            "top_logprobs": [
-                                {
-                                    "id": 436,
-                                    "token": '"',
-                                    "bytes": [34],
-                                    "logprob": -1.1505162715911865,
-                                }
-                            ],
-                        },
-                        {
-                            "id": 414,
-                            "token": "o",
-                            "bytes": [111],
-                            "logprob": -2.8719468116760254,
-                            "top_logprobs": [
-                                {
-                                    "id": 425,
-                                    "token": "u",
-                                    "bytes": [117],
-                                    "logprob": -0.44975802302360535,
-                                }
-                            ],
-                        },
-                    ]
-                },
-                "created": 1744381795,
-                "model": "stories260K.gguf",
-                "system_fingerprint": "b4839-42994048",
-                "object": "chat.completion",
-                "usage": {
-                    "completion_tokens": 1000,
-                    "prompt_tokens": 45,
-                    "total_tokens": 1045,
-                },
-                "id": "chatcmpl - PreWjyi55gzlFy91x0LEfj7Xp91G197i",
-                "timings": {
-                    "prompt_n": 1,
-                    "prompt_ms": 6.191,
-                    "prompt_per_token_ms": 6.191,
-                    "prompt_per_second": 161.52479405588758,
-                    "predicted_n": 1000,
-                    "predicted_ms": 1137.463,
-                    "predicted_per_token_ms": 1.137463,
-                    "predicted_per_second": 879.1494756312953,
-                },
-            }
-        ]
-    }
-    with aioresponses.aioresponses() as mock:
-        mock.post(
-            "http://localhost:8080/v1/chat/completions",
-            status=200,
-            body=json.dumps(mock_response),
-        )
-        data = {
-            "messages": [
-                {
-                    "role": "user",
-                    "content": "Hello!",
-                }
-            ],
-            "max_tokens": 1000,
-            "logprobs": 1,
-            "stream": False,
-            "model": "stories260K.gguf",
-            "temperature": 0.8,
-        }
-        headers = {"Content-Type": "application/json"}
-
-        response = submit_to_llm_endpoint(
-            "/v1/chat/completions",
-            data,
-            headers,
-            stream=False,
-            inference_cfg=inference_cfg,
-        )
-        response = await response
-        assert response == mock_response
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -6,6 +6,8 @@ import pytest
 
 from fastapi import HTTPException
 
+from tests.server.test_helpers import mock_chat_completions
+
 from logdetective.server.config import SERVER_CONFIG
 from logdetective.server.llm import (
     perform_staged_analysis,
@@ -14,8 +16,6 @@ from logdetective.server.llm import (
 from logdetective.remote_log import RemoteLog
 from logdetective.server.config import load_server_config
 from logdetective.server.models import InferenceConfig, Explanation
-
-from tests.server.test_helpers import mock_chat_completions
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_server_gitlab.py
+++ b/tests/server/test_server_gitlab.py
@@ -9,7 +9,6 @@ import responses
 import aioresponses
 from packaging.version import Version
 
-from aiolimiter import AsyncLimiter
 from flexmock import flexmock
 
 from tests.server.test_helpers import (

--- a/tests/server/test_server_gitlab.py
+++ b/tests/server/test_server_gitlab.py
@@ -14,6 +14,7 @@ from flexmock import flexmock
 
 from tests.server.test_helpers import (
     DatabaseFactory,
+    mock_chat_completions
 )
 
 from logdetective.server.gitlab import is_eligible_package, retrieve_and_preprocess_koji_logs
@@ -308,12 +309,13 @@ async def mock_job_hook():
             yield sync_rsps, async_rsps, job_hook
 
 
+@pytest.mark.parametrize("mock_chat_completions", ["This is a mock message"], indirect=True)
 @pytest.mark.skipif(
     Version(aioresponses.__version__) < Version("0.7.8"),
     reason="aioresponses lacks support for base_url",
 )
 @pytest.mark.asyncio
-async def test_process_gitlab_job_event(mock_config, mock_job_hook):
+async def test_process_gitlab_job_event(mock_config, mock_job_hook, mock_chat_completions):
     with DatabaseFactory().make_new_db() as session_factory:
         _, _, job_hook = mock_job_hook
         gitlab_instance = GitLabInstanceConfig(


### PR DESCRIPTION
Refactor:
- `openai` library is now part of our dependencies
- Instead of handcrafted requests, we are using `openai` API calls and verify the results with their data structures.
- `InferenceConfig` now has default API token set to `"None"` since OpenAI library can't handle zero length strings.


Misc:

- `openai` isn't packaged, it has to be installed from pypi. The version is pinned in both container image and in the lockfile, and must be kept in sync if we do an update.
- `submit_to_llm_endpoint` function wasn't used anywhere and so it was removed, together with tests.
- several unused imports were removed