### PR TITLE
Add instructions for verbosity limitation

### DIFF
--- a/logdetective/prompts/system_prompt.j2
+++ b/logdetective/prompts/system_prompt.j2
@@ -39,6 +39,13 @@ Emails have been replaced by copr-team@redhat.com.
 Fingerprints and keys in hexadecimal have been replaced with all Fs.
 Note that this is not an error, but a security measure.
 
+## Response format
+
+Keep your responses brief and to the point. Do not include any markdown, or other formatting
+of the text, except for paragraphs and line breaks.
+
+Your responses should be at most one paragraph in length, if possible.
+
 {% if references %}
 ## References:
 


### PR DESCRIPTION
The prompt now nudges model to produce shorter output, without markdown formatting. This makes responses faster.