### PR TITLE
Create note in MR rather than a discussion

### DIFF
--- a/logdetective/server/gitlab.py
+++ b/logdetective/server/gitlab.py
@@ -329,7 +329,7 @@ async def comment_on_mr(  # pylint: disable=too-many-arguments disable=too-many-
 
     # Submit a new comment to the Merge Request using the Gitlab API
     discussion = await asyncio.to_thread(
-        merge_request.discussions.create, {"body": short_comment}
+        merge_request.notes.create, {"body": short_comment}
     )
 
     # Get the ID of the first note


### PR DESCRIPTION
Unresolved threads in GitLab MRs block merges In CS/RHEL development. The MRs also require approval, which is not provided by automation in the case of failed builds, so it is not necessary to force the author to acknowledge the thread.

In [this example](https://gitlab.com/redhat/centos-stream/rpms/selinux-policy/-/merge_requests/208), the author had the builds fail then succeed in a subsequent run. They got the necessary approvals, and resolved the failed results thread, but failed to notice that Log Detective had also opened a thread.

I think a note, which is non-blocking, is sufficient but it is possible I am missing supporting context and a discussion is in fact necessary.