### PR TITLE
Use SkipSnippets in agent's tools

### DIFF
--- a/logdetective/server/agent/agent.py
+++ b/logdetective/server/agent/agent.py
@@ -15,7 +15,7 @@ from litellm.exceptions import (
 )
 from pydantic import ValidationError
 
-from logdetective.server.config import PROMPT_CONFIG, SERVER_CONFIG
+from logdetective.server.config import PROMPT_CONFIG, SERVER_CONFIG, SKIP_SNIPPETS_CONFIG
 from logdetective.server.agent.tools import (
     ExtractorTool,
     DrainExtractorTool,
@@ -47,7 +47,9 @@ async def analyze_artifacts(
     # TODO: Handle build_metadata by supplying it to the agent
 
     drain_extractor = DrainExtractorTool(
-        extractor_config=SERVER_CONFIG.extractor, available_artifacts=artifacts
+        extractor_config=SERVER_CONFIG.extractor,
+        available_artifacts=artifacts,
+        skip_snippets=SKIP_SNIPPETS_CONFIG,
     )
     csgrep_extractor = None
     python_tb_extractor = None
@@ -73,7 +75,9 @@ async def analyze_artifacts(
     # Use CSGrepExtractorTool only if it is enabled
     if SERVER_CONFIG.extractor.csgrep:
         csgrep_extractor = CSGrepExtractorTool(
-            extractor_config=SERVER_CONFIG.extractor, available_artifacts=artifacts
+            extractor_config=SERVER_CONFIG.extractor,
+            available_artifacts=artifacts,
+            skip_snippets=SKIP_SNIPPETS_CONFIG,
         )
         tools.append(csgrep_extractor)
         requirements.append(
@@ -86,7 +90,9 @@ async def analyze_artifacts(
 
     if SERVER_CONFIG.extractor.python_traceback:
         python_tb_extractor = PythonTracebackExtractorTool(
-            extractor_config=SERVER_CONFIG.extractor, available_artifacts=artifacts
+            extractor_config=SERVER_CONFIG.extractor,
+            available_artifacts=artifacts,
+            skip_snippets=SKIP_SNIPPETS_CONFIG,
         )
         tools.append(python_tb_extractor)
         requirements.append(

--- a/logdetective/server/agent/tools.py
+++ b/logdetective/server/agent/tools.py
@@ -14,6 +14,7 @@ from logdetective.extractors import (
     CSGrepExtractor,
     PythonTracebackExtractor,
 )
+from logdetective.models import SkipSnippets
 from logdetective.server.models import ExtractorConfig, Snippet, AnalyzedSnippet
 
 
@@ -132,6 +133,7 @@ class DrainExtractorTool(ExtractorTool):
         self,
         extractor_config: ExtractorConfig,
         available_artifacts: dict[str, str],
+        skip_snippets: SkipSnippets = SkipSnippets({}),
         options: dict[str, Any] | None = None,
     ) -> None:
 
@@ -142,6 +144,7 @@ class DrainExtractorTool(ExtractorTool):
         )
         self.extractor = DrainExtractor(
             verbose=extractor_config.verbose,
+            skip_snippets=skip_snippets,
             max_snippet_len=extractor_config.max_snippet_len,
             max_clusters=extractor_config.max_clusters,
         )
@@ -167,6 +170,7 @@ class CSGrepExtractorTool(ExtractorTool):
         self,
         extractor_config: ExtractorConfig,
         available_artifacts: dict[str, str],
+        skip_snippets: SkipSnippets = SkipSnippets({}),
         options: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(all_artifacts=available_artifacts, options=options)
@@ -176,6 +180,7 @@ class CSGrepExtractorTool(ExtractorTool):
         )
         self.extractor = CSGrepExtractor(
             verbose=extractor_config.verbose,
+            skip_snippets=skip_snippets,
             max_snippet_len=extractor_config.max_snippet_len,
             max_clusters=extractor_config.max_clusters,
             csgrep_timeout=extractor_config.csgrep_timeout,
@@ -202,6 +207,7 @@ class PythonTracebackExtractorTool(ExtractorTool):
         self,
         extractor_config: ExtractorConfig,
         available_artifacts: dict[str, str],
+        skip_snippets: SkipSnippets = SkipSnippets({}),
         options: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(all_artifacts=available_artifacts, options=options)
@@ -210,6 +216,7 @@ class PythonTracebackExtractorTool(ExtractorTool):
         )
         self.extractor = PythonTracebackExtractor(
             verbose=extractor_config.verbose,
+            skip_snippets=skip_snippets,
             max_snippet_len=extractor_config.max_snippet_len,
         )
 

--- a/logdetective/utils.py
+++ b/logdetective/utils.py
@@ -308,6 +308,13 @@ def load_skip_snippet_patterns(path: str | None) -> SkipSnippets:
                 path,
                 stack_info=True,
             )
+        except (TypeError, AttributeError) as exc:
+            LOG.warning(
+                "Skip pattern file `%s` is empty, no skip patterns loaded: %s",
+                path,
+                exc,
+            )
+            return SkipSnippets({})
     return SkipSnippets({})
 
 


### PR DESCRIPTION
I looked into some older pre-agent releases (e.g. 3.6) and it seems that this was never actually used outside of the CLI tool. Also added empty YAML handling (tested in podman-compose, it raises AttributeError, but also catching TypeError won't hurt).