### PR TITLE
Try getting logs without size headers

### DIFF
--- a/logdetective/exceptions.py
+++ b/logdetective/exceptions.py
@@ -12,7 +12,7 @@ class RemoteLogRequestError(RemoteLogError):
 
 
 class RemoteLogHeaderError(RemoteLogError):
-    """Missing or invalid header when accessing a log via URL."""
+    """Invalid Content-Length header when accessing a log via URL."""
     status_code = 411  # Length Required
 
 

--- a/logdetective/remote_log.py
+++ b/logdetective/remote_log.py
@@ -66,7 +66,9 @@ class RemoteLog:
         return True
 
     async def get_url_content(self) -> str:
-        """Validate log url, check the content size from header, and return log text."""
+        """Validate log url, check content size (either using Content-Length, or,
+        if missing, during file reading), and return log text.
+        """
         if not self.validate_url():
             LOG.error("Invalid URL received ")
             raise RemoteLogRequestError(f"Invalid log URL: {self.url}")
@@ -79,25 +81,40 @@ class RemoteLog:
         except (aiohttp.ClientResponseError, aiohttp.ClientConnectorError) as ex:
             raise RemoteLogAccessError(f"We couldn't obtain the headers from {self.url}") from ex
         size_check: ContentSizeCheck = check_content_size(
-            head_response.headers, self._limit_bytes
+            head_response.headers, self._limit_bytes, require_header=False
         )
-        if not size_check.result:
+        if not size_check.proceed:
             if size_check.size_in_bytes is None:
-                if not size_check.value_present:
-                    raise RemoteLogHeaderError("Content-Length is missing")
-                raise RemoteLogHeaderError(
-                    f"Content-Length is invalid: `{size_check.size_in_bytes}`"
-                )
+                raise RemoteLogHeaderError("Content-Length header is invalid")
             raise RemoteLogTooLargeError(
                 f"Content-Length is over the limit: `{size_check.size_in_bytes}`"
             )
-        self.remote_log_size = size_check.size_in_bytes
-        # if size-check passes, we obtain the whole content
+        if size_check.size_in_bytes is None:
+            LOG.info(
+                "No Content-Length header for %s; enforcing size limit while reading", self.url
+            )
         try:
-            response = await self._http_session.get(self.url, raise_for_status=True)
+            async with self._http_session.get(self.url, raise_for_status=True) as response:
+                return await self._read_with_size_limit(response)
         except (aiohttp.ClientResponseError, aiohttp.ClientConnectorError) as ex:
             raise RemoteLogAccessError(f"We couldn't obtain the log from {self.url}") from ex
