### PR TITLE
Rate limit and other inference errors handling

### DIFF
--- a/logdetective/server/agent/agent.py
+++ b/logdetective/server/agent/agent.py
@@ -1,12 +1,18 @@
 from typing import Optional
+
 from beeai_framework.agents.requirement import RequirementAgent
 from beeai_framework.agents.requirement.requirements.conditional import (
     ConditionalRequirement,
 )
+from beeai_framework.backend.errors import ChatModelError
 from beeai_framework.memory import UnconstrainedMemory
 from beeai_framework.tools.think import ThinkTool
 from beeai_framework.adapters.openai import OpenAIChatModel
 from beeai_framework.middleware.trajectory import GlobalTrajectoryMiddleware
+from litellm.exceptions import (
+    Timeout as LiteLLMTimeout,
+    RateLimitError as LiteLLMRateLimit
+)
 
 from logdetective.server.config import PROMPT_CONFIG, SERVER_CONFIG
 from logdetective.server.agent.tools import DrainExtractorTool, CSGrepExtractorTool
@@ -14,13 +20,15 @@ from logdetective.server.models import APIResponse, BuildMetadata, Explanation
 from logdetective.server.exceptions import (
     LogDetectiveAgentResponseFailure,
     LogDetectiveInferenceTimeout,
+    LogDetectiveInferenceError,
+    LogDetectiveInferenceRateLimit,
 )
