### PR TITLE
Reworking visibility of certainty ratings 

### DIFF
--- a/logdetective/logdetective.py
+++ b/logdetective/logdetective.py
@@ -204,7 +204,7 @@ async def run():  # pylint: disable=too-many-statements,too-many-locals,too-many
             print(delta, end="", flush=True)
     certainty = compute_certainty(probs)
 
-    print(f"\nResponse certainty: {certainty:.2f}%\n")
+    LOG.debug("Response certainty: %.2f %%" % certainty)
 
 
 def main():

--- a/logdetective/logdetective.py
+++ b/logdetective/logdetective.py
@@ -204,7 +204,7 @@ async def run():  # pylint: disable=too-many-statements,too-many-locals,too-many
             print(delta, end="", flush=True)
     certainty = compute_certainty(probs)
 
-    LOG.debug("Response certainty: %.2f %%" % certainty)
+    LOG.debug("Response certainty: %.2f %%", certainty)
 
 
 def main():

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -303,6 +303,7 @@ class GeneralConfig(BaseModel):
     sentry_dsn: HttpUrl | None = None
     collect_emojis_interval: int = 60 * 60  # seconds
     top_k_snippets: int = 0
+    report_certainty: bool = False
 
 
 class Config(BaseModel):

--- a/logdetective/server/server.py
+++ b/logdetective/server/server.py
@@ -603,7 +603,8 @@ async def receive_gitlab_job_event_webhook(
         forge,
         job_hook,
         request.app.state.llm_request_limiter,
-        request.app.state.extractors
+        request.app.state.extractors,
+        SERVER_CONFIG.general.report_certainty,
     )
 
     # No return value or body is required for a webhook.

--- a/logdetective/server/templates/gitlab_full_comment.md.j2
+++ b/logdetective/server/templates/gitlab_full_comment.md.j2
@@ -1,7 +1,9 @@
 The package {{ package }} build has experienced an issue.
 Please know that the explanation was provided by AI and may be incorrect.
+{% if report_certainty %}
 {% if certainty > 0 %}
     In this case, we are {{ "%.2f" | format(certainty) }}% certain of the response {{ emoji_face }}.
+{% endif %}
 {% endif %}
 
 <details open>

--- a/logdetective/server/templates/gitlab_short_comment.md.j2
+++ b/logdetective/server/templates/gitlab_short_comment.md.j2
@@ -1,7 +1,9 @@
 The package {{ package }} build has experienced an issue.
 Please know that the explanation was provided by AI and may be incorrect.
+{% if report_certainty %}
 {% if certainty > 0 %}
     In this case, we are {{ "%.2f" | format(certainty) }}% certain of the response {{ emoji_face }}.
+{% endif %}
 {% endif %}
 
 <details open>

--- a/server/config.yml
+++ b/server/config.yml
@@ -63,3 +63,5 @@ general:
   # Values equal, or higher, than number of snippets produced,
   # will effectivelly result in no filtering at all.
   # top_k_snippets: 0
+  # Certainty ratings are disabled by default.
+  # report_certainty: false


### PR DESCRIPTION
Certainty ratings in CLI will now be on `debug` level of the output, and visible only if the verbosity is increased.

Certainty ratings in server mode, will only be outputted, if `report_certainty` field in config is set to `True`. The value is set to `False` by default. If the `report_certainty` field is set to false, the certainty will not be rendered in the gitlab comment, even if it has been calculated.