-        return await response.text()
+
+    async def _read_with_size_limit(self, response: aiohttp.ClientResponse) -> str:
+        """Stream response chunks, raising RemoteLogTooLargeError if the limit is exceeded."""
+        chunks: list[bytes] = []
+        total = 0
+        async for chunk in response.content.iter_chunked(65536):
+            total += len(chunk)
+            if total > self._limit_bytes:
+                self.remote_log_size = total
+                response.close()  # prevent aiohttp from draining the body on exit
+                raise RemoteLogTooLargeError(
+                    f"Content exceeds the limit of {self._limit_bytes} bytes while reading"
+                )
+            chunks.append(chunk)
+        self.remote_log_size = total
+        encoding = response.charset or "utf-8"
+        return b"".join(chunks).decode(encoding, errors="replace")
 
 
 async def retrieve_log_content(

--- a/logdetective/server/gitlab.py
+++ b/logdetective/server/gitlab.py
@@ -308,13 +308,13 @@ async def check_artifacts_file_size(
     The python-gitlab library doesn't expose a way to check this value directly,
     so we need to interact with directly with the headers.
 
-    If the `content-length` is not set or is invalid, treat artifacts as too large.
+    If the `Content-Length` is not set or is invalid, treat artifacts as too large (reject).
 
     Raises:
         LogDetectiveArtifactsMissingError in case error status code 404
         LogDetectiveConnectionError in case of other error status codes
     Return:
-        True if artifact is not over the max limit.
+        True if Content-Length is present, valid, and within the size limit; False otherwise.
     """
     artifacts_path = (
         f"{gitlab_cfg.api_path}/projects/{job.project_id}/jobs/{job.id}/artifacts"
@@ -346,7 +346,7 @@ async def check_artifacts_file_size(
         str(size_check.size_in_bytes),
         gitlab_cfg.max_artifact_size,
     )
-    return size_check.result
+    return size_check.proceed
 
 
 async def comment_on_mr(  # pylint: disable=too-many-arguments disable=too-many-positional-arguments

--- a/logdetective/server/utils.py
+++ b/logdetective/server/utils.py
@@ -97,11 +97,11 @@ def validate_request_size(request: Request) -> int:
     size_check: ContentSizeCheck = check_content_size(
         request.headers, SERVER_CONFIG.general.max_artifact_size
     )
-    if not (size_check.value_present and size_check.size_in_bytes is not None):
+    if size_check.size_in_bytes is None:
         raise HTTPException(
             status_code=411, detail="Content-Length is missing or invalid."
         )
-    if not size_check.result:
+    if not size_check.proceed:
         raise HTTPException(
             status_code=413,
             detail=(

--- a/logdetective/utils.py
+++ b/logdetective/utils.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import subprocess as sp
+from collections.abc import Mapping
 from typing import (
     Iterator,
     List,
@@ -344,50 +345,48 @@ class ContentSizeCheck(NamedTuple):
     Aggregate requests content-size info for checks.
 
     Args:
-        result: the check is successful (content-size info is present within limits)
-        value_present: content-length info is present (value_present=False => result=False)
-        size_in_bytes: None if content-length missing or invalid
+        proceed: True if download should proceed; False to reject.
+        size_in_bytes: Parsed Content-Length value, or None if absent or invalid.
     """
 
-    result: bool
-    value_present: bool
+    proceed: bool
     size_in_bytes: int | None
 
 
-def check_content_size(headers: dict[str, str], size_limit: int) -> ContentSizeCheck:
+def check_content_size(
+    headers: Mapping,
+    size_limit: int,
+    require_header: bool = True,
+) -> ContentSizeCheck:
     """
     Validate that a request's content size doesn't exceed a maximum based on headers.
 
     Args:
-        headers: Dictionary of HTTP headers
+        headers: HTTP headers
+        size_limit: Maximum allowed size in bytes
+        require_header:
+            True(defualt): request with no Content-Length header is rejected.
+            False: request with an absent header is allowed (limit is then checked while reading).
 
     Returns:
-        ContentSizeCheck, If its `.result=False` => request should be rejected.
+        ContentSizeCheck.`.proceed=True` means safe to download. `.proceed=False` means reject.
+        `.size_in_bytes` is None when the header is absent or unparseable.
     """
-    header_name = "Content-Length"
-    content_length: str | int | None = headers.get(header_name) or headers.get(
-        header_name.lower()
-    )
+    content_length = headers.get("content-length")
 
     if content_length is None:
-        transfer_header = "Transfer-Encoding"
-        transfer_encoding = headers.get(transfer_header) or headers.get(
-            transfer_header.lower(), "None"
-        )
-        LOG.warning(
-            (
-                "No `Content-Length`. Transfer-Encoding: %s "
-                "Treating artifacts as over the maximum size."
-            ),
+        transfer_encoding = headers.get("transfer-encoding", "None")
+        LOG.info(
+            "No Content-Length header. Transfer-Encoding: %s",
             transfer_encoding,
         )
-        return ContentSizeCheck(result=False, value_present=False, size_in_bytes=None)
+        return ContentSizeCheck(proceed=not require_header, size_in_bytes=None)
 
     try:
         size = int(content_length)
     except (ValueError, TypeError):
         LOG.error("Invalid Content-Length header value: %s", content_length)
-        return ContentSizeCheck(result=False, value_present=True, size_in_bytes=None)
+        return ContentSizeCheck(proceed=False, size_in_bytes=None)
 
     is_valid = size <= size_limit
     if not is_valid:
@@ -398,7 +397,7 @@ def check_content_size(headers: dict[str, str], size_limit: int) -> ContentSizeC
             size_limit,
             size_limit / (1024 * 1024),
         )
-    return ContentSizeCheck(result=is_valid, value_present=True, size_in_bytes=size)
+    return ContentSizeCheck(proceed=is_valid, size_in_bytes=size)
 
 
 def mine_logs(log: str, extractors: list) -> List[Tuple[int, str]]:

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -72,41 +72,72 @@ def test_load_prompts_correct_path():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "url, mock_header, exc_type, exc_match",
+    "url, mock_header, mock_body, limit_bytes, exc_type, exc_match",
     [
-        ("http://example.com/build.log", {"Content-Length": "3"}, None, None),
+        ("http://example.com/build.log", {"Content-Length": "3"}, "123", None, None, None),
         (
             "http://example.com/build.log",
             {"Content-Length": "test"},
+            "123",
+            None,
             RemoteLogHeaderError,
-            "Content-Length is invalid",
+            "Content-Length header is invalid",
         ),
         (
             "http://example.com/build.log",
             {"Content-Length": f"{mib_to_bytes(DEFAULT_MAXIMUM_ARTIFACT_MIB) + 1}"},
+            "123",
+            None,
             RemoteLogTooLargeError,
             "Content-Length is over the limit",
         ),
-        ("not-a-valid-url", {}, RemoteLogRequestError, "Invalid log URL"),
-        ("http://example.com/build.log", {}, RemoteLogHeaderError, "Content-Length is missing")
+        ("not-a-valid-url", {}, "123", None, RemoteLogRequestError, "Invalid log URL"),
+        # No Content-Length: small body succeeds
+        ("http://example.com/build.log", {}, "123", None, None, None),
+        # No Content-Length: body over limit is rejected while reading
+        (
+            "http://example.com/build.log",
+            {},
+            "x" * 20,
+            10,
+            RemoteLogTooLargeError,
+            "exceeds the limit",
+        ),
+        # Lying Content-Length: declared within limit, actual body over limit
+        (
+            "http://example.com/build.log",
+            {"Content-Length": "3"},
+            "x" * 20,
+            10,
+            RemoteLogTooLargeError,
+            "exceeds the limit",
+        ),
     ],
     indirect=False,
 )
-async def test_get_url_content(url, mock_header, exc_type, exc_match):
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+async def test_get_url_content(
+    url,
+    mock_header,
+    mock_body,
+    limit_bytes,
+    exc_type,
+    exc_match
+):
     """Test various URL requests and correct Exceptions during RemoteLog access."""
-    mock_response = "123"
     with aioresponses.aioresponses() as mock:
         mock.head(url, status=200, headers=mock_header)
-        mock.get(url, status=200, body=mock_response)
+        mock.get(url, status=200, body=mock_body)
         async with aiohttp.ClientSession() as http:
+            kwargs = {"limit_bytes": limit_bytes} if limit_bytes is not None else {}
             if exc_type:
                 with pytest.raises(exc_type, match=exc_match):
-                    remote_log = RemoteLog(url, http)
+                    remote_log = RemoteLog(url, http, **kwargs)
                     await remote_log.get_url_content()
             else:
-                remote_log = RemoteLog(url, http)
+                remote_log = RemoteLog(url, http, **kwargs)
                 url_output = await remote_log.get_url_content()
-                assert url_output == "123"
+                assert url_output == mock_body
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This change affects only RemoteLogs - requests that contain URLs. Putting log content directly into the request still requires Content-Length header.
- Content-Length is present and too large -> `RemoteLogTooLargeError`
- Content-Length is present and invalid -> `RemoteLogHeaderError`
- Content Length is present and okay -> stream the file and continually check size (in case header lies about size)
- Content Length is not-present -> stream the file and continually check size (this fixes what OBS guys suggested)