-from beeai_framework.backend.errors import ChatModelError
-from litellm.exceptions import Timeout as LiteLLMTimeout
 
 
 async def analyze_artifacts(
-    artifacts: dict[str, str], chat_model: OpenAIChatModel, build_metadata: Optional[BuildMetadata] = None
+    artifacts: dict[str, str],
+    chat_model: OpenAIChatModel,
+    build_metadata: Optional[BuildMetadata] = None
 ) -> APIResponse:
     """Analyze build artifacts using Log Detective agent.
 
@@ -93,10 +101,13 @@ async def analyze_artifacts(
             max_retries_per_step=SERVER_CONFIG.inference.max_retries_per_step,
             total_max_retries=SERVER_CONFIG.inference.total_max_retries,
         ).middleware(middleware)
-    except ChatModelError as e:
-        if isinstance(e.__cause__, LiteLLMTimeout):
-            raise LogDetectiveInferenceTimeout from e
-        raise
+    except ChatModelError as exc:
+        cause = exc.__cause__
+        if isinstance(cause, LiteLLMTimeout):
+            raise LogDetectiveInferenceTimeout(str(cause)) from exc
+        if isinstance(cause, LiteLLMRateLimit):
+            raise LogDetectiveInferenceRateLimit(str(cause)) from exc
+        raise LogDetectiveInferenceError(exc.message) from exc
 
     if not agent_output.state.answer:
         raise LogDetectiveAgentResponseFailure

--- a/logdetective/server/exceptions.py
+++ b/logdetective/server/exceptions.py
@@ -49,5 +49,16 @@ class LogDetectiveAgentResponseFailure(LogDetectiveException):
     """Log Detective agent did not return a valid response."""
 
 
-class LogDetectiveInferenceTimeout(LogDetectiveException):
+class LogDetectiveInferenceError(LogDetectiveException):
+    """Inference service encountered some issue."""
+    http_status_code = 500
+
+
+class LogDetectiveInferenceTimeout(LogDetectiveInferenceError):
     """Inference server took longer than allowed to respond."""
+    http_status_code = 500
+
+
+class LogDetectiveInferenceRateLimit(LogDetectiveInferenceError):
+    """Inference service (temporarily) unavailable. Try again later."""
+    http_status_code = 503

--- a/logdetective/server/gitlab.py
+++ b/logdetective/server/gitlab.py
@@ -22,7 +22,7 @@ from logdetective.server.exceptions import (
     LogsTooLargeError,
     LogDetectiveConnectionError,
     LogDetectiveArtifactsMissingError,
-    LogDetectiveInferenceTimeout,
+    LogDetectiveInferenceError,
 )
 from logdetective.server.agent.agent import analyze_artifacts
 from logdetective.server.metric import add_new_metrics, update_metrics
@@ -125,11 +125,10 @@ async def process_gitlab_job_event(
         response = await analyze_artifacts(
             artifacts={log_url: log_text}, chat_model=chat_model
         )
-    except LogDetectiveInferenceTimeout:
+    except LogDetectiveInferenceError as exc:
         LOG.error(
-            "Inference server timed out for job %d in project %s.",
-            job_hook.build_id,
-            project.id,
+            "%s during job %d in project %s: %s",
+            type(exc).__name__, job_hook.build_id, project.id, exc
         )
         return
     finally:

--- a/logdetective/server/server.py
+++ b/logdetective/server/server.py
@@ -25,7 +25,7 @@ from beeai_framework.adapters.openai import OpenAIChatModel
 from logdetective.utils import sanitize_artifact
 from logdetective.server.exceptions import (
     KojiInvalidTaskID,
-    LogDetectiveInferenceTimeout,
+    LogDetectiveInferenceError,
 )
 
 from logdetective.server.database.models.koji import KojiTaskAnalysis
@@ -266,10 +266,10 @@ async def analyze(
         response = await analyze_artifacts(
             artifacts=artifacts, chat_model=request.app.state.openai_chat_model
         )
-    except LogDetectiveInferenceTimeout as exc:
+    except LogDetectiveInferenceError as exc:
         raise HTTPException(
-            status_code=504,
-            detail="Inference server timed out during some LLM call.",
+            status_code=exc.http_status_code,
+            detail=f"{type(exc).__doc__}: {exc}",
         ) from exc
     return response
 
@@ -430,10 +430,10 @@ async def analyze_koji_task(
         response = await analyze_artifacts(
             {log_file_name: log_text}, chat_model=openai_chat_model
         )
-    except LogDetectiveInferenceTimeout:
-        LOG.error("Inference service timed out for koji task %d.", task_id)
+    except LogDetectiveInferenceError as exc:
         # The empty task will sit with null response_id until analysis_timeout elapses,
         # then callers get KojiTaskAnalysisTimeoutError -> handled as 503
+        LOG.error("Not processing Koji task %d: %s: %s", task_id, type(exc).__name__, exc)
         return
 
     # Now that we have the response, we can update the metrics and mark the

--- a/tests/server/test_agent.py
+++ b/tests/server/test_agent.py
@@ -1,11 +1,19 @@
 from unittest.mock import AsyncMock, patch, MagicMock
+
 import pytest
 from beeai_framework.tools.think import ThinkTool
 from beeai_framework.adapters.openai import OpenAIChatModel
+from beeai_framework.backend.errors import ChatModelError
+from litellm.exceptions import Timeout, RateLimitError
 
 from logdetective.server.agent.agent import analyze_artifacts
 from logdetective.server.agent.tools import DrainExtractorTool, CSGrepExtractorTool
-from logdetective.server.config import SERVER_CONFIG
+from logdetective.server.config import SERVER_CONFIG, get_openai_chat_model
+from logdetective.server.exceptions import (
+    LogDetectiveInferenceError,
+    LogDetectiveInferenceTimeout,
+    LogDetectiveInferenceRateLimit,
+)
 
 
 @pytest.fixture
@@ -86,3 +94,27 @@ async def test_analyze_artifacts_execution_flow():
         run_call_args = mock_agent_instance.run.call_args[0][0]
         assert "artifact_1.log" in run_call_args
         assert "artifact_2.log" in run_call_args
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cause, expected_exc", [
+    (Timeout("timed out", "model-mock", "provider-mock"), LogDetectiveInferenceTimeout),
+    (RateLimitError("rate limited", "model-mock", "provider-mock"), LogDetectiveInferenceRateLimit),
+    (ChatModelError(), LogDetectiveInferenceError),
+])
+async def test_analyze_artifacts_inference_errors(mock_agent_setup, cause, expected_exc):
+    mock_artifacts, mock_chat_model, _ = mock_agent_setup
+    mock_error = ChatModelError("model error")
+    mock_error.__cause__ = cause
+
+    with patch("logdetective.server.agent.agent.RequirementAgent") as MockAgent:
+        mock_run_instance = MagicMock()
+        mock_run_instance.middleware = AsyncMock(
+            side_effect=mock_error
+        )
+        MockAgent.return_value.run.return_value = mock_run_instance
+
+        with pytest.raises(LogDetectiveInferenceError) as exc_info:
+            await analyze_artifacts(mock_artifacts, mock_chat_model)
+
+    assert isinstance(exc_info.value, expected_exc)


### PR DESCRIPTION
Tested in local deployment (either by setting timeout config very low, or by modifying nginx location to return 429, or by shutting down inference container mid-request).