### PR TITLE
Improve response quality for analysis involving multiple artifacts

### DIFF
--- a/logdetective/prompts/agent_start_prompt.j2
+++ b/logdetective/prompts/agent_start_prompt.j2
@@ -3,7 +3,7 @@ Use provided tools to analyze following build artifacts:
 {% for artifact in artifacts %}
 * {{ artifact }}
 {% endfor %}
-You MUST extract snippets from all artifacts, until you have clear root cause.
+You MUST extract snippets from ALL artifacts.
 Focus on issues that are likely to cause a build failure.
 
 {% if commentary %}

--- a/logdetective/prompts/system_prompt.j2
+++ b/logdetective/prompts/system_prompt.j2
@@ -1,56 +1,39 @@
 System time: {{ system_time }}
 
-You are a highly capable expert system specialized in packaging and delivery of software using RPM,
-within the RHEL ecosystem. Your purpose is to help package maintainers diagnose and resolve package build failures.
-You are truthful, concise, and helpful.
+You diagnose RPM build failures in the RHEL ecosystem. You are truthful, concise, and helpful.
 
-## Input processing
+## Input
 
-You will work with build artifacts produced during a failed RPM build.
-Using provided tools you will extract snippets from them.
-These snippets were extracted using data mining algorithm, and may not contain information
-useful for diagnosing the root cause. Snippets without useful information must be disregarded.
-General error messages, such as failure of commands used during build, are expected.
+You will extract snippets from failed build artifacts using provided tools.
+Some snippets may not be useful — disregard them.
+Exit codes, "Bad exit status" messages, and command failure wrappers are consequences, not causes.
+Focus on the specific error messages, test failures, or compilation errors that triggered them.
 
-## Temporal Logic and Causality
+## Causality
 
-Log snippets are typically provided in chronological order. When analyzing multiple snippets
-the first significant error in the log is usually the root cause.
+Snippets are chronological. The first significant error is usually the root cause.
+Later errors are typically side effects — focus on the primary trigger.
 
-An error occurring at line #500 cannot be caused by an error occurring at line #1000.
+## Procedure
 
-Subsequent errors are often side effects of the initial failure. Focus your diagnosis on the primary trigger.
-
-## Analysis procedure
-
-Avoid generic or boilerplate recommendations (e.g., "check the logs," "ensure dependencies are met").
-If a specific root cause is identified, the recommendation must directly address that cause.
-
-1. Analyze individual build artifacts with provided tools.
-2. Disregard snippets that do not contain useful information.
-3. Using information from all snippets provide explanation of the issue. Be as specific as possible.
-4. (Optional) Recommend a solution for the package maintainer, only if the cause is clear.
+1. Analyze ALL build artifacts.
+2. Provide a specific explanation of the root cause.
+3. (Optional) Recommend a solution only if the cause is clear.
+Avoid generic recommendations like "check the logs" or "ensure dependencies are met."
 
 ## Redacted data
 
-The data you receive come from logs that have been redacted. Personal information,
-such as emails, GPG fingerprints, RSA or other public keys have been redacted.
-Emails have been replaced by copr-team@redhat.com.
-Fingerprints and keys in hexadecimal have been replaced with all Fs.
-Note that this is not an error, but a security measure.
+Personal data has been redacted: emails replaced with copr-team@redhat.com,
+keys/fingerprints replaced with Fs. This is intentional, not an error.
 
 ## Response format
 
-Keep your responses brief and to the point. Do not include any markdown, or other formatting
-of the text, except for paragraphs and line breaks.
-
-Your responses should be at most one paragraph in length, if possible.
+Brief, plain text only. Reference original error messages with artifact name and location.
+Do not mention tools or analysis steps.
+One paragraph if possible.
 
 {% if references %}
 ## References:
-
-When necessary, suggest resources that may be helpful to user.
-
     {% for reference in references %}
     * {{ reference.name }} : {{ reference.link }}
     {% endfor %}

--- a/logdetective/server/agent/agent.py
+++ b/logdetective/server/agent/agent.py
@@ -67,7 +67,7 @@ async def analyze_artifacts(
         ConditionalRequirement(
             DrainExtractorTool,
             consecutive_allowed=True,
-            min_invocations=1,
+            min_invocations=len(artifacts),
             max_invocations=len(artifacts),
         ),
     ]

--- a/logdetective/server/agent/tools.py
+++ b/logdetective/server/agent/tools.py
@@ -104,15 +104,18 @@ class ExtractorTool(Tool[ExtractorToolInput]):
 
         artifact = self.all_artifacts[input.artifact_name]
         raw_snippets = self.extractor(artifact)
+        current_snippets = []
         for line_number, text in raw_snippets:
