### PR TITLE
Create structured output for the agent

### DIFF
--- a/logdetective/server/agent/agent.py
+++ b/logdetective/server/agent/agent.py
@@ -13,6 +13,7 @@ from litellm.exceptions import (
     Timeout as LiteLLMTimeout,
     RateLimitError as LiteLLMRateLimit
 )
+from pydantic import ValidationError
 
 from logdetective.server.config import PROMPT_CONFIG, SERVER_CONFIG
 from logdetective.server.agent.tools import (
@@ -22,7 +23,7 @@ from logdetective.server.agent.tools import (
     PythonTracebackExtractorTool,
     SnippetAnalysisTool,
 )
-from logdetective.server.models import APIResponse, BuildMetadata, Explanation
+from logdetective.server.models import APIResponse, BuildMetadata, AgentResponse
 from logdetective.server.exceptions import (
     LogDetectiveAgentResponseFailure,
     LogDetectiveInferenceTimeout,
@@ -110,7 +111,6 @@ async def analyze_artifacts(
         )
     )
 
-    # TODO: Use AgentResponse as an output
     agent = RequirementAgent(
         llm=chat_model,
         memory=UnconstrainedMemory(),
@@ -128,10 +128,11 @@ async def analyze_artifacts(
     agent_input = PROMPT_CONFIG.agent_start_prompt(list(artifacts.keys()))
 
     try:
-        agent_output = await agent.run(
+        raw_output = await agent.run(
             agent_input,
             max_retries_per_step=SERVER_CONFIG.inference.max_retries_per_step,
             total_max_retries=SERVER_CONFIG.inference.total_max_retries,
+            expected_output=AgentResponse
         ).middleware(middleware)
     except ChatModelError as exc:
         cause = exc.__cause__
@@ -141,8 +142,12 @@ async def analyze_artifacts(
             raise LogDetectiveInferenceRateLimit(str(cause)) from exc
         raise LogDetectiveInferenceError(exc.message) from exc
 
-    if not agent_output.state.answer:
+    if not raw_output.output_structured:
         raise LogDetectiveAgentResponseFailure
+    try:
+        structured_output: AgentResponse = AgentResponse.model_validate(raw_output.output_structured)
+    except ValidationError as exc:
+        raise LogDetectiveInferenceError("Invalid format of the agent response") from exc
 
     all_snippets = drain_extractor.extracted_snippets
 
@@ -153,7 +158,9 @@ async def analyze_artifacts(
         all_snippets.extend(python_tb_extractor.extracted_snippets)
 
     response = APIResponse(
-        explanation=Explanation(text=agent_output.state.answer.text),
+        explanation=structured_output.explanation,
+        solution=structured_output.solution,
+        no_issue_found=structured_output.no_issue_found,
         snippets=all_snippets,
     )
     return response

--- a/tests/server/agent/test_agent.py
+++ b/tests/server/agent/test_agent.py
@@ -14,6 +14,7 @@ from logdetective.server.exceptions import (
     LogDetectiveInferenceTimeout,
     LogDetectiveInferenceRateLimit,
 )
+from logdetective.server.models import AgentResponse, Explanation
 
 
 @pytest.fixture
@@ -24,7 +25,8 @@ def mock_agent_setup():
 
     mock_agent_output = MagicMock()
     mock_agent_output.state.answer.text = "Mocked analysis result"
-
+    mock_agent_output.output_structured = AgentResponse(
+        explanation=Explanation(text="Mock explanation"))
     return mock_artifacts, mock_chat_model, mock_agent_output
 
 
@@ -71,14 +73,13 @@ async def test_analyze_artifacts_init_with_csgrep(mock_agent_setup):
 
 
 @pytest.mark.asyncio
-async def test_analyze_artifacts_execution_flow():
+async def test_analyze_artifacts_execution_flow(mock_agent_setup):
     """Test the execution flow and response mapping of analyze_artifacts."""
+    mock_artifacts, mock_chat_model, mock_agent_output = mock_agent_setup
     mock_artifacts = {"artifact_1.log": "content 1", "artifact_2.log": "content 2"}
-    mock_chat_model = MagicMock(spec=OpenAIChatModel)
 
     expected_answer = "The build failed because of a missing dependency."
-    mock_agent_output = MagicMock()
-    mock_agent_output.state.answer.text = expected_answer
+    mock_agent_output.output_structured.explanation.text = expected_answer
 
     mock_run_chain = MagicMock()
     mock_run_chain.middleware = AsyncMock(return_value=mock_agent_output)


### PR DESCRIPTION
Using the `AgentResponse` structure, we can separate proposed solution, from the discovered root cause. This will make displaying results in frontend much easier, and it will allow us to potentially block the solution entirely, if it turns out this feature doesn't make sense under the particular circumstances.

The output is technically validated twice, once in beeai-framework, and the other time by us. This is defense in depth play, just in case beeai-framework validation turns faulty for some reason. It also helps with type hints.

Tests were adjusted to work with the new code. 