### PR TITLE
Switch to Fedora 43 base image didn't include update of python version in PYTHONPATH override

### DIFF
--- a/.env
+++ b/.env
@@ -7,7 +7,7 @@ ENV="devel"
 LOGDETECTIVE_SERVER_PORT=8080
 LOGDETECTIVE_CERTDIR="/src/server/"
 # for some reason, fastapi cripples sys.path and some deps cannot be found
-PYTHONPATH=/src:/usr/local/lib64/python3.13/site-packages:/usr/lib64/python313.zip:/usr/lib64/python3.13/:/usr/lib64/python3.13/lib-dynload:/usr/local/lib/python3.13/site-packages:/usr/lib64/python3.13/site-packages:/usr/lib/python3.13/site-packages
+PYTHONPATH=/src:/usr/local/lib64/python3.14/site-packages:/usr/lib64/python314.zip:/usr/lib64/python3.14/:/usr/lib64/python3.14/lib-dynload:/usr/local/lib/python3.14/site-packages:/usr/lib64/python3.14/site-packages:/usr/lib/python3.14/site-packages
 # Variables are taken from documentation to llama.cpp server runtime
 # https://github.com/ggml-org/llama.cpp/blob/master/examples/server/README.md#usage
 LLAMA_ARG_MODEL="/models/granite-4.0-h-tiny-Q8_0.gguf"


### PR DESCRIPTION
This PR fixes the issue, and allows FastAPI server to function appropriately. 