### PR TITLE
Double inference proxy timeouts

### DIFF
--- a/server/nginx_dev.conf.template
+++ b/server/nginx_dev.conf.template
@@ -5,6 +5,9 @@ upstream inference_backend {
 }
 server {
     listen ${INFERENCE_PROXY_PORT};
+    proxy_connect_timeout 120s;
+    proxy_send_timeout 120s;
+    proxy_read_timeout 120s;
     location / {
         proxy_pass http://inference_backend;
         proxy_set_header Host $host;

--- a/server/nginx_prod.conf.template
+++ b/server/nginx_prod.conf.template
@@ -8,6 +8,9 @@ upstream inference_backend {
 }
 server {
     listen ${INFERENCE_PROXY_PORT};
+    proxy_connect_timeout 120s;
+    proxy_send_timeout 120s;
+    proxy_read_timeout 600s;
     location / {
         proxy_pass http://inference_backend;
         proxy_set_header Host $host;


### PR DESCRIPTION
Default timeouts are all 60, this is sometimes not enough to get a response.

https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_read_timeout