### PR TITLE
Removing links that are not rendering, fixing line

### DIFF
--- a/logdetective/server/templates/gitlab_full_comment.md.j2
+++ b/logdetective/server/templates/gitlab_full_comment.md.j2
@@ -57,15 +57,15 @@ Please know that the explanation was provided by AI and may be incorrect.
         </li>
     </ul>
 </details>
----
-This comment was created by [Log Detective][log-detective].
+
+<hr>
+
+This comment was created by <a href="https://logdetective.com">Log Detective</a>.
 Was the provided feedback accurate and helpful?
 <br>
 Please vote with :thumbsup:
 or :thumbsdown: to help us improve.
 <br>
-<i>If this Log Detective report contains harmful content, please use the
-    [Gitlab reporting feature for harmful content](https://docs.gitlab.com/user/report_abuse/)
-and contact the [Log Detective developers](https://github.com/fedora-copr/logdetective/issues).</i>
-[log-detective]: https://log-detective.com/
-[contact]: https://github.com/fedora-copr
+<i>If this Log Detective report contains harmful content,
+please use the <a href="https://docs.gitlab.com/user/report_abuse/">Gitlab reporting feature for harmful content</a>
+and contact the <a href="https://github.com/fedora-copr/logdetective/issues">Log Detective developers</a>.</i>

--- a/logdetective/server/templates/gitlab_short_comment.md.j2
+++ b/logdetective/server/templates/gitlab_short_comment.md.j2
@@ -46,15 +46,15 @@ Please know that the explanation was provided by AI and may be incorrect.
         </li>
     </ul>
 </details>
----
-This comment was created by [Log Detective][log-detective].
+
+<hr>
+
+This comment was created by <a href="https://logdetective.com">Log Detective</a>.
 Was the provided feedback accurate and helpful?
 <br>
 Please vote with :thumbsup:
 or :thumbsdown: to help us improve.
 <br>
-<i>If this Log Detective report contains harmful content, please use the
-    [Gitlab reporting feature for harmful content](https://docs.gitlab.com/user/report_abuse/)
-and contact the [Log Detective developers](https://github.com/fedora-copr/logdetective/issues).</i>
-[log-detective]: https://log-detective.com/
-[contact]: https://github.com/fedora-copr
+<i>If this Log Detective report contains harmful content,
+please use the <a href="https://docs.gitlab.com/user/report_abuse/">Gitlab reporting feature for harmful content</a>
+and contact the <a href="https://github.com/fedora-copr/logdetective/issues">Log Detective developers</a>.</i>


### PR DESCRIPTION
Gitlab just can't handle markdown properly. For some reason it keeps breaking, even things that used to work. Example attached. So I'm moving the comment to full HTML. 
<img width="867" height="124" alt="image" src="https://github.com/user-attachments/assets/572cd619-1251-452a-8902-6e2c8ffc8a2f" />
