### PR TITLE
Removing LLM summarizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Usage
 To analyze a log file, run the script with the following command line arguments:
 - `url` (required): The URL of the log file to be analyzed.
 - `--model` (optional, default: "Mistral-7B-Instruct-v0.2-GGUF"): The path or URL of the language model for analysis. As we are using LLama.cpp we want this to be in the `gguf` format. You can include the download link to the model here. If the model is already on your machine it will skip the download.
-- `--summarizer` (optional, default: "drain"): Choose between LLM and Drain template miner as the log summarizer. You can also provide the path to an existing language model file instead of using a URL.
-- `--n_lines` (optional, default: 8): The number of lines per chunk for LLM analysis. This only makes sense when you are summarizing with LLM.
+- `--summarizer` DISABLED: LLM summarization option was removed. Argument is kept for backward compatibility only.(optional, default: "drain"): Choose between LLM and Drain template miner as the log summarizer. You can also provide the path to an existing language model file instead of using a URL.
+- `--n_lines` DISABLED: LLM summarization option was removed. Argument is kept for backward compatibility only. (optional, default: 8): The number of lines per chunk for LLM analysis. This only makes sense when you are summarizing with LLM.
 - `--n_clusters` (optional, default 8): Number of clusters for Drain to organize log chunks into. This only makes sense when you are summarizing with Drain
 
 Example usage:

--- a/logdetective/constants.py
+++ b/logdetective/constants.py
@@ -26,17 +26,6 @@ Analysis:
 
 """
 
-SUMMARIZATION_PROMPT_TEMPLATE = """
-Does following log contain error or issue?
-
-Log:
-
-{}
-
-Answer:
-
-"""
-
 SNIPPET_PROMPT_TEMPLATE = """
 Analyse following RPM build log snippet. Describe contents accurately, without speculation or suggestions for resolution.
 

--- a/logdetective/extractors.py
+++ b/logdetective/extractors.py
@@ -4,73 +4,10 @@ from typing import Tuple
 
 import drain3
 from drain3.template_miner_config import TemplateMinerConfig
-from llama_cpp import Llama, LlamaGrammar
 
-from logdetective.constants import SUMMARIZATION_PROMPT_TEMPLATE
 from logdetective.utils import get_chunks
 
 LOG = logging.getLogger("logdetective")
-
-
-class LLMExtractor:
-    """
-    A class that extracts relevant information from logs using a language model.
-    """
-
-    def __init__(
-        self,
-        model: Llama,
-        n_lines: int = 2,
-        prompt: str = SUMMARIZATION_PROMPT_TEMPLATE,
-    ):
-        self.model = model
-        self.n_lines = n_lines
-        self.grammar = LlamaGrammar.from_string(
-            'root ::= ("Yes" | "No")', verbose=False
-        )
-        self.prompt = prompt
-
-    def __call__(
-        self, log: str, n_lines: int = 2, neighbors: bool = False
-    ) -> list[str]:
-        chunks = self.rate_chunks(log)
-        out = self.create_extract(chunks, neighbors)
-        return out
-
-    def rate_chunks(self, log: str) -> list[tuple]:
-        """Scan log by the model and store results.
-
-        :param log: log file content
-        """
-        results = []
-        log_lines = log.split("\n")
-
-        for i in range(0, len(log_lines), self.n_lines):
-            block = "\n".join(log_lines[i: i + self.n_lines])
-            prompt = self.prompt.format(log)
-            out = self.model(prompt, max_tokens=7, grammar=self.grammar)
-            out = f"{out['choices'][0]['text']}\n"
-            results.append((block, out))
-
-        return results
-
-    def create_extract(self, chunks: list[tuple], neighbors: bool = False) -> list[str]:
-        """Extract interesting chunks from the model processing."""
-        interesting = []
-        summary = []
-        # pylint: disable=consider-using-enumerate
-        for i in range(len(chunks)):
-            if chunks[i][1].startswith("Yes"):
-                interesting.append(i)
-                if neighbors:
-                    interesting.extend([max(i - 1, 0), min(i + 1, len(chunks) - 1)])
-
-        interesting = set(interesting)
-
-        for i in interesting:
-            summary.append(chunks[i][0])
-
-        return summary
 
 
 class DrainExtractor:

--- a/logdetective/models.py
+++ b/logdetective/models.py
@@ -4,7 +4,6 @@ from pydantic import BaseModel
 from logdetective.constants import (
     PROMPT_TEMPLATE,
     PROMPT_TEMPLATE_STAGED,
-    SUMMARIZATION_PROMPT_TEMPLATE,
     SNIPPET_PROMPT_TEMPLATE,
     DEFAULT_SYSTEM_PROMPT,
 )
@@ -14,7 +13,6 @@ class PromptConfig(BaseModel):
     """Configuration for basic log detective prompts."""
 
     prompt_template: str = PROMPT_TEMPLATE
-    summarization_prompt_template: str = SUMMARIZATION_PROMPT_TEMPLATE
     snippet_prompt_template: str = SNIPPET_PROMPT_TEMPLATE
     prompt_template_staged: str = PROMPT_TEMPLATE_STAGED
 
@@ -27,9 +25,6 @@ class PromptConfig(BaseModel):
         if data is None:
             return
         self.prompt_template = data.get("prompt_template", PROMPT_TEMPLATE)
-        self.summarization_prompt_template = data.get(
-            "summarization_prompt_template", SUMMARIZATION_PROMPT_TEMPLATE
-        )
         self.snippet_prompt_template = data.get(
             "snippet_prompt_template", SNIPPET_PROMPT_TEMPLATE
         )

--- a/logdetective/prompts.yml
+++ b/logdetective/prompts.yml
@@ -21,17 +21,6 @@ prompt_template: |
 
   Analysis:
 
-
-summarization_prompt_template: |
-  Does following log contain error or issue?
-
-  Log:
-
-  {}
-
-  Answer:
-
-
 snippet_prompt_template: |
   Analyse following RPM build log snippet. Describe contents accurately, without speculation or suggestions for resolution.
 

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -41,10 +41,6 @@ def test_load_prompts_wrong_path():
     assert prompts_config.prompt_template == constants.PROMPT_TEMPLATE
     assert prompts_config.snippet_prompt_template == constants.SNIPPET_PROMPT_TEMPLATE
     assert prompts_config.prompt_template_staged == constants.PROMPT_TEMPLATE_STAGED
-    assert (
-        prompts_config.summarization_prompt_template
-        == constants.SUMMARIZATION_PROMPT_TEMPLATE  # noqa: W503 flake vs lint
-    )
 
 
 def test_load_prompts_correct_path():
@@ -60,10 +56,6 @@ def test_load_prompts_correct_path():
     assert prompts_config.prompt_template == "This is basic template."
     assert prompts_config.snippet_prompt_template == "This is template for snippets."
     assert prompts_config.prompt_template_staged == constants.PROMPT_TEMPLATE_STAGED
-    assert (
-        prompts_config.summarization_prompt_template
-        == constants.SUMMARIZATION_PROMPT_TEMPLATE  # noqa: W503 flake vs lint
-    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
LLM base summarization hasn't worked in a while and even when it did there wasn't much point to it.
Main issue was that it takes way too long, as the entire log needs to be submitted to LLM in parts.

We have  also never implemented it in server and if we are going to use LLMs for rating chunks of text, we should be using it with first pass by Drain. But that would require a substantial rewrite, to the point of almost making the entire thing from scratch.

For these reasons I suggest we scrap the current implementation entirely.