### PR TITLE
Add timeout to inference config

### DIFF
--- a/logdetective/server/agent/agent.py
+++ b/logdetective/server/agent/agent.py
@@ -11,7 +11,12 @@ from beeai_framework.middleware.trajectory import GlobalTrajectoryMiddleware
 from logdetective.server.config import PROMPT_CONFIG, SERVER_CONFIG
 from logdetective.server.agent.tools import DrainExtractorTool, CSGrepExtractorTool
 from logdetective.server.models import APIResponse, BuildMetadata, Explanation
-from logdetective.server.exceptions import LogDetectiveAgentResponseFailure
+from logdetective.server.exceptions import (
+    LogDetectiveAgentResponseFailure,
+    LogDetectiveInferenceTimeout,
+)
+from beeai_framework.backend.errors import ChatModelError
+from litellm.exceptions import Timeout as LiteLLMTimeout
 
 
 async def analyze_artifacts(
@@ -82,11 +87,16 @@ async def analyze_artifacts(
         artifacts=",".join(artifacts.keys())
     )
 
-    agent_output = await agent.run(
-        agent_input,
-        max_retries_per_step=SERVER_CONFIG.inference.max_retries_per_step,
-        total_max_retries=SERVER_CONFIG.inference.total_max_retries,
-    ).middleware(middleware)
+    try:
+        agent_output = await agent.run(
+            agent_input,
+            max_retries_per_step=SERVER_CONFIG.inference.max_retries_per_step,
+            total_max_retries=SERVER_CONFIG.inference.total_max_retries,
+        ).middleware(middleware)
+    except ChatModelError as e:
+        if isinstance(e.__cause__, LiteLLMTimeout):
+            raise LogDetectiveInferenceTimeout from e
+        raise
 
     if not agent_output.state.answer:
         raise LogDetectiveAgentResponseFailure

--- a/logdetective/server/config.py
+++ b/logdetective/server/config.py
@@ -59,6 +59,9 @@ def get_openai_chat_model(inference_config: InferenceConfig) -> OpenAIChatModel:
         api_key=inference_config.api_token,
         base_url=inference_config.url,
         tool_choice_support={"auto"},
+        settings={
+            "timeout": inference_config.api_timeout,
+        },
     )
 
     chat_model.parameters.temperature = inference_config.temperature

--- a/logdetective/server/exceptions.py
+++ b/logdetective/server/exceptions.py
@@ -45,5 +45,9 @@ class InvalidKojiTaskResultResponse(LogDetectiveKojiException):
     """Call to `getTaskResult` has returned an unexpected data structure"""
 
 
-class LogDetectiveAgentResponseFailure(Exception):
+class LogDetectiveAgentResponseFailure(LogDetectiveException):
     """Log Detective agent did not return a valid response."""
+
+
+class LogDetectiveInferenceTimeout(LogDetectiveException):
+    """Inference server took longer than allowed to respond."""

--- a/logdetective/server/gitlab.py
+++ b/logdetective/server/gitlab.py
@@ -22,6 +22,7 @@ from logdetective.server.exceptions import (
     LogsTooLargeError,
     LogDetectiveConnectionError,
     LogDetectiveArtifactsMissingError,
+    LogDetectiveInferenceTimeout,
 )
 from logdetective.server.agent.agent import analyze_artifacts
 from logdetective.server.metric import add_new_metrics, update_metrics
@@ -43,7 +44,8 @@ MR_REGEX = re.compile(r"refs/merge-requests/(\d+)/.*$")
 FAILURE_LOG_REGEX = re.compile(r"(\w*\.log)")
 
 
