### PR TITLE
Fix issue with loading empty prompt config

### DIFF
--- a/logdetective/utils.py
+++ b/logdetective/utils.py
@@ -247,9 +247,9 @@ def load_prompts(
         try:
             with open(config_path, "r") as file:
                 configuration = PromptConfig(**yaml.safe_load(file))
-        except FileNotFoundError:
+        except (FileNotFoundError, TypeError):
             LOG.error(
-                "Prompt configuration file not found, reverting to defaults.",
+                "Prompt configuration file not found or empty, reverting to defaults.",
                 exc_info=True,
             )
 


### PR DESCRIPTION
noticed this while testing Python traceback tool inside agent (empty prompts.yml):

```
Traceback (most recent call last):
...
  File "/src/logdetective/server/server.py", line 31, in <module>
    from logdetective.server.database.models.koji import KojiTaskAnalysis
  File "/src/logdetective/server/database/models/__init__.py", line 7, in <module>
    from logdetective.server.database.models.koji import (
        KojiTaskAnalysis,
    )
  File "/src/logdetective/server/database/models/koji.py", line 10, in <module>
    from logdetective.server.config import SERVER_CONFIG
  File "/src/logdetective/server/config.py", line 83, in <module>
    PROMPT_CONFIG = load_prompts(
        template_path=PROMPT_PATH, config_path=PROMPT_CONF_PATH
    )
  File "/src/logdetective/utils.py", line 250, in load_prompts
    configuration = PromptConfig(**yaml.safe_load(file))
TypeError: logdetective.models.PromptConfig() argument after ** must be a mapping, not NoneType
```