### PR TITLE
Constraining builds and tests to latest Fedora releases

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -26,26 +26,31 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-      - fedora-all
+      - fedora-rawhide
+      - fedora-44
   # Run build on commit with OpenScanHub checks
   - job: copr_build
     trigger: commit
     branch: main
     targets:
-      - fedora-all
+      - fedora-rawhide
+      - fedora-44
     osh_diff_scan_after_copr_build: true
   - job: tests
     trigger: pull_request
     targets:
-      - fedora-all
+      - fedora-rawhide
+      - fedora-44
   # downstream automation:
   - job: koji_build
     trigger: commit
     allowed_committers: ['packit', 'msuchy']
     dist_git_branches:
-      - fedora-all
+      - fedora-rawhide
+      - fedora-44
 
   - job: bodhi_update
     trigger: commit
     dist_git_branches:
-      - fedora-all
+      - fedora-rawhide
+      - fedora-44


### PR DESCRIPTION
This PR limits builds and tests triggered by packit to Fedora 44 and Fedora rawhide targets.
This change has been introduced for two reasons:

- Only Fedora rawhide is receiving new releases of Log Detective. Testing them on older releases doesn't make sense.
- Newest Fedora release introduce versions of our dependencies that fall outside of set ranges. Having multiple dependencies with allowed version range over one major release could lead to issues.

Once this PR is merged, we can revise dependency constraints.

Depends-On: https://github.com/fedora-copr/logdetective/pull/459 