### PR TITLE
Allow for explicit filtering of log patterns

### DIFF
--- a/.env
+++ b/.env
@@ -28,6 +28,8 @@ LOGDETECTIVE_SERVER_CONF="/config.yml"
 LOGDETECTIVE_PROMPTS="/src/logdetective/prompts.yml"
 # llama.cpp inference server will look for `LLAMA_ARG_MODEL` in this location
 MODELS_PATH="./models"
+# Path to patterns to be skipped during processing
+LOGDETECIVE_SKIP_PATTERNS="/src/logdetective/skip_snippets.yml"
 
 # Database
 POSTGRESQL_USER=logdetective

--- a/README.md
+++ b/README.md
@@ -395,6 +395,28 @@ with spaces, or replacement fields marked with curly braces, `{}` left for inser
 Number of replacement fields in new prompts, must be the same as in originals.
 Although their position may be different.
 
+
+Skip Snippets
+-------------
+
+Certain log chunks may not contribute to the analysis of the problem under any circumstances.
+User can specify regular expressions, matching such log chunks, along with simple description,
+using Skip Snippets feature.
+
+Patterns to be skipped must be defined yaml file as a dictionary, where key is a description
+and value is a regular expression. For example:
+
+```
+child_exit_code_zero: "Child return code was: 0"
+```
+
+Special care must be taken not to write a regular expression which may match
+too many chunks, or which may be evaluated as data structure by the yaml parser.
+
+Example of a valid pattern definition file: `logdetective/skip_patterns.yml`,
+can be used as a starting point and is used as a default if no other definition is provided.
+
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ To analyze a log file, run the script with the following command line arguments:
 - `--summarizer` DISABLED: LLM summarization option was removed. Argument is kept for backward compatibility only.(optional, default: "drain"): Choose between LLM and Drain template miner as the log summarizer. You can also provide the path to an existing language model file instead of using a URL.
 - `--n_lines` DISABLED: LLM summarization option was removed. Argument is kept for backward compatibility only. (optional, default: 8): The number of lines per chunk for LLM analysis. This only makes sense when you are summarizing with LLM.
 - `--n_clusters` (optional, default 8): Number of clusters for Drain to organize log chunks into. This only makes sense when you are summarizing with Drain
+- `--skip_snippets` Path to patterns for skipping snippets.
 
 Example usage:
 

--- a/logdetective/extractors.py
+++ b/logdetective/extractors.py
@@ -5,7 +5,8 @@ from typing import Tuple
 import drain3
 from drain3.template_miner_config import TemplateMinerConfig
 
-from logdetective.utils import get_chunks
+from logdetective.utils import get_chunks, filter_snippet_patterns
+from logdetective.models import SkipSnippets
 
 LOG = logging.getLogger("logdetective")
 
@@ -13,7 +14,13 @@ LOG = logging.getLogger("logdetective")
 class DrainExtractor:
     """A class that extracts information from logs using a template miner algorithm."""
 
-    def __init__(self, verbose: bool = False, context: bool = False, max_clusters=8):
+    def __init__(
+        self,
+        verbose: bool = False,
+        context: bool = False,
+        max_clusters=8,
+        skip_snippets: SkipSnippets = SkipSnippets({}),
+    ):
         config = TemplateMinerConfig()
         config.load(f"{os.path.dirname(__file__)}/drain3.ini")
         config.profiling_enabled = verbose
@@ -21,11 +28,15 @@ class DrainExtractor:
         self.miner = drain3.TemplateMiner(config=config)
         self.verbose = verbose
         self.context = context
+        self.skip_snippets = skip_snippets
 
     def __call__(self, log: str) -> list[Tuple[int, str]]:
         out = []
         # First pass create clusters
         for _, chunk in get_chunks(log):
+            # Do not process chunks matching any of the excluded patterns
+            if filter_snippet_patterns(chunk, self.skip_snippets):
+                continue
             processed_chunk = self.miner.add_log_message(chunk)
             LOG.debug(processed_chunk)
         # Sort found clusters by size, descending order
@@ -35,6 +46,9 @@ class DrainExtractor:
         # Second pass, only matching lines with clusters,
         # to recover original text
         for chunk_start, chunk in get_chunks(log):
