### PR TITLE
Limit on maximum length of a snippet

### DIFF
--- a/logdetective/extractors.py
+++ b/logdetective/extractors.py
@@ -20,7 +20,8 @@ class DrainExtractor:
         context: bool = False,
         max_clusters=8,
         skip_snippets: SkipSnippets = SkipSnippets({}),
-    ):
+        max_snippet_len: int = 2000
+    ):  # pylint: disable=R0913,R0917
         config = TemplateMinerConfig()
         config.load(f"{os.path.dirname(__file__)}/drain3.ini")
         config.profiling_enabled = verbose
@@ -29,11 +30,12 @@ class DrainExtractor:
         self.verbose = verbose
         self.context = context
         self.skip_snippets = skip_snippets
+        self.max_snippet_len = max_snippet_len
 
     def __call__(self, log: str) -> list[Tuple[int, str]]:
         out = []
         # Create chunks
-        chunks = list(get_chunks(log))
+        chunks = list(get_chunks(log, self.max_snippet_len))
         # Keep only chunks that don't match any of the excluded patterns
         chunks = [
             (_, chunk)

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -247,6 +247,7 @@ class ExtractorConfig(BaseModel):
     context: bool = True
     max_clusters: int = 8
     verbose: bool = False
+    max_snippet_len: int = 2000
 
     def __init__(self, data: Optional[dict] = None):
         super().__init__()
@@ -256,6 +257,7 @@ class ExtractorConfig(BaseModel):
         self.context = data.get("context", True)
         self.max_clusters = data.get("max_clusters", 8)
         self.verbose = data.get("verbose", False)
+        self.max_snippet_len = data.get("max_snippet_len", 2000)
 
 
 class GitLabInstanceConfig(BaseModel):  # pylint: disable=too-many-instance-attributes

--- a/logdetective/server/utils.py
+++ b/logdetective/server/utils.py
@@ -29,6 +29,7 @@ def mine_logs(log: str) -> List[Tuple[int, str]]:
         context=True,
         max_clusters=SERVER_CONFIG.extractor.max_clusters,
         skip_snippets=SKIP_SNIPPETS_CONFIG,
+        max_snippet_len=SERVER_CONFIG.extractor.max_snippet_len
     )
 
     LOG.info("Getting summary")

--- a/logdetective/utils.py
+++ b/logdetective/utils.py
@@ -39,7 +39,7 @@ def chunk_continues(text: str, index: int) -> bool:
     return False
 
 
-def get_chunks(text: str) -> Generator[Tuple[int, str], None, None]:
+def get_chunks(text: str, max_len: int = 2000) -> Generator[Tuple[int, str], None, None]:
     """Split log into chunks according to heuristic
     based on whitespace and backslash presence.
     """
@@ -54,7 +54,7 @@ def get_chunks(text: str) -> Generator[Tuple[int, str], None, None]:
         chunk += text[i]
         if text[i] == "\n":
             next_line_number += 1
-            if i + 1 < text_len and chunk_continues(text, i):
+            if i + 1 < text_len and chunk_continues(text, i) and i + 1 < max_len:
                 i += 1
                 continue
             yield (original_line_number, chunk)

--- a/server/config.yml
+++ b/server/config.yml
@@ -26,6 +26,8 @@ extractor:
   context: true
   max_clusters: 25
   verbose: false
+# Set this value to reasonable number based on maximum context length of your model
+  # max_snippet_len: 2000
 gitlab:
   "GitLab SaaS":
     url: https://gitlab.com


### PR DESCRIPTION
Template mining is generally reliable when it comes to extracting significant snippets of build logs and limiting the amount of text we send to LLMs. Unfortunately, there are rare edge cases, when our heuristics for chunking produce snippets that are unreasonably large.

When submitted, these snippets cause overflow of model context and failure of analysis. Cases like this are, thankfully, very rare. But we need to guard against them.

This check on maximum number of characters in a snippet takes the pessimistic assumption about tokenizer performance `1 char == 1 token`. Under most circumstances we can expect one token to represent more than one character on average. Nevertheless, in interest of stability and simplicity, the conditional works with characters.

The limit on snippet size must be set in accordance with properties of model used for inference. Setting the limit too high, will, for obvious reasons, effectively prevent the conditional from doing it's job.