### PR TITLE
Gemini compatibility

### DIFF
--- a/logdetective/server/gitlab.py
+++ b/logdetective/server/gitlab.py
@@ -434,7 +434,7 @@ async def generate_mr_comment(
     content = tpl.render(
         package=job.project_name,
         explanation=response.explanation.text,
-        certainty=f"{response.response_certainty:.2f}",
+        certainty=response.response_certainty,
         emoji_face=emoji_face,
         snippets=response.snippets,
         log_url=log_url,

--- a/logdetective/server/templates/gitlab_full_comment.md.j2
+++ b/logdetective/server/templates/gitlab_full_comment.md.j2
@@ -1,7 +1,9 @@
 The package {{ package }} failed to build, here is a possible explanation why.
 
 Please know that the explanation was provided by AI and may be incorrect.
-In this case, we are {{ certainty }}% certain of the response {{ emoji_face }}.
+{% if certainty > 0 %}
+In this case, we are {{ "%.2f" | format(certainty) }}% certain of the response {{ emoji_face }}.
+{% endif %}
 
 {{ explanation }}
 

--- a/logdetective/server/templates/gitlab_short_comment.md.j2
+++ b/logdetective/server/templates/gitlab_short_comment.md.j2
@@ -1,7 +1,9 @@
 The package {{ package }} failed to build, here is a possible explanation why.
 
 Please know that the explanation was provided by AI and may be incorrect.
-In this case, we are {{ certainty }}% certain of the response {{ emoji_face }}.
+{% if certainty > 0 %}
+In this case, we are {{ "%.2f" | format(certainty) }}% certain of the response {{ emoji_face }}.
+{% endif %}
 
 {{ explanation }}
 


### PR DESCRIPTION
These changes will allow us to use gemini as an inference backend. Most importantly, since gemini does not support the entire OpenAI API, specifically log probabilities, we have to change the way we make calls. The openai library distinguishes between argument not being specified and argument being `None`, so we need to supply different number of arguments based on us calling impaired backend, like gemini. 

The previous implementation simply branched and made different API call if the structured output wasn't required. With two such parameters, it's better to construct a dictionary made of them and supply that instead. 

Smaller changes were made to jinja templates. The certainty, which depends on log probabilities, won't be displayed if it equals to zero. This case can only arise when for some reason no log probabilities are provided. Formatting of certainty has moved to the jinja template. 