+            # Chunks matching excluded patterns are again disregarded
+            if filter_snippet_patterns(chunk, self.skip_snippets):
+                continue
             cluster = self.miner.match(chunk, "always")
             if cluster in sorted_clusters:
                 out.append((chunk_start, chunk))

--- a/logdetective/logdetective.py
+++ b/logdetective/logdetective.py
@@ -127,7 +127,11 @@ async def run():  # pylint: disable=too-many-statements,too-many-locals
         LOG.error("You likely do not have enough memory to load the AI model")
         sys.exit(3)
 
-    skip_snippets = load_skip_snippet_patterns(args.skip_snippets)
+    try:
+        skip_snippets = load_skip_snippet_patterns(args.skip_snippets)
+    except OSError as e:
+        LOG.error(e)
+        sys.exit(5)
 
     # Log file summarizer initialization
     extractor = DrainExtractor(

--- a/logdetective/logdetective.py
+++ b/logdetective/logdetective.py
@@ -14,6 +14,7 @@ from logdetective.utils import (
     format_snippets,
     compute_certainty,
     load_prompts,
+    load_skip_snippet_patterns,
 )
 from logdetective.extractors import DrainExtractor
 
@@ -82,6 +83,12 @@ def setup_args():
         default=DEFAULT_TEMPERATURE,
         help="Temperature for inference.",
     )
+    parser.add_argument(
+        "--skip_snippets",
+        type=str,
+        default=f"{os.path.dirname(__file__)}/skip_snippets.yml",
+        help="Path to patterns for skipping snippets.",
+    )
     return parser.parse_args()
 
 
@@ -120,9 +127,14 @@ async def run():  # pylint: disable=too-many-statements,too-many-locals
         LOG.error("You likely do not have enough memory to load the AI model")
         sys.exit(3)
 
+    skip_snippets = load_skip_snippet_patterns(args.skip_snippets)
+
     # Log file summarizer initialization
     extractor = DrainExtractor(
-        args.verbose > 1, context=True, max_clusters=args.n_clusters
+        args.verbose > 1,
+        context=True,
+        max_clusters=args.n_clusters,
+        skip_snippets=skip_snippets,
     )
 
     LOG.info("Getting summary")

--- a/logdetective/server/config.py
+++ b/logdetective/server/config.py
@@ -3,7 +3,7 @@ import logging
 import yaml
 from openai import AsyncOpenAI
 
-from logdetective.utils import load_prompts
+from logdetective.utils import load_prompts, load_skip_snippet_patterns
 from logdetective.server.models import Config, InferenceConfig
 
 
@@ -60,9 +60,11 @@ def get_openai_api_client(ineference_config: InferenceConfig):
 
 SERVER_CONFIG_PATH = os.environ.get("LOGDETECTIVE_SERVER_CONF", None)
 SERVER_PROMPT_PATH = os.environ.get("LOGDETECTIVE_PROMPTS", None)
+SERVER_SKIP_PATTERNS_PATH = os.environ.get("LOGDETECIVE_SKIP_PATTERNS", None)
 
 SERVER_CONFIG = load_server_config(SERVER_CONFIG_PATH)
 PROMPT_CONFIG = load_prompts(SERVER_PROMPT_PATH)
+SKIP_SNIPPETS_CONFIG = load_skip_snippet_patterns(SERVER_SKIP_PATTERNS_PATH)
 
 LOG = get_log(SERVER_CONFIG)
 

--- a/logdetective/server/config.py
+++ b/logdetective/server/config.py
@@ -5,6 +5,7 @@ from openai import AsyncOpenAI
 
 from logdetective.utils import load_prompts, load_skip_snippet_patterns
 from logdetective.server.models import Config, InferenceConfig
+import logdetective
 
 
 def load_server_config(path: str | None) -> Config:
@@ -60,7 +61,12 @@ def get_openai_api_client(ineference_config: InferenceConfig):
 
 SERVER_CONFIG_PATH = os.environ.get("LOGDETECTIVE_SERVER_CONF", None)
 SERVER_PROMPT_PATH = os.environ.get("LOGDETECTIVE_PROMPTS", None)
