### PR TITLE
Add a tool for Python traceback extraction

### DIFF
--- a/logdetective/extractors.py
+++ b/logdetective/extractors.py
@@ -171,3 +171,139 @@ class CSGrepExtractor(DrainExtractor):
         snippets = self._extract_messages(chunks=chunks)
 
         return snippets
+
+
+class PythonTracebackExtractor(Extractor):
+    """Extract Python exception tracebacks from logs using a line-scanning state machine."""
+
+    _TB_START = "Traceback (most recent call last):"
+    _CHAIN_CONT = (
+        "During handling of the above exception, another exception occurred:",
+        "The above exception was the direct cause of the following exception:",
+    )
+    _TRUNCATE_STR = "\n...<truncated>...\n"
+
+    def __call__(self, log: str) -> list[Tuple[int, str]]:
+        lines = log.splitlines()
+        chunks = []
+        current_idx = 0
+        while current_idx < len(lines):
+            if lines[current_idx] == self._TB_START:
+                snippet_lines, next_idx = self._collect_traceback(lines, current_idx)
+                text = "\n".join(snippet_lines)
+                chunks.append((current_idx + 1, text))  # 1-indexed
+                current_idx = next_idx
+            else:
+                current_idx += 1
+        filtered_chunks = self.filter_snippet_patterns(chunks)
+        truncated_chunks = list(map(self._truncate_long_traceback, filtered_chunks))
+        LOG.info("Total %d python tracebacks messages", len(truncated_chunks))
+        return truncated_chunks
+
+    def _truncate_long_traceback(self, snippet: tuple[int, str]) -> list[tuple[int, str]]:
+        """Shorten a snippet with text longer than `max_snippet_len`"""
+        line_no, text = snippet
+        if len(text) <= self.max_snippet_len:
+            return snippet
+        border = (self.max_snippet_len - len(self._TRUNCATE_STR)) // 2
+        return (line_no, f"{text[:border]}{self._TRUNCATE_STR}{text[-border:]}")
+
+    # In the following, by chaining, we mean:
+    #   |Traceback ...
+    #   |...
+    #   |<blank line>
+    #   |During handling of the above ...
+    #   |<blank line>
+    #   |Traceback ...
+    #   |...
+
+    # And by frames, we mean file-code references:
+    #   |Traceback ...
+    #   |  File "module1.py", line 42, in <module>  <- frame
+    #   |    foo()
+    #   |  File "module2.py" ...  <- another frame
+    #   |    bar()
+    #   |  ...
+    #   |Exception: details of exception
+
+    def _is_frame_line(self, line: str) -> bool:
+        """Check if line is an indented traceback frame (File/code reference)."""
+        return bool(line.startswith((" ", "\t")) and line.strip())
+
+    def _is_chain_marker(self, line: str) -> bool:
+        """Check if line marks a chained exception or new traceback."""
+        return bool(line in self._CHAIN_CONT or line == self._TB_START)
+
+    def _find_next_non_blank(self, lines: list[str], start_idx: int) -> int:
+        """Find index of next non-blank line. Returns len(lines) if none found."""
+        idx = start_idx
+        while idx < len(lines) and not lines[idx].strip():
+            idx += 1
+        return idx
+
+    def _has_chain_continuation(self, lines: list[str], from_idx: int) -> int:
+        """Check if a chain continuation follows after blank lines.
+
+        Returns:
+            Non-negative index of chain marker if found, otherwise -1
+        """
+        next_non_blank = self._find_next_non_blank(lines, from_idx)
+        if next_non_blank < len(lines) and self._is_chain_marker(lines[next_non_blank]):
+            return next_non_blank
+        return -1
+
+    def _collect_traceback(self, lines: list[str], start_idx: int) -> tuple[list[str], int]:
+        """Collect all lines belonging to a traceback, including chained exceptions.
+
+        Handles the state machine for parsing Python tracebacks:
+        1. Indented frame lines (File/code references)
+        2. Blank lines (may separate chained tracebacks)
+        3. Chain continuation markers
+        4. Exception type lines (non-indented, non-blank)
+
+        Args:
+            lines: All log lines
+            start_idx: Index of "Traceback (most recent call last):" line
+
+        Returns:
+            Tuple of (collected lines, index after last collected line)
+        """
+        collected = [lines[start_idx]]
+        current_idx = start_idx + 1
+
+        while current_idx < len(lines):
+            line = lines[current_idx]
+            line = line.rstrip()
+
+            # frame line (File/code reference)
+            if self._is_frame_line(line):
+                collected.append(line)
+                current_idx += 1
+                continue
+
+            # blank line -> check if chain continues
+            if not line.strip():
+                chain_idx = self._has_chain_continuation(lines, current_idx + 1)
+                if chain_idx >= 0:
+                    current_idx = chain_idx
+                    continue
+                break
+
+            # chain marker / new traceback
+            if self._is_chain_marker(line):
+                collected.append(line)
+                current_idx += 1
+                continue
+
+            # exception type (non-indented, non-blank)
+            collected.append(line)
+            current_idx += 1
+
+            # check if another exception follows after
+            chain_idx = self._has_chain_continuation(lines, current_idx)
+            if chain_idx >= 0:
+                current_idx = chain_idx
+                continue
+            break
+
+        return collected, current_idx

