### PR TITLE
New production configuration defaults

### DIFF
--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -16,22 +16,25 @@ services:
         condition: service_healthy
 
 
-  # 4 GPU vLLM inference using 8-bit quant of granite-4.0-tiny
+  # 4 GPU vLLM inference using gemma-4-E4B-it
   # requires the exact number of CUDA devices and accesss to Hugging Face
   # for pulling the model.
 
   # GPU 0 Instance
   inference-0: &inference-base
-    image: vllm/vllm-openai:v0.16.0
+    image: vllm/vllm-openai:v0.22.0
     command: >
-      fedora-copr/granite-4.0-h-tiny-quantized.w8a8
-      --gpu-memory-utilization 0.9
-      --max-model-len 65536
-      --kv-cache-dtype fp8
-      --max-num-seqs 64
-      --tool-call-parser granite
+      google/gemma-4-E4B-it
+      --gpu-memory-utilization 0.95
+      --max-model-len 31504
+      --tool-call-parser gemma4
+      --reasoning-parser gemma4
       --port ${INFERENCE_SERVER_PORT:-8100}
       --enable-auto-tool-choice
+      --enable-prefix-caching
+      --enable-chunked-prefill
+      --kv-cache-dtype auto
+      --chat-template examples/tool_chat_template_gemma4.jinja
     deploy:
       resources:
         reservations:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -74,6 +74,7 @@ services:
   packit-interface:
     image: quay.io/logdetective/packit:latest
     volumes:
+      - ./files/fedora_messaging_conf.toml:/etc/fedora-messaging/config.toml:ro,Z
       - ${FM_CERT_PATH:-./fedora_messaging_certs/logdetective-packit-cert.pem}:/etc/fedora-messaging/fedora-cert.pem:ro,Z
       - ${FM_KEY_PATH:-./fedora_messaging_certs/logdetective-packit-key.pem}:/etc/fedora-messaging/fedora-key.pem:ro,Z
     depends_on:

--- a/files/fedora_messaging_conf.toml
+++ b/files/fedora_messaging_conf.toml
@@ -1,0 +1,62 @@
+# Configuration for fedora-messaging
+amqp_url = "amqps://logdetective-packit:@rabbitmq.fedoraproject.org/%2Fpubsub"
+callback = "fedora_messaging.example:printer"
+passive_declares = true
+publish_exchange = "amq.topic"
+topic_prefix = "org.fedoraproject.prod"
+
+[tls]
+ca_cert = "/etc/fedora-messaging/cacert.pem"
+keyfile = "/etc/fedora-messaging/fedora-key.pem"
+certfile = "/etc/fedora-messaging/fedora-cert.pem"
+
+[client_properties]
+app = "Log Detective"
+app_url = "https://github.com/fedora-copr/logdetective-packit"
+app_contacts_email = "copr-team@redhat.com"
+
+# If the exchange or queue name  has a "." in it, use quotes as seen here.
+[exchanges."amq.topic"]
+type = "topic"
+durable = true
+auto_delete = false
+arguments = {}
+
+[qos]
+prefetch_size = 0
+prefetch_count = 25
+
+[log_config]
+version = 1
+disable_existing_loggers = false
+
+[log_config.formatters.simple]
+format = "[%(levelname)s %(name)s] %(message)s"
+
+[log_config.handlers.console]
+class = "logging.StreamHandler"
+formatter = "simple"
+stream = "ext://sys.stdout"
+
+[log_config.loggers.fedora_messaging]
+level = "INFO"
+propagate = false
+handlers = ["console"]
+
+# Twisted is the asynchronous framework that manages the TCP/TLS connection, as well
+# as the consumer event loop. When debugging you may want to lower this log level.
+[log_config.loggers.twisted]
+level = "DEBUG"
+propagate = false
+handlers = ["console"]
+
+# Pika is the underlying AMQP client library. When debugging you may want to
+# lower this log level.
+[log_config.loggers.pika]
+level = "DEBUG"
+propagate = false
+handlers = ["console"]
+
+[log_config.root]
+level = "DEBUG"
+handlers = ["console"]

--- a/logdetective/skip_snippets.yml
+++ b/logdetective/skip_snippets.yml
@@ -15,13 +15,13 @@
 child_exit_code_zero: ".*Child return code was: 0"
 
 # All DEBUG-level mock traces (file ops, mount, env, packages, nspawn)
-mock_debug: "^DEBUG "
+# mock_debug: "^DEBUG "
 
 # All INFO-level mock traces (buildroot, backend, package manager)
-mock_info: "^INFO "
+# mock_info: "^INFO "
 
 # Mock informational lines from mock_output.log
-mock_info_colon: "^INFO: "
+# mock_info_colon: "^INFO: "
 
 # Mock lifecycle markers
 mock_lifecycle_start: "^Start[:(]"

--- a/server/config.yml
+++ b/server/config.yml
@@ -8,7 +8,7 @@ inference:
   url: http://inference-server:8000/v1
   api_token: "XXX" # Must not be empty, even if the server doesn't require authentication
   api_timeout: 60.0 # Timeout for the LLM API client, how long should it wait for inference server response
-  model: "fedora-copr/granite-4.0-h-tiny-quantized.w8a8"
+  model: "google/gemma-4-E4B-it"
   # Role needs to be aligned with chat template
   system_role: system
   # How many attempts agent has to make a correct tool call

--- a/server/config.yml
+++ b/server/config.yml
@@ -3,7 +3,7 @@ log:
   level_file: "DEBUG"
   path: "log/logdetective.log"
 inference:
-  max_tokens: 10000 # maximum number of tokens must be a positive integer
+  max_tokens: 2000 # maximum number of tokens must be a positive integer
   log_probs: true
   url: http://inference-server:8000/v1
   api_token: "XXX" # Must not be empty, even if the server doesn't require authentication


### PR DESCRIPTION
This change includes new configuration for example configuration config.

- Model is now gemma-4-E4B-it
- Fedora messaging config is part of the repo
- Token limit per message is set to 2000, hopefully preventing worst of Gemmas misbehavior
- Several skip patterns were disabled, as they led to entire files being skipped
- vLLM runtime is now set to version 0.22.0