### PR TITLE
Make csgrep timeout configurable

### DIFF
--- a/logdetective/extractors.py
+++ b/logdetective/extractors.py
@@ -104,14 +104,17 @@ class CSGrepExtractor(DrainExtractor):
     extracting other messages from the logs. Therefore, it must only
     be used together with the Drain based extractor."""
 
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
     def __init__(
         self,
         verbose: bool = False,
         skip_snippets: SkipSnippets = SkipSnippets({}),
         max_snippet_len: int = 2000,
         max_clusters: int = 8,
+        csgrep_timeout: float = 1.0,
     ):
         super().__init__(verbose, skip_snippets, max_snippet_len, max_clusters)
+        self.csgrep_timeout = csgrep_timeout
 
     def __call__(self, log: str) -> list[Tuple[int, str]]:
         """Extract error messages from log using csgrep"""
@@ -133,7 +136,7 @@ class CSGrepExtractor(DrainExtractor):
                 check=False,
                 capture_output=True,
                 text=True,
-                timeout=1.0,
+                timeout=self.csgrep_timeout,
             )
         except sp.TimeoutExpired as ex:
             LOG.exception("Exception encountered while parsing log with csgrep %s", ex)

--- a/logdetective/server/agent/tools.py
+++ b/logdetective/server/agent/tools.py
@@ -162,6 +162,7 @@ class CSGrepExtractorTool(ExtractorTool):
             verbose=extractor_config.verbose,
             max_snippet_len=extractor_config.max_snippet_len,
             max_clusters=extractor_config.max_clusters,
+            csgrep_timeout=extractor_config.csgrep_timeout,
         )
 
     def _create_emitter(self) -> Emitter:

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -238,6 +238,7 @@ class ExtractorConfig(BaseModel):
     verbose: bool = False
     max_snippet_len: int = 2000
     csgrep: bool = False
+    csgrep_timeout: float = 1.0
     python_traceback: bool = False
 
     @field_validator("csgrep", mode="before")

--- a/server/config.yml
+++ b/server/config.yml
@@ -22,6 +22,8 @@ extractor:
   # max_snippet_len: 2000
   # Enable csgrep extractor for GCC compiler errors (requires csgrep binary)
   # csgrep: false
+  # Set max timeout (in seconds) for csgrep calls, 1.0 by default
+  # csgrep_timeout: 5.0
   # Enable Python traceback extractor for Python exception tracebacks
   # python_traceback: false
 # Configuration for gitlab and koji

--- a/tests/server/test_server_models.py
+++ b/tests/server/test_server_models.py
@@ -56,6 +56,8 @@ def test_default_initialization_and_configuration():
     assert config.verbose is False
     assert config.max_snippet_len == 2000
     assert config.csgrep is False
+    assert config.csgrep_timeout == 1.0
+    assert not config.python_traceback
 
 
 def test_initialization_with_custom_data(mocker: MockerFixture):


### PR DESCRIPTION
1s is not enough for large logs with many C/C++ errors/warnings, so it is worth it to make it configurable (5s sounds like enough).