--- a/logdetective/models.py
+++ b/logdetective/models.py
@@ -19,7 +19,7 @@ class SkipSnippets(BaseModel):
         if data is None:
             return
         self.snippet_patterns = {
-            key: re.compile(pattern) for key, pattern in data.items()
+            key: re.compile(pattern, re.DOTALL) for key, pattern in data.items()
         }
 
     @model_validator(mode="before")

--- a/logdetective/server/agent/agent.py
+++ b/logdetective/server/agent/agent.py
@@ -19,6 +19,7 @@ from logdetective.server.agent.tools import (
     ExtractorTool,
     DrainExtractorTool,
     CSGrepExtractorTool,
+    PythonTracebackExtractorTool,
     SnippetAnalysisTool,
 )
 from logdetective.server.models import APIResponse, BuildMetadata, Explanation
@@ -48,6 +49,7 @@ async def analyze_artifacts(
         extractor_config=SERVER_CONFIG.extractor, available_artifacts=artifacts
     )
     csgrep_extractor = None
+    python_tb_extractor = None
     tools = [
         ThinkTool(),
         drain_extractor,
@@ -76,6 +78,19 @@ async def analyze_artifacts(
         requirements.append(
             ConditionalRequirement(
                 CSGrepExtractorTool,
+                consecutive_allowed=True,
+                max_invocations=len(artifacts),
+            )
+        )
+
+    if SERVER_CONFIG.extractor.python_traceback:
+        python_tb_extractor = PythonTracebackExtractorTool(
+            extractor_config=SERVER_CONFIG.extractor, available_artifacts=artifacts
+        )
+        tools.append(python_tb_extractor)
+        requirements.append(
+            ConditionalRequirement(
+                PythonTracebackExtractorTool,
                 consecutive_allowed=True,
                 max_invocations=len(artifacts),
             )
@@ -133,6 +148,9 @@ async def analyze_artifacts(
 
     if csgrep_extractor:
         all_snippets.extend(csgrep_extractor.extracted_snippets)
+
+    if python_tb_extractor:
+        all_snippets.extend(python_tb_extractor.extracted_snippets)
 
     response = APIResponse(
         explanation=Explanation(text=agent_output.state.answer.text),

--- a/logdetective/server/agent/tools.py
+++ b/logdetective/server/agent/tools.py
@@ -7,7 +7,12 @@ from beeai_framework.tools.errors import ToolInputValidationError, ToolError
 from beeai_framework.tools.types import ToolOutput, ToolRunOptions
 from pydantic import BaseModel, Field
 
-from logdetective.extractors import DrainExtractor, CSGrepExtractor, Extractor
+from logdetective.extractors import (
+    Extractor,
+    DrainExtractor,
+    CSGrepExtractor,
+    PythonTracebackExtractor,
+)
 from logdetective.server.models import ExtractorConfig, Snippet, AnalyzedSnippet
 
 
@@ -162,6 +167,38 @@ class CSGrepExtractorTool(ExtractorTool):
     def _create_emitter(self) -> Emitter:
         return Emitter.root().child(
             namespace=["tool", "extractor", "csgrep"], creator=self
+        )
+
+
+class PythonTracebackExtractorTool(ExtractorTool):
+    name: str = "python_traceback_extractor"
+    description_template: str = (
+        "Use this tool at most once per artifact. "
+        "Extracts Python exception tracebacks from a log file. "
+        "Use on artifacts that contain Python output or test results. "
+        "Do not use on artifacts that don't contain Python tracebacks. "
+        "Maximum length of extracted snippet is {max_snippet_len}."
+    )
+    extractor: PythonTracebackExtractor
+
+    def __init__(
+        self,
+        extractor_config: ExtractorConfig,
+        available_artifacts: dict[str, str],
+        options: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(available_artifacts=available_artifacts, options=options)
+        self.description = self.description_template.format(
+            max_snippet_len=extractor_config.max_snippet_len,
+        )
+        self.extractor = PythonTracebackExtractor(
+            verbose=extractor_config.verbose,
+            max_snippet_len=extractor_config.max_snippet_len,
+        )
+
+    def _create_emitter(self) -> Emitter:
+        return Emitter.root().child(
+            namespace=["tool", "extractor", "python_traceback"], creator=self
         )
 
 

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -238,6 +238,7 @@ class ExtractorConfig(BaseModel):
     verbose: bool = False
     max_snippet_len: int = 2000
     csgrep: bool = False
+    python_traceback: bool = False
 
     @field_validator("csgrep", mode="before")
     @classmethod

--- a/server/config.yml
+++ b/server/config.yml
@@ -18,8 +18,12 @@ inference:
 extractor:
   max_clusters: 25
   verbose: false
-# Set this value to reasonable number based on maximum context length of your model
+  # Set this value to reasonable number based on maximum context length of your model
   # max_snippet_len: 2000
+  # Enable csgrep extractor for GCC compiler errors (requires csgrep binary)
+  # csgrep: false
+  # Enable Python traceback extractor for Python exception tracebacks
+  # python_traceback: false
 # Configuration for gitlab and koji
 # gitlab:
 #   "GitLab SaaS":

--- a/tests/base/test_extractors.py
+++ b/tests/base/test_extractors.py
@@ -1,9 +1,15 @@
+import re
 import subprocess as sp
 from unittest.mock import MagicMock
 import pytest
 
 from logdetective.models import SkipSnippets
-from logdetective.extractors import DrainExtractor, CSGrepExtractor, Extractor
+from logdetective.extractors import (
+    Extractor,
+    DrainExtractor,
+    CSGrepExtractor,
+    PythonTracebackExtractor,
+)
 
 from tests.base.test_helpers import (
     simple_log,
@@ -14,6 +20,14 @@ from tests.base.test_helpers import (
     csgrep_output_dolphin_emu,
     package_unavailable_log,
     DNF_PACKAGE_UNAVAILABLE_EXPECTED_SNIPPETS,
+    SIMPLE_TRACEBACK_LOG,
+    CHAINED_TRACEBACK_LOG,
+    LONGER_TRACEBACK_LOG,
+    LONG_CHAIN_TRACEBACK_LOG,
+    PYTHON_SIMPLE_TB,
+    PYTHON_SIMPLE_CHAINED_TB,
+    PYTHON_LONGER_TB,
+    PYTHON_LONG_CHAIN_TB,
 )
 
 
@@ -238,3 +252,138 @@ def test_csgrep_extractor_invalid_json(monkeypatch, simple_log):
     with pytest.raises(Exception):
         extractor(simple_log)
     mock_run.assert_called_once()
+
+
+# --- Tests for PythonTracebackExtractor ---
+
+
+def test_python_tb_single():
+    """Single traceback embedded in surrounding log output."""
+    extractor = PythonTracebackExtractor()
+    results = extractor(SIMPLE_TRACEBACK_LOG)
+
+    assert len(results) == 1
+    line_no, text = results[0]
+    assert line_no == 3
+    assert PYTHON_SIMPLE_TB in text
+    assert "\n\n" not in text
+
+
+def test_python_tb_chained():
+    """Chained tracebacks are coalesced into a single snippet."""
+    extractor = PythonTracebackExtractor()
+    results = extractor(CHAINED_TRACEBACK_LOG)
+
+    assert len(results) == 1
+    line_no, text = results[0]
+    assert line_no == 13
+    assert not text.startswith("\n")
+    assert not text.endswith("\n")
+    assert PYTHON_SIMPLE_CHAINED_TB.replace("\n\n", "\n") in text
+    assert "\n\n" not in text
+
+
+def test_python_tb_multiple_independent():
+    """Two separate tracebacks produce two independent snippets."""
+    log = SIMPLE_TRACEBACK_LOG + "\n" + SIMPLE_TRACEBACK_LOG
+    extractor = PythonTracebackExtractor()
+    results = extractor(log)
+
+    assert len(results) == 2
+    assert results[0][0] == 3
+    assert results[1][0] == 15
+    assert all(PYTHON_SIMPLE_TB in snip for _, snip in results)
+    assert all("\n\n" not in snip for _, snip in results)
+
+
+def test_python_tb_empty():
+    """Log with no tracebacks returns empty list."""
+    extractor = PythonTracebackExtractor()
+    results = extractor("[INFO] All good\n[INFO] Done\n")
+
+    assert not results
+
+
+def test_python_tb_max_snippet_len():
+    """Traceback exceeding max_snippet_len is truncated with ...<truncated>..."""
+    extractor = PythonTracebackExtractor(max_snippet_len=50)
+    results = extractor(SIMPLE_TRACEBACK_LOG)
+
+    assert len(results) == 1
+    line_no, text = results[0]
+    assert line_no == 3
+    assert "...<truncated>..." in text
+    assert "\n\n" not in text
+
+
+def test_python_tb_skip_patterns():
+    """Skip pattern matching removes tracebacks whose text matches the pattern."""
+    skip = SkipSnippets(data={"skip_file_not_found": ".*FileNotFoundError.*"})
+    extractor = PythonTracebackExtractor(skip_snippets=skip)
+    results = extractor(SIMPLE_TRACEBACK_LOG)
+
+    assert len(results) == 0
+
+
+def test_python_tb_line_numbers():
+    """Line numbers correspond to the 1-indexed position of the Traceback header in the log."""
+    log = "line1\nline2\n" + CHAINED_TRACEBACK_LOG
+    extractor = PythonTracebackExtractor()
+    results = extractor(log)
+
+    assert len(results) == 1
+    line_no, text = results[0]
+    assert line_no == 15
+    assert "\n\n" not in text
+
+
+def test_python_tb_long_stack():
+    """Long call stack (5+ frames) is captured completely."""
+    extractor = PythonTracebackExtractor()
+    results = extractor(LONGER_TRACEBACK_LOG)
+
+    assert len(results) == 1
+    line_no, text = results[0]
+    assert line_no == 4
+    assert PYTHON_LONGER_TB in text
+    assert "\n\n" not in text
+
+
+def test_python_tb_chained_3():
+    """Three-level exception chain is captured as single snippet."""
+    extractor = PythonTracebackExtractor()
+    results = extractor(LONG_CHAIN_TRACEBACK_LOG)
+
+    assert len(results) == 1
+    line_no, text = results[0]
+    assert line_no == 5
+    assert not text.startswith("\n")
+    assert not text.endswith("\n")
+    assert PYTHON_LONG_CHAIN_TB.replace("\n\n", "\n") in text
+
+
+def test_python_tb_all():
+    """Four concatenated logs, each with 1 separate traceback."""
+    long_log: str = "\n".join([
+        SIMPLE_TRACEBACK_LOG,
+        LONGER_TRACEBACK_LOG,
+        CHAINED_TRACEBACK_LOG,
+        LONG_CHAIN_TRACEBACK_LOG,
+    ])
+    extractor = PythonTracebackExtractor()
+    results = extractor(long_log)
+
+    assert len(results) == 4
+    assert all("\n\n" not in snip for _, snip in results)
+
+    assert results[0][0] == 3
+    assert PYTHON_SIMPLE_TB in results[0][1]
+
+    assert results[1][0] == 16
+    assert PYTHON_LONGER_TB in results[1][1]
+
+    assert results[2][0] == 44
+    assert PYTHON_SIMPLE_CHAINED_TB.replace("\n\n", "\n") in results[2][1]
+
+    assert results[3][0] == 64
+    assert PYTHON_LONG_CHAIN_TB.replace("\n\n", "\n") in results[3][1]

--- a/tests/base/test_helpers.py
+++ b/tests/base/test_helpers.py
@@ -61,6 +61,133 @@ DNF_PACKAGE_UNAVAILABLE_EXPECTED_SNIPPETS = [
 ]
 
 
+# --- Python traceback examples ---
+
+
+PYTHON_SIMPLE_TB = """\
+Traceback (most recent call last):
+  File "/usr/lib/rpm/redhat/pyproject_buildrequires.py", line 721, in main
+    generate_requires()
+  File "/usr/lib/rpm/redhat/pyproject_buildrequires.py", line 263, in get_backend
+    raise FileNotFoundError('File "setup.py" not found for legacy project.')
+FileNotFoundError: File "setup.py" not found for legacy project.\
+"""
+
+
+PYTHON_SIMPLE_CHAINED_TB = """\
+Traceback (most recent call last):
+  File "/usr/bin/tool", line 10, in run
+    do_work()
+ValueError: inner error
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/usr/bin/tool", line 20, in main
+    run()
+RuntimeError: outer error\
+"""
+
+
+PYTHON_LONGER_TB = """\
+Traceback (most recent call last):
+  File "/app/main.py", line 12, in <module>
+    app.run()
+  File "/app/app.py", line 45, in run
+    self.process()
+  File "/app/handler.py", line 78, in process
+    self.execute()
+  File "/app/executor.py", line 120, in execute
+    self.validate()
+  File "/app/validator.py", line 34, in validate
+    raise ValueError("Invalid input")
+ValueError: Invalid input\
+"""
+
+
+PYTHON_LONG_CHAIN_TB = """\
+Traceback (most recent call last):
+  File "/app/level1.py", line 10, in func1
+    level2.call()
+ValueError: Error at level 1
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/app/level2.py", line 20, in func2
+    level3.call()
+RuntimeError: Error at level 2
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/app/level3.py", line 30, in func3
+    raise TypeError("Error at level 3")
+TypeError: Error at level 3\
+"""
+
+
+# --- Log examples with inserted tracebacks ---
+
+
+SIMPLE_TRACEBACK_LOG = f"""\
+[INFO] Starting job
+[INFO] Running step
+{PYTHON_SIMPLE_TB}
+[ERROR] Build failed
+Finish: rpmbuild random-package-2026.1.2.3-4.fc42.src.rpm
+Finish: build phase for random-package-2026.1.2.3-4.fc42.src.rpm
+"""
+
+
+CHAINED_TRACEBACK_LOG = f"""\
+Mock output
+Running: git clone https://copr.org/author/org/product /some/abs/path/to/package --depth 500 --no-single-branch --recursive
+
+cmd: ['git', 'clone', 'https://copr.org/author/org/product', '/some/abs/path/to/package', '--depth', '500', '--no-single-branch', '--recursive']
+cwd: .
+rc: 0
+stdout:
+stderr: Cloning into '/some/abs/path/to/package'...
+INFO: calling preinit hooks
+INFO: enabled root cache
+INFO: enabled package manager cache
+
+{PYTHON_SIMPLE_CHAINED_TB}
+Installing group/module packages:
+ bash                              x86_64 5.2.37-1.fc42              fedora       8.2 MiB
+ bzip2                             x86_64 1.0.8-20.fc42              fedora      99.3 KiB
+ coreutils                         x86_64 9.6-4.fc42                 updates      5.4 MiB
+"""
+
+
+LONGER_TRACEBACK_LOG = f"""\
+Building target platforms: x86_64
+Building for target x86_64
+warning: %source_date_epoch_from_changelog is set, but %changelog has no entries to take a date from
+{PYTHON_LONGER_TB}
+
+Start(bootstrap): cleaning package manager metadata
+Finish(bootstrap): cleaning package manager metadata
+"""
+
+
+LONG_CHAIN_TRACEBACK_LOG = f"""\
+RPM build warnings:
+    %source_date_epoch_from_changelog is set, but %changelog has no entries to take a date from
+    absolute symlink: /usr/bin/package -> /usr/share/package
+
+{PYTHON_LONG_CHAIN_TB}
+
++ RPM_EC=0
+++ jobs -p
++ exit 0
+"""
+
+
+# --- Other log examples for CSGrep ---
+
+
 @pytest.fixture
 def simple_log() -> list[str]:
     """Provides a simple log for testing."""


### PR DESCRIPTION
State-machine implementation seemed like the most natural and simple, even though it might lack in pythonicity/readability.

- tested on a locally run agent with some log samples from `logdetective_sample` repo -> tool calls return what they're supposed to,  `Traceback ... ExceptionClass: message` .
- noticed that we do not use skip snippets config anywhere in server code -> created a follow-up task
- the traceback extractor inherits only from the base extractor class (subject for discussion)
  - I did not look into the implications of this
  - theoretically, drain might extract a part of the traceback, so there is a potential for some duplication

Assisted by: Claude Code