### PR TITLE
Removing original pytest env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -102,5 +102,3 @@ ignore =
 per-file-ignores =
     # Ignore F401 (unused imports) and F811 (redefined names) in test files because of fixtures
     tests/*: F401,F811
-[pytest]
-asyncio_default_fixture_loop_scope = function


### PR DESCRIPTION
Since the tests were split into server and base suites, the original test environment has become vestigial. 