### PR TITLE
Simplify tool output to conserve tokens

### DIFF
--- a/logdetective/server/agent/tools.py
+++ b/logdetective/server/agent/tools.py
@@ -6,6 +6,7 @@ from beeai_framework.tools import Tool
 from beeai_framework.tools.errors import ToolInputValidationError, ToolError
 from beeai_framework.tools.types import ToolOutput, ToolRunOptions
 from pydantic import BaseModel, Field
+import yaml
 
 from logdetective.extractors import (
     Extractor,
@@ -34,7 +35,17 @@ class ExtractorToolOutput(ToolOutput, BaseModel):
     )
 
     def get_text_content(self) -> str:
-        return f"source_artifact: {self.source_artifact}, extracted_snippets: {self.extracted_snippets}, remaining_artifacts: {self.remaining_artifacts}"
+        """Convert the extractor output into YAML"""
+        return yaml.safe_dump(
+            self.model_dump(
+                exclude_defaults=True,
+                exclude_none=True,
+                exclude_computed_fields=True,
+                exclude_unset=True,
+                mode="json",
+            ),
+            default_flow_style=False,
+        )
 
     def is_empty(self) -> bool:
         return not self.extracted_snippets


### PR DESCRIPTION
The tool output used up a lot of tokens since it contained serialized python objects. This both slowed down the response on prefill, and made it more likely that we'll go over the context size. This patch turns the output into a yaml, keeping the information intact, while cutting number of tokens down.

In both cases, number of tokens raises linearly with the number of snippets, but when using the yaml format, the slope is much less steep. In this minimal example, the change in format saves 9 characters. With default settings, that means 20 snippets per log, the savings will amount to `=<180` tokens. Which is not that bad, considering our maximum context with local models is in around 30K tokens.

The new format will also be much more readable in logs.

Before:
```
source_artifact: builder-live.log, extracted_snippets: [Snippet(text='ERROR: gcc: fatal error: no input files', line_number=142, source_file='builder-live.log')], remaining_artifacts: {'root.log', 'build.log}
```

Now:
```
extracted_snippets:
- line_number: 142
  source_file: builder-live.log
  text: 'ERROR: gcc: fatal error: no input files'
remaining_artifacts:
- root.log
- build.log
source_artifact: builder-live.log
```

