### PR TITLE
Fix comment link

### DIFF
--- a/logdetective/server/gitlab.py
+++ b/logdetective/server/gitlab.py
@@ -264,8 +264,7 @@ async def retrieve_and_preprocess_koji_logs(
     LOG.debug("Failed architecture: %s", failed_arch)
 
     log_path = failed_arches[failed_arch].as_posix()
-
-    log_url = f"{gitlab_cfg.api_path}/projects/{job.project_id}/jobs/{job.id}/artifacts/{log_path}"  # pylint: disable=line-too-long
+    log_url = f"{gitlab_cfg.url}/{gitlab_cfg.api_path}/projects/{job.project_id}/jobs/{job.id}/artifacts/{log_path}"  # pylint: disable=line-too-long
     LOG.debug("Returning contents of %s%s", gitlab_cfg.url, log_url)
 
     # Return the log as a file-like object with .read() function

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -307,6 +307,7 @@ class GitLabInstanceConfig(BaseModel):  # pylint: disable=too-many-instance-attr
 
     name: str = None
     url: str = None
+    # Path to API of the gitlab instance, assuming `url` as prefix.
     api_path: str = None
     api_token: str = None
 


### PR DESCRIPTION
Links to log url in gitlab comments were defined as relative. When clicked on, they resolved to a location within the source repository. Leading to errors, such as: ` "...kojilogs/noarch-00000/noarch-0000/task_failed.log" did not exist on "c10s" `.

This had negative impact on user experience and debugging. By setting the URL, and the visual component, of the link to an absolute path, we can make sure that the actual location of logs is accessible.

PR includes improved testing for the `retrieve_and_preprocess_koji_logs` function.
 