-# pylint: disable=too-many-locals disable=too-many-arguments disable=too-many-positional-arguments
+# pylint: disable=too-many-locals, too-many-arguments, \
+# pylint: disable=too-many-positional-arguments, too-many-return-statements
 async def process_gitlab_job_event(
     gitlab_cfg: GitLabInstanceConfig,
     gitlab_connection: gitlab.Gitlab,
@@ -119,10 +121,21 @@ async def process_gitlab_job_event(
     metrics_id = await add_new_metrics(
         api_name=EndpointType.ANALYZE_GITLAB_JOB,
     )
-    response = await analyze_artifacts(artifacts={log_url: log_text}, chat_model=chat_model)
+    try:
+        response = await analyze_artifacts(
+            artifacts={log_url: log_text}, chat_model=chat_model
+        )
+    except LogDetectiveInferenceTimeout:
+        LOG.error(
+            "Inference server timed out for job %d in project %s.",
+            job_hook.build_id,
+            project.id,
+        )
+        return
+    finally:
+        preprocessed_log.close()
 
     await update_metrics(metrics_id, response)
-    preprocessed_log.close()
 
     # check if this project is on the opt-in list for posting comments.
     if not is_eligible_package(project.name):

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -225,6 +225,7 @@ class InferenceConfig(BaseModel):  # pylint: disable=too-many-instance-attribute
     # OpenAI client library requires a string to be specified for API token
     # even if it is not checked on the server side
     api_token: str = "None"
+    api_timeout: float = 30.0
     model: str = "default-model"
     temperature: NonNegativeFloat = DEFAULT_TEMPERATURE
     system_role: str = SYSTEM_ROLE_DEFAULT

--- a/logdetective/server/server.py
+++ b/logdetective/server/server.py
@@ -23,7 +23,10 @@ import sentry_sdk
 from beeai_framework.adapters.openai import OpenAIChatModel
 
 from logdetective.utils import sanitize_artifact
-from logdetective.server.exceptions import KojiInvalidTaskID
+from logdetective.server.exceptions import (
+    KojiInvalidTaskID,
+    LogDetectiveInferenceTimeout,
+)
 
 from logdetective.server.database.models.koji import KojiTaskAnalysis
 from logdetective.server.database.models.exceptions import (
@@ -259,9 +262,16 @@ async def analyze(
         payload, http_session, request_size=request_size
     )
 
-    return await analyze_artifacts(
-        artifacts=artifacts, chat_model=request.app.state.openai_chat_model
-    )
+    try:
+        response = await analyze_artifacts(
+            artifacts=artifacts, chat_model=request.app.state.openai_chat_model
+        )
+    except LogDetectiveInferenceTimeout as exc:
+        raise HTTPException(
+            status_code=504,
+            detail="Inference server timed out during some LLM call.",
+        ) from exc
+    return response
 
 
 @app.get(
@@ -416,9 +426,15 @@ async def analyze_koji_task(
         task_id=task_id,
         log_file_name=log_file_name,
     )
-    response = await analyze_artifacts(
-        {log_file_name: log_text}, chat_model=openai_chat_model
-    )
+    try:
+        response = await analyze_artifacts(
+            {log_file_name: log_text}, chat_model=openai_chat_model
+        )
+    except LogDetectiveInferenceTimeout:
+        LOG.error("Inference service timed out for koji task %d.", task_id)
+        # The empty task will sit with null response_id until analysis_timeout elapses,
+        # then callers get KojiTaskAnalysisTimeoutError -> handled as 503
+        return
 
     # Now that we have the response, we can update the metrics and mark the
     # koji task analysis as completed.

--- a/server/config.yml
+++ b/server/config.yml
@@ -7,6 +7,7 @@ inference:
   log_probs: true
   url: http://inference-server:8000/v1
   api_token: "XXX" # Must not be empty, even if the server doesn't require authentication
+  api_timeout: 60.0 # Timeout for the LLM API client, how long should it wait for inference server response
   model: "fedora-copr/granite-4.0-h-tiny-quantized.w8a8"
   # Role needs to be aligned with chat template
   system_role: system


### PR DESCRIPTION
Also adding proper error handling for koji and gitlab analysis. In case of koji and gitlab, error is logged and empty result returned. Not sure how empty task will be handled in the koji background tasks queue -> Claude says it's going to raise 503, which seems fine.