### PR TITLE
Insert commentary into the first agent message

### DIFF
--- a/logdetective/prompts.py
+++ b/logdetective/prompts.py
@@ -42,9 +42,10 @@ class PromptManager:  # pylint: disable=too-many-instance-attributes
         """Render message prompt from the template"""
         return self.default_message_template.render(snippets=snippets)
 
-    def agent_start_prompt(self, artifacts: list[str]) -> str:
+    def agent_start_prompt(self, artifacts: list[str], commentary: Optional[str] = None) -> str:
         """Render agent start prompt"""
 
         return self._default_agent_start_prompt_template.render(
-            artifacts=artifacts
+            artifacts=artifacts,
+            commentary=commentary,
         )

--- a/logdetective/prompts/agent_start_prompt.j2
+++ b/logdetective/prompts/agent_start_prompt.j2
@@ -5,3 +5,12 @@ Use provided tools to analyze following build artifacts:
 {% endfor %}
 You MUST extract snippets from all artifacts, until you have clear root cause.
 Focus on issues that are likely to cause a build failure.
+
+{% if commentary %}
+Comments:
+
+Following provides additional insight into circumstances of the build failure,
+such as environment.
+
+{{ commentary }}
+{% endif %}

--- a/logdetective/server/agent/agent.py
+++ b/logdetective/server/agent/agent.py
@@ -125,7 +125,10 @@ async def analyze_artifacts(
     middleware = GlobalTrajectoryMiddleware(pretty=True)
 
     # Names of build artifacts are inserted into the template.
-    agent_input = PROMPT_CONFIG.agent_start_prompt(list(artifacts.keys()))
+    if build_metadata:
+        agent_input = PROMPT_CONFIG.agent_start_prompt(artifacts=list(artifacts.keys()), commentary=build_metadata.commentary)
+    else:
+        agent_input = PROMPT_CONFIG.agent_start_prompt(artifacts=list(artifacts.keys()))
 
     try:
         raw_output = await agent.run(


### PR DESCRIPTION
The commentary is now part of the first message send to the agent. This way we can steer agent behavior on per-request basis.
