### PR TITLE
Collect emojis only when applicable

### DIFF
--- a/logdetective/server/server.py
+++ b/logdetective/server/server.py
@@ -211,8 +211,10 @@ async def lifespan(fapp: FastAPI):
     # Ensure that the database is initialized.
     await logdetective.server.database.base.init()
 
-    # Start the background task scheduler for collecting emojis
-    asyncio.create_task(schedule_collect_emojis_task(fapp.state.connection_manager))
+    # Start the background task scheduler for collecting emojis, if applicable.
+    # ConnectionManager.gitlab_connections is empty if gitlab.instances contains no entries
+    if fapp.state.connection_manager.gitlab_connections:
+        asyncio.create_task(schedule_collect_emojis_task(fapp.state.connection_manager))
 
     yield
 

--- a/server/config.yml
+++ b/server/config.yml
@@ -73,3 +73,7 @@ general:
   # Log Detective server blocks analysis of local files
   # as a security measure. This block can be disabled.
   # block_localhost_urls: true
+  # This is the period in seconds of how often is the emoji feedback collected,
+  # default = 1 hour. Emoji feedback is collected only if `gitlab` config
+  # contains some valid configuration entry.
+  # collect_emojis_interval: 3600


### PR DESCRIPTION
This change should reduce the server load a little and clean up logs. After merging this, we will need to release `v3.10.0` on github and then also rollout on public and oc instances.