### PR TITLE
Use pgvector with database

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,6 +17,7 @@ env:
   REGISTRY: quay.io
   SERVER_IMAGE: logdetective/server
   INFERENCE_IMAGE: logdetective/inference
+  DATABASE_IMAGE: logdetective/database
 
 jobs:
   build:
@@ -110,6 +111,32 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # Extract metadata (tags, labels) for database image with pgvector
+      # https://github.com/docker/metadata-action
+      - name: Extract metadata for database image with pgvector support
+        id: meta-database
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.DATABASE_IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha
+            type=raw,value=latest,enable=${{ contains(github.ref, 'refs/tags/') }}
+
+      # Build Docker image with Buildx
+      # https://github.com/docker/build-push-action
+      - name: Build and push database image with pgvector support
+        id: build-image-database
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          file: Containerfile.database
+          push: ${{ github.event_name != 'pull_request' && contains(github.ref, 'refs/tags/') }}
+          tags: ${{ steps.meta-database.outputs.tags }}
+          labels: ${{ steps.meta-database.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker
       # repository is public to avoid leaking data.  If you would like to publish
@@ -136,6 +163,21 @@ jobs:
           # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
           TAGS: ${{ steps.meta-cuda.outputs.tags }}
           DIGEST: ${{ steps.build-image-cuda.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published database server image
+        if: ${{ github.event_name != 'pull_request' && contains(github.ref, 'refs/tags/') }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta-database.outputs.tags }}
+          DIGEST: ${{ steps.build-image-database.outputs.digest }}
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/Containerfile.database
+++ b/Containerfile.database
@@ -1,0 +1,35 @@
+FROM quay.io/sclorg/postgresql-15-c9s
+
+USER root
+
+RUN dnf install -y \
+    git \
+    make \
+    postgresql-private-devel \
+    postgresql-server-devel \
+    gcc \
+    redhat-rpm-config
+
+RUN cd /tmp && \
+git clone --branch v0.8.2 https://github.com/pgvector/pgvector.git
+
+RUN cd /tmp/pgvector && \
+make && \
+make install
+
+# Cleanup
+RUN rm -r /tmp/pgvector
+RUN dnf remove -y \
+    git \
+    make \
+    postgresql-private-devel \
+    postgresql-server-devel \
+    gcc \
+    redhat-rpm-config &&\
+    dnf clean all
+
+# Copy script enabling pgvector extension so that it runs on startup
+COPY ./scripts/enable_pgvector.sh /usr/share/container-scripts/postgresql/start/
+
+# Switching back to user from the base image
+USER 26

--- a/Containerfile.database
+++ b/Containerfile.database
@@ -10,8 +10,9 @@ RUN dnf install -y \
     gcc \
     redhat-rpm-config
 
+# Use pgvector v0.8.2
 RUN cd /tmp && \
-git clone --branch v0.8.2 https://github.com/pgvector/pgvector.git
+git clone --rev cab9da72c04353f143bb06b42ab70a403daac64a https://github.com/pgvector/pgvector.git
 
 RUN cd /tmp/pgvector && \
 make && \
@@ -31,5 +32,5 @@ RUN dnf remove -y \
 # Copy script enabling pgvector extension so that it runs on startup
 COPY ./scripts/enable_pgvector.sh /usr/share/container-scripts/postgresql/start/
 
-# Switching back to user from the base image
+# Switching to default Postgresql user
 USER 26

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ alembic-generate-revision: server-up
 
 	@echo "Checking if database is ready..."
 	$(CONTAINER_ENGINE) run --rm --network logdetective_default \
-		quay.io/sclorg/postgresql-15-c9s \
+		quay.io/logdetective/postgresql-15-c9s-pgvector \
 		pg_isready -h postgres -U $(POSTGRESQL_USER) -d $(POSTGRESQL_DATABASE) \
 		|| (echo "Database not ready -h postgres -U $(POSTGRESQL_USER) -d $(POSTGRESQL_DATABASE)"; exit 1)
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,7 +61,10 @@ services:
     entrypoint: ["/run_server.sh"]
 
   postgres:
-    image: quay.io/sclorg/postgresql-15-c9s
+    image: quay.io/logdetective/postgresql-15-c9s-pgvector
+    build:
+      context: .
+      dockerfile: ./Containerfile.database
     volumes:
       - database_data:/var/lib/postgresql/data
     ports:

--- a/scripts/enable_pgvector.sh
+++ b/scripts/enable_pgvector.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Enable vector extension
+
+set -eux
+
+psql -v ON_ERROR_STOP=1 -d "${POSTGRESQL_DATABASE}" -c "CREATE EXTENSION IF NOT EXISTS vector;"


### PR DESCRIPTION
We'll have our own container image for database, with enabled pgvector extension. The image will be published on quay.io, in our namespace. The `scripts/enable_pgvector.sh` enables pgvector extension on service startup.

This doesn't mean that there are tables using vector indices. Only that our database service is ready for them. 