### PR TITLE
Replacing versions with hashes to improve security, bumping versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,13 +31,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.0.0
 
       # Install and test the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: ${{ github.event_name != 'pull_request' && contains(github.ref, 'refs/tags/') }}
-        uses: sigstore/cosign-installer@v3.6.0
+        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
       - name: Check install!
         if: ${{ github.event_name != 'pull_request' && contains(github.ref, 'refs/tags/') }}
         run: cosign version

--- a/.github/workflows/new-issues-to-board.yml
+++ b/.github/workflows/new-issues-to-board.yml
@@ -12,7 +12,7 @@ jobs:
   move-new-issue:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@31b3f3ccdc584546fc445612dec3f38ff5edb41c # v0.5.0
         with:
           project-url: https://github.com/orgs/fedora-copr/projects/1
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.0.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       # Regex by https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
       - name: Check semver
         run: >
@@ -26,4 +26,4 @@ jobs:
       - name: Build package
         run: poetry build
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,8 +8,8 @@ jobs:
   run_pytest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.0.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       - name: Install tox
         run: pip install tox
       - name: Run pytest for base package

--- a/.github/workflows/python-diff-lint.yml
+++ b/.github/workflows/python-diff-lint.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.0.0
 
       - name: VCS Diff Lint
-        uses: fedora-copr/vcs-diff-lint-action@v1
+        uses: fedora-copr/vcs-diff-lint-action@3fe529c95a55cf7d25d1ef73d53f790710c9a352 # v1.10.0
         id: VCS_Diff_Lint
         with:
           install_rpm_packages: |
@@ -35,14 +35,14 @@ jobs:
             ruff
 
       - name: Upload artifact with detected defects in SARIF format
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: VCS Diff Lint SARIF
           path: ${{ steps.VCS_Diff_Lint.outputs.sarif }}
         if: ${{ always() }}
 
       - name: Upload SARIF to GitHub using github/codeql-action/upload-sarif
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
         with:
           sarif_file: ${{ steps.VCS_Diff_Lint.outputs.sarif }}
         if: ${{ always() }}

--- a/.github/workflows/tox-lint.yml
+++ b/.github/workflows/tox-lint.yml
@@ -8,8 +8,8 @@ jobs:
   run_linters:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.0.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       - name: Install tox
         run: pip install tox
       - name: Run linters


### PR DESCRIPTION
While improbable, it is technically possible for one of the action repos to be taken over, and used tags to be reassigned to new, now malicious code. That would in turn compromise our entire pipeline, exposing secrets and potentially allowing attacker to upload new version of our code using our own keys.

This is a mitigation. Instead of using tags, we will now be using commit hashes from source repos. It is important that the actual version is noted in the comment, for easier maintenance. 

At the same time I'm bumping versions of several actions, notably the `actions/checkout` in docker-publish.yml workflow, which has been out of sync with the one used in other actions.

The only case where I wasn't certain was `github/codeql-action/upload-sarif` which doesn't have it's own repo, and is bundled with other actions. The releases for them are not very straightforward.[1] There is a separate versioning for bundle and action.


[1] https://github.com/github/codeql-action/releases