### PR TITLE
Disable invalid-name for what is not a constant

### DIFF
--- a/logdetective/server/database/base.py
+++ b/logdetective/server/database/base.py
@@ -24,7 +24,7 @@ sqlalchemy_echo = getenv("SQLALCHEMY_ECHO", "False").lower() in (
     "1",
 )
 engine = create_engine(get_pg_url(), echo=sqlalchemy_echo)
-SessionFactory = sessionmaker(autoflush=True, bind=engine)
+SessionFactory = sessionmaker(autoflush=True, bind=engine)  # pylint: disable=invalid-name
 Base = declarative_base()
 
 


### PR DESCRIPTION
Linter has been complaining recently about a non-standard name of a variable.[1] I have no idea why it didn't have an issue ever before, but it hardly matters. The `SessionFactory` is not really a constant, so the rule does not make sense in this case. 

[1] https://github.com/fedora-copr/logdetective/actions/runs/18469608875/job/52619938554 