-SERVER_SKIP_PATTERNS_PATH = os.environ.get("LOGDETECIVE_SKIP_PATTERNS", None)
+# The default location for skip patterns is in the same directory
+# as logdetective __init__.py file.
+SERVER_SKIP_PATTERNS_PATH = os.environ.get(
+    "LOGDETECIVE_SKIP_PATTERNS",
+    f"{os.path.dirname(logdetective.__file__)}/skip_snippets.yml",
+)
 
 SERVER_CONFIG = load_server_config(SERVER_CONFIG_PATH)
 PROMPT_CONFIG = load_prompts(SERVER_PROMPT_PATH)

--- a/logdetective/server/llm.py
+++ b/logdetective/server/llm.py
@@ -16,7 +16,13 @@ from logdetective.utils import (
     compute_certainty,
     prompt_to_messages,
 )
-from logdetective.server.config import LOG, SERVER_CONFIG, PROMPT_CONFIG, CLIENT
+from logdetective.server.config import (
+    LOG,
+    SERVER_CONFIG,
+    PROMPT_CONFIG,
+    CLIENT,
+    SKIP_SNIPPETS_CONFIG,
+)
 from logdetective.server.models import (
     AnalyzedSnippet,
     InferenceConfig,
@@ -42,7 +48,10 @@ def format_analyzed_snippets(snippets: list[AnalyzedSnippet]) -> str:
 def mine_logs(log: str) -> List[Tuple[int, str]]:
     """Extract snippets from log text"""
     extractor = DrainExtractor(
-        verbose=True, context=True, max_clusters=SERVER_CONFIG.extractor.max_clusters
+        verbose=True,
+        context=True,
+        max_clusters=SERVER_CONFIG.extractor.max_clusters,
+        skip_snippets=SKIP_SNIPPETS_CONFIG,
     )
 
     LOG.info("Getting summary")

--- a/logdetective/skip_snippets.yml
+++ b/logdetective/skip_snippets.yml
@@ -1,0 +1,12 @@
+# This file holds patterns you want to skip during log parsing.
+# By default, no patterns are supplied.
+# Patterns are to be specified as values of dictionary,
+# with each key being a descriptive name of the pattern.
+# Patterns themselves are evaluated as a regular expression.
+# Make sure to avoid regular expressions that may be interpreted
+# as yaml syntax.
+# Example:
+
+# contains_capital_a: "^.*A.*"
+# starts_with_numeric: "^[0-9].*"
+child_exit_code_zero: "Child return code was: 0"

--- a/logdetective/utils.py
+++ b/logdetective/utils.py
@@ -242,6 +242,8 @@ def load_skip_snippet_patterns(path: str | None) -> SkipSnippets:
         try:
             with open(path, "r") as file:
                 return SkipSnippets(yaml.safe_load(file))
-        except FileNotFoundError:
-            LOG.error("Patterns for skipping snippets not found at %s", path)
+        except OSError as e:
+            LOG.error("Couldn't open file with snippet skip patterns `%s`", path)
+            raise e
+
     return SkipSnippets({})

--- a/tests/base/test_helpers.py
+++ b/tests/base/test_helpers.py
@@ -4,11 +4,6 @@ test_snippets = [
         "Snippet 1",
         "Snippet 2",
         "Snippet 3",
-        "This is a snippet number 1",
-        "This snippet has more than 2 characters",
-        "This snippet contains capital A and \n",
-        "",
-        ".....=====....."
     ],
     # Tuples
     [(10, "Snippet 1"), (120, "Snippet 1"), (240, "Snippet 1")],
@@ -27,3 +22,15 @@ test_filter_patterns = {
     "contains_c": ".*c.*",
     "contains_x_followed_by_y": "x.*y"
 }
+# Following must be kept in sync with `test_filter_patterns`
+# bool values of tuples must equal to output of the `filter_snippet_patterns`
+test_snippets_filtering = [
+    ("This is a snippet number 1", False),
+    ("This snippet has more than 2 characters", True),
+    ("This snippet contains capital A and \n", True),
+    ("", False),
+    (".....=====.....", False),
+    ("A nice matching snippet", True),
+    ("x is a good name for independent variable, unlike y", True),
+    ("1. This snippet should be skipped", True)
+]

--- a/tests/base/test_helpers.py
+++ b/tests/base/test_helpers.py
@@ -1,6 +1,15 @@
 test_snippets = [
     # Simple
-    ["Snippet 1", "Snippet 2", "Snippet 3"],
+    [
+        "Snippet 1",
+        "Snippet 2",
+        "Snippet 3",
+        "This is a snippet number 1",
+        "This snippet has more than 2 characters",
+        "This snippet contains capital A and \n",
+        "",
+        ".....=====....."
+    ],
     # Tuples
     [(10, "Snippet 1"), (120, "Snippet 1"), (240, "Snippet 1")],
 ]
@@ -10,3 +19,11 @@ prompt_template: This is basic template.
 
 snippet_prompt_template: This is template for snippets.
 """
+
+# For testing snippet filtering
+test_filter_patterns = {
+    "starts_one_or_two": "^[12]",
+    "starts_with_capital_a": "^A",
+    "contains_c": ".*c.*",
+    "contains_x_followed_by_y": "x.*y"
+}

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -127,11 +127,8 @@ def test_snippet_filtering():
 
 def test_load_skip_snippet_patterns_wrong_path():
     """Test behavior for case when the path doesn't lead to a any file."""
-    prompts_config = load_skip_snippet_patterns("/there/is/nothing/to/read.yml")
-
-    assert isinstance(prompts_config, SkipSnippets)
-
-    assert len(prompts_config.snippet_patterns) == 0
+    with pytest.raises(FileNotFoundError):
+        load_skip_snippet_patterns("/there/is/nothing/to/read.yml")
 
 
 def test_load_skip_snippet_patterns_correct_path():
@@ -145,7 +142,7 @@ def test_load_skip_snippet_patterns_correct_path():
         test_skip_snippet_data += f'{key}: "{value}"\n'
 
     with mock.patch("logdetective.utils.open", mock.mock_open(read_data=test_skip_snippet_data)):
-        prompts_config = load_skip_snippet_patterns("/there/is/nothing/to/read.yml")
+        prompts_config = load_skip_snippet_patterns("/valid/filters.yml")
 
     assert isinstance(prompts_config, SkipSnippets)
 

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -23,6 +23,7 @@ from tests.base.test_helpers import (
     test_snippets,
     test_prompts,
     test_filter_patterns,
+    test_snippets_filtering,
 )
 
 
@@ -118,11 +119,9 @@ def test_message_formatting(system_role, user_role):
 def test_snippet_filtering():
     """Test snippet filtering"""
 
-    # We only need strings not line numbers
-    simple_snippets = test_snippets[0]
     skip_snippets = SkipSnippets(test_filter_patterns)
-    for snippet in simple_snippets:
-        filter_snippet_patterns(snippet, skip_snippets=skip_snippets)
+    for snippet in test_snippets_filtering:
+        assert filter_snippet_patterns(snippet[0], skip_snippets=skip_snippets) == snippet[1]
 
 
 def test_load_skip_snippet_patterns_wrong_path():
@@ -147,11 +146,6 @@ def test_load_skip_snippet_patterns_correct_path():
     assert isinstance(prompts_config, SkipSnippets)
 
     assert len(prompts_config.snippet_patterns) == len(test_filter_patterns)
-
-    for key, value in prompts_config.snippet_patterns.items():
-
-        assert key in test_filter_patterns
-        assert re.compile(test_filter_patterns[key]) == value
 
 
 def test_load_skip_snippet_patterns_invalid_syntax():


### PR DESCRIPTION
Some log lines are just not useful at all. We can filter them out explicitly, by providing a dictionary of matching regular expressions. 

The `skip_snippets.yml` holds a dictionary of patterns we want to avoid when processing logs. Each entry has a key, which should denote what the pattern is meant to match, thus documenting the intention and also providing useful information in our logs.

The regular expressions are compiled ahead, to save time, and are then matched against chunks before they are submitted to drain. Matching chunks are skipped. The test is executed twice, because there is a chance that a template generated by drain may match one of the excluded patterns. This behavior can occur when a very similar text is present in the logs. Even though it didn't match the specified regular expression, the template generated from it can, thanks to masking.

Feature is enabled in both CLI and server applications.

Empty file will simply allow all chunks to be processed, maintaining existing behavior.

Special care needs to be taken when writing regular expressions in the file. Certain patterns may match syntax of yaml, and be processed by pydanting as part of the data structure.