### PR TITLE
Moving explanation into folded "Description" section

### DIFF
--- a/logdetective/server/templates/gitlab_full_comment.md.j2
+++ b/logdetective/server/templates/gitlab_full_comment.md.j2
@@ -5,20 +5,20 @@ Please know that the explanation was provided by AI and may be incorrect.
 In this case, we are {{ "%.2f" | format(certainty) }}% certain of the response {{ emoji_face }}.
 {% endif %}
 
+<b>Snippets:</b>
+
+<ul>
+{% for snippet in snippets %}
+  <li>
+    <b>Line {{ snippet.line_number }}:</b> <code>{{ snippet.text }}</code>
+  {{ snippet.explanation.text }}
+  </li>
+{% endfor %}
+</ul>
+
 <details>
   <summary>Description</summary>
   {{ explanation }}
-</details>
-
-<details>
-<ul>
-{% for snippet in snippets %}
-<li>
-<b>Line {{ snippet.line_number }}:</b> <code>{{ snippet.text }}</code>
-{{ snippet.explanation.text }}
-</li>
-{% endfor %}
-</ul>
 </details>
 
 <details>
@@ -34,8 +34,8 @@ In this case, we are {{ "%.2f" | format(certainty) }}% certain of the response {
   <p>
     Additional logs are available from:
     <ul>
-    <li><a href="{{ artifacts_url }}">artifacts.zip</a></li>
-  </ul>
+      <li><a href="{{ artifacts_url }}">artifacts.zip</a></li>
+    </ul>
   </p>
 
   <p>

--- a/logdetective/server/templates/gitlab_short_comment.md.j2
+++ b/logdetective/server/templates/gitlab_short_comment.md.j2
@@ -23,8 +23,8 @@ In this case, we are {{ "%.2f" | format(certainty) }}% certain of the response {
   <p>
     Additional logs are available from:
     <ul>
-    <li><a href="{{ artifacts_url }}">artifacts.zip</a></li>
-  </ul>
+      <li><a href="{{ artifacts_url }}">artifacts.zip</a></li>
+    </ul>
   </p>
 
   <p>


### PR DESCRIPTION
As per UX consultation, the output from LLM is moved into a folded section in the comment. From now, the output will be hidden unless user wants to see it, just like is already the case with snippet analysis and log URLs.

Wording of the first line was slightly adjusted to reflect the change. Some tags were indented to improve code readability. 