### PR TITLE
Show correct line numbers in csgrep extractor

### DIFF
--- a/logdetective/extractors.py
+++ b/logdetective/extractors.py
@@ -123,6 +123,7 @@ class CSGrepExtractor(DrainExtractor):
                 [
                     "csgrep",
                     "--event=error",
+                    "--record-input-locations",
                     "--remove-duplicates",
                     "--mode=json",
                     "--quiet",
@@ -149,16 +150,20 @@ class CSGrepExtractor(DrainExtractor):
         try:
             report = CSGrepOutput.model_validate_json(result.stdout)
         except ValidationError as ex:
-            LOG.exception("Exception encountered while parsing csgrpe output %s", ex)
+            LOG.exception("Exception encountered while parsing csgrep output %s", ex)
             raise ex
-        for defect in report.defects:
-            # Single original error message can be split across multiple events
-            # before returning, we will turn them back into single string.
-            # We must also extract the original line number.
-            # Line number is NOT location of message in the log, but location of
-            # the issue in source, we can't really mix the two, so we'll set it to `0`.
-
-            chunks.append((0, "\n".join([event.message for event in defect.events])))
+        # Single original error message can be split across multiple events.
+        # Before returning, we will turn them back into single string.
+        # We must also extract the original line number,
+        # i.e. NOT the location of the issue in the source code ("event.line"),
+        # but the location of message in the log ("event.input_line").
+        chunks = [
+            (
+                d.events[0].input_line,
+                "\n".join([e.message for e in d.events])
+            )
+            for d in report.defects if d.events  # skipping potential 0-event defects
+        ]
 
         chunks = self.filter_snippet_patterns(chunks)
         LOG.info("Total %d messages extracted with csgrep", len(chunks))

--- a/logdetective/models.py
+++ b/logdetective/models.py
@@ -57,10 +57,12 @@ class SkipSnippets(BaseModel):
 class CSGrepEvent(BaseModel):
     """`csgrep` splits error and warning messages into individual events."""
 
-    file_name: str
-    line: int
+    file_name: str  # references the source file which compilation error talks about
+    line: int  # line number in the source file
     event: str
     message: str
+    input_file: str  # references the name of the compilation log (absolute path)
+    input_line: int  # line number in the compilation log
     verbosity_level: int
 
 

--- a/logdetective/utils.py
+++ b/logdetective/utils.py
@@ -97,8 +97,8 @@ def get_chunks(
     # Chunk we will be yielding
     chunk = ""
     # Number of line where the message started
-    original_line = 0
-    for i, line in enumerate(lines):
+    original_line = 1
+    for i, line in enumerate(lines, start=1):
         if len(line) == 0:
             continue
         if new_message(line):

--- a/tests/base/test_extractors.py
+++ b/tests/base/test_extractors.py
@@ -7,7 +7,11 @@ from logdetective.extractors import DrainExtractor, CSGrepExtractor, Extractor
 
 from tests.base.test_helpers import (
     simple_log,
-    csgrep_output,
+    csgrep_output_simple,
+    siril_log_snippet,
+    csgrep_output_siril,
+    dolphin_emu_log_snippet,
+    csgrep_output_dolphin_emu,
     package_unavailable_log,
     DNF_PACKAGE_UNAVAILABLE_EXPECTED_SNIPPETS,
 )
@@ -37,7 +41,7 @@ def test_filter_snippet_patterns():
 # --- Tests for DrainExtractor ---
 
 
-def test_drain_extractor_call(simple_log):
+def test_drain_extractor_call(simple_log: list[str]):
     """Tests the basic functionality of the DrainExtractor to ensure it
     clusters and extracts log messages correctly.
     """
@@ -45,7 +49,7 @@ def test_drain_extractor_call(simple_log):
     result = extractor("".join(simple_log))
     # The extractor should identify the two unique "An error occurred" lines
     assert len(result) == 2
-    messages = [e[1] for e in result]
+    messages = [msg for _, msg in result]
     # Two of the longest messages must be included in the results
     assert simple_log[6].strip() in messages
     assert simple_log[7].strip() in messages
@@ -65,21 +69,117 @@ def test_drain_extractor_package_unavailable_log(package_unavailable_log):
 # --- Tests for CSGrepExtractor ---
 
 
-def test_csgrep_extractor_call_success(monkeypatch, simple_log, csgrep_output):
+def test_csgrep_extractor_call_success(monkeypatch, simple_log: list[str], csgrep_output_simple):
     """Tests a successful run of the CSGrepExtractor, ensuring it correctly
     parses the JSON output from a mocked csgrep process.
     """
     mock_run = MagicMock()
-    mock_run.return_value = MagicMock(returncode=0, stdout=csgrep_output, stderr="")
+    mock_run.return_value = MagicMock(returncode=0, stdout=csgrep_output_simple, stderr="")
     monkeypatch.setattr(sp, "run", mock_run)
 
     extractor = CSGrepExtractor()
-    result = extractor(simple_log)
+    snippets = extractor("".join(simple_log))
 
-    assert len(result) == 2
-    assert result[0] == (0, "An error occurred: file not found.")
-    assert result[1] == (0, "An error occurred: permission denied.")
+    assert len(snippets) == 2
+    assert snippets[0] == (3, "An error occurred: file not found.")
+    assert snippets[1] == (4, "An error occurred: permission denied.")
     mock_run.assert_called_once()
+
+
+def test_csgrep_extractor_call_success_model_output(
+    monkeypatch,
+    siril_log_snippet,
+    csgrep_output_siril
+):
+    """
+    Test a snippet from a failed build log file, mocking csgrep result as as validated model.
+    Note: Actually running csgrep would require us to run these tests
+    in a container setup, so we mock the results.
+    """
+    mock_run = MagicMock()
+    mock_run.return_value = MagicMock(
+        returncode=0,
+        stdout=csgrep_output_siril,
+        stderr=""
+    )
+    monkeypatch.setattr(sp, "run", mock_run)
+
+    extractor = CSGrepExtractor()
+    snippets = extractor(siril_log_snippet)
+
+    assert len(snippets) == 1
+    line, text = snippets[0]
+    assert line == 2
+    assert "ld returned 1 exit status" in text
+    mock_run.assert_called_once()
+
+
+def test_csgrep_extractor_call_success_raw_output(
+    monkeypatch,
+    dolphin_emu_log_snippet,
+    csgrep_output_dolphin_emu
+):
+    """
+    Test a snippet from a failed build log file, mocking csgrep result as raw string.
+    Note: Actually running csgrep would require us to run these tests
+    in a container setup, so we mock the results.
+    """
+    mock_run = MagicMock()
+    mock_run.return_value = MagicMock(
+        returncode=0,
+        stdout=csgrep_output_dolphin_emu,
+        stderr=""
+    )
+    monkeypatch.setattr(sp, "run", mock_run)
+
+    extractor = CSGrepExtractor()
+    snippets = extractor(dolphin_emu_log_snippet)
+
+    assert len(snippets) == 1
+    line, text = snippets[0]
+    assert line == 1
+    assert "expected primary-expression before > token" in text
+    assert "static_assert(fmt::detail::is_compile_string<S>::value)" in text
+    mock_run.assert_called_once()
+
+
+def _get_csgrep_version() -> tuple[int]:
+    try:
+        csgrep_ver = tuple(
+            int(x) for x in
+            sp.run(
+                [
+                    "csgrep",
+                    "--version",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            ).stdout.split()[-1].split(".")
+        )
+    except (FileNotFoundError, IndexError, ValueError):
+        csgrep_ver = (0, 0, 0)
+    return csgrep_ver
+
+
+@pytest.mark.skipif(_get_csgrep_version() < (3, 5, 7), reason="requires csgrep >= 3.5.7")
+def test_csgrep_extractor_no_mock(dolphin_emu_log_snippet, siril_log_snippet):
+    extractor = CSGrepExtractor()
+    snippets = extractor(siril_log_snippet)
+
+    assert len(snippets) == 1
+    line, text = snippets[0]
+    assert line == 2
+    assert "ld returned 1 exit status" in text
+
+    extractor = CSGrepExtractor()
+    snippets = extractor(dolphin_emu_log_snippet)
+
+    assert len(snippets) == 1
+    line, text = snippets[0]
+    assert line == 1
+    assert "expected primary-expression before > token" in text
+    assert "static_assert(fmt::detail::is_compile_string<S>::value)" in text
 
 
 def test_csgrep_extractor_call_no_output(monkeypatch, simple_log):

--- a/tests/base/test_helpers.py
+++ b/tests/base/test_helpers.py
@@ -83,16 +83,17 @@ def simple_log() -> list[str]:
             and here.\n""",
         """This message is splint into an introduction:
             and a very long continuation, and a very long continuation, and a very long continuation,
-            and a very long continuation ............."""]
+            and a very long continuation ............."""
+    ]
 
 
 @pytest.fixture
-def package_unavailable_log():
+def package_unavailable_log() -> str:
     return "\n".join(DNF_PACKAGE_UNAVAILABLE_EXPECTED_SNIPPETS)
 
 
 @pytest.fixture
-def csgrep_output():
+def csgrep_output_simple() -> str:
     """Provides a sample csgrep JSON output using the new data structures."""
     return CSGrepOutput(
         defects=[
@@ -106,6 +107,8 @@ def csgrep_output():
                         file_name="test.c",
                         line=3,
                         event="error",
+                        input_file="simple.log",
+                        input_line=3,
                         message="An error occurred: file not found.",
                         verbosity_level=1,
                     )
@@ -120,6 +123,8 @@ def csgrep_output():
                     CSGrepEvent(
                         file_name="test.cpp",
                         line=4,
+                        input_file="simple.log",
+                        input_line=4,
                         event="error",
                         message="An error occurred: permission denied.",
                         verbosity_level=1,
@@ -128,3 +133,113 @@ def csgrep_output():
             ),
         ]
     ).model_dump_json()
+
+
+@pytest.fixture
+def siril_log_snippet() -> str:
+    """see https://github.com/fedora-copr/logdetective-sample/blob/main/data/21ad14e5-f01f-4f88-ae60-eea095478e45/build.log#L657"""
+    lines = [
+        (
+            "/usr/bin/ld: "
+            "/builddir/build/BUILD/siril-1.2.5/redhat-linux-build/../src/gui/newdeconv.c:835:"
+            "(.text+0x6003): undefined reference to `gf_estimate_kernel'"
+        ),
+        "collect2: error: ld returned 1 exit status",
+        (
+            "[234/235] g++  -o src/siril-cli src/siril-cli.p/main-cli.c.o -Wl,--as-needed "
+            "-Wl,--no-undefined -Wl,--whole-archive -Wl,--start-group src/libsiril.a"
+        ),
+    ]
+    return "\n".join(lines)
+
+
+@pytest.fixture
+def dolphin_emu_log_snippet() -> str:
+    """see https://github.com/fedora-copr/logdetective-sample/blob/main/data/449ca0a3-a264-4f86-a3ec-b0a7b0af9b4d/build.log#L600"""
+    lines = [
+        (
+            "/builddir/build/BUILD/dolphin-emu-2409-build/dolphin-2409/"
+            "Source/Core/Common/MsgHandler.h:45:49: "
+            "error: expected primary-expression before > token [-Wtemplate-body]"
+        ),
+        "   45 |   static_assert(fmt::detail::is_compile_string<S>::value);",
+        "      |                                                 ^",
+    ]
+    return "\n".join(lines)
+
+
+@pytest.fixture
+def csgrep_output_siril() -> str:
+    """Provides a sample csgrep JSON-validated output from an actual build log file."""
+    return CSGrepOutput(
+        defects=[
+            CSGrepDefect(
+                checker="COMPILER_WARNING",
+                language="c/c++",
+                tool="gcc",
+                key_event_idx=0,
+                events=[
+                    CSGrepEvent(
+                        file_name="collect2",
+                        line=0,
+                        input_file="siril.log",
+                        input_line=2,
+                        event="error",
+                        message="ld returned 1 exit status",
+                        verbosity_level=0,
+                    )
+                ]
+            ),
+        ]
+    ).model_dump_json()
+
+
+@pytest.fixture
+def csgrep_output_dolphin_emu() -> str:
+    """
+    Provides a raw csgrep JSON output from an actual build log file -.
+    Note: csgrep may include 'column' for some events,
+    but it is irrelevant for Log Detective purposes
+    """
+    return (
+        '{'
+        '    "defects": ['
+        '        {'
+        '            "checker": "COMPILER_WARNING",'
+        '            "language": "c/c++",'
+        '            "tool": "gcc",'
+        '            "key_event_idx": 0,'
+        '            "events": ['
+        '                {'
+        '                    "file_name": "/builddir/build/BUILD/dolphin-emu-2409-build/dolphin-2409/Source/Core/Common/MsgHandler.h",'
+        '                    "line": 45,'
+        '                    "column": 49,'
+        '                    "input_file": "dolphin-emu.log",'
+        '                    "input_line": 1,'
+        '                    "event": "error[-Wtemplate-body]",'
+        '                    "message": "expected primary-expression before > token",'
+        '                    "verbosity_level": 0'
+        '                },'
+        '                {'
+        '                    "file_name": "",'
+        '                    "line": 0,'
+        '                    "input_file": "dolphin-emu.log",'
+        '                    "input_line": 2,'
+        '                    "event": "#",'
+        '                    "message": "   45 |   static_assert(fmt::detail::is_compile_string<S>::value);",'
+        '                    "verbosity_level": 1'
+        '                },'
+        '                {'
+        '                    "file_name": "",'
+        '                    "line": 0,'
+        '                    "input_file": "dolphin-emu.log",'
+        '                    "input_line": 3,'
+        '                    "event": "#",'
+        '                    "message": "      |                                                 ^",'
+        '                    "verbosity_level": 1'
+        '                }'
+        '            ]'
+        '        }'
+        '    ]'
+        '}'
+    )


### PR DESCRIPTION
This PR fixes snippet line-number references in extractors, utilizing `event.input_line` field introduced in `csdiff-3.5.7`, now available in dnf.

The feature is tested in `csdiff` itself. One integration test (requiring csdiff >= 3.5.7 to run) was added. Snippet line numbers are now 1-indexed across all extractors.