-            self.extracted_snippets.append(
-                Snippet(
-                    text=text, line_number=line_number, source_file=input.artifact_name
-                )
+            new_snippet = Snippet(
+                text=text, line_number=line_number, source_file=input.artifact_name
             )
+            self.extracted_snippets.append(
+                new_snippet
+            )
+            current_snippets.append(new_snippet)
         return ExtractorToolOutput(
             source_artifact=input.artifact_name,
-            extracted_snippets=self.extracted_snippets,
+            extracted_snippets=current_snippets,
             remaining_artifacts=self._remaining_artifacts,
         )
 

--- a/logdetective/server/agent/tools.py
+++ b/logdetective/server/agent/tools.py
@@ -1,4 +1,5 @@
 from typing import Any, Optional
+from enum import Enum
 
 from beeai_framework.context import RunContext
 from beeai_framework.emitter.emitter import Emitter
@@ -17,10 +18,13 @@ from logdetective.extractors import (
 from logdetective.models import SkipSnippets
 from logdetective.server.models import ExtractorConfig, Snippet, AnalyzedSnippet
 
+ARTIFACT_NAME_DESC = "The exact name of the artifact you want to extract information from."
+
 
 class ExtractorToolInput(BaseModel):
-    artifact_name: str = Field(
-        description="The exact name of the artifact you want to extract information from."
+    """Possible values of artifact_name, are derived during runtime."""
+    artifact_name: Enum = Field(
+        description=ARTIFACT_NAME_DESC
     )
 
 
@@ -117,7 +121,15 @@ class ExtractorTool(Tool[ExtractorToolInput]):
 
     @property
     def input_schema(self) -> type[ExtractorToolInput]:
-        return self._input_schema
+        if not self._remaining_artifacts:
+            return self._input_schema
+
+        ArtifactName = Enum("ArtifactName", {artifact: artifact for artifact in self._remaining_artifacts}, type=str)
+
+        class DynamicExtractorToolInput(ExtractorToolInput):
+            artifact_name: ArtifactName = Field(description=ARTIFACT_NAME_DESC)
+
+        return DynamicExtractorToolInput
 
 
 class DrainExtractorTool(ExtractorTool):

--- a/logdetective/skip_snippets.yml
+++ b/logdetective/skip_snippets.yml
@@ -3,10 +3,54 @@
 # Patterns are to be specified as values of dictionary,
 # with each key being a descriptive name of the pattern.
 # Patterns themselves are evaluated as a regular expression.
+# This file is only an example, following patterns are derived from
+# behavior of Mock.
+# Users are encouraged to provide their own patterns.
+# NOTE: Matching uses re.match (anchored to start of string).
+# Use .* prefix for patterns that appear mid-string.
 # Make sure to avoid regular expressions that may be interpreted
 # as yaml syntax.
-# Example:
 
-# contains_capital_a: "^.*A.*"
-# starts_with_numeric: "^[0-9].*"
-child_exit_code_zero: "Child return code was: 0"
+# Successful child process exits
+child_exit_code_zero: ".*Child return code was: 0"
+
+# All DEBUG-level mock traces (file ops, mount, env, packages, nspawn)
+mock_debug: "^DEBUG "
+
+# All INFO-level mock traces (buildroot, backend, package manager)
+mock_info: "^INFO "
+
+# Mock informational lines from mock_output.log
+mock_info_colon: "^INFO: "
+
+# Mock lifecycle markers
+mock_lifecycle_start: "^Start[:(]"
+mock_lifecycle_finish: "^Finish[:(]"
+
+# Mock deprecation warnings (not the build failure)
+mock_deprecation: "^ERROR: Option .* has been deprecated"
+
+# Mock/Koji infrastructure wrappers (fail whenever any inner step fails, never diagnostic)
+mock_nspawn_command_failed: "^ERROR: Command failed:"
+koji_exception_wrapper: "^ERROR: Exception\\("
+
+# Mock version line
+mock_version: "^Mock Version:"
+
+# Test framework - non-failure results and boilerplate
+test_non_failure: ".*(PASSED|XFAIL|SKIPPED)\\s+\\["
+test_bracket_non_failure: "^\\[\\s+(PASSED|OK|RUN)"
+test_bracket_separator: "^\\[[-=]"
+pytest_section: "^=+\\s"
+
+# Build boilerplate
+rpm_build_header: "^RPM build (warnings|errors):"
+port_server: ".*[Pp]ort server"
+koji_buildroot: ".*koji\\.build\\.buildroot"
+
+# Package NVR lines and kernel version strings
+pkg_nvr: "^[a-z].*\\.(noarch|x86_64|i686|aarch64|ppc64le|s390x)$"
+kernel_version: "^\\d+\\.\\d+\\.\\d+"
+
+# Shell trace lines (single + and double ++)
+shell_trace: "^\\+\\+? "


### PR DESCRIPTION
This PR addresses several issues that were discovered during course of experimentation with our existing setup, namely:

- Agent attempting to extract snippets from the same artifact multiple times
- Agent ignoring all artifacts except for one
- Extractor output being flooded by non-informative messages
- System prompt taking up too many tokens

The biggest change was made to the tool signature. The input schema is now defined dynamically, with allowed input values changing depending on already analyzed artifacts. This prevents model from ever attempting to extract snippets from a single artifact multiple times.

The tool output has also been modified, to only produce the newest batch of extracted snippets. This limits the context usage, but since we are using unlimited agent memory, all information will remain available for agent to work with.

The prompt  has been condensed, so that it takes up fewer tokens and more emphasis was put on analyzing all artifacts before reporting results.

The agent is now forced, by harness constraint, to analyze all artifacts, so putting this request in prompt is not strictly necessary. But if we ever decide to change constraints, it may prove valuable.

The final batch of changes are default skip snippet patterns. The new list is derived from common messages encountered in builds handled by mock. Previously we had only one. But even inclusion of few more led to substantial improvement of agent response. 