### PR TITLE
Restore models import

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -7,6 +7,8 @@ from sqlalchemy import pool
 from alembic import context
 
 from logdetective.server.database.base import get_pg_url, Base
+# This import needs to stay in order for revision generation to pick up current state
+from logdetective.server.database import models  # noqa: F401
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.


### PR DESCRIPTION
Without import of the models module, the revision generation created changes that make no sense, such as removal of existing tables etc.

This is because without the import, models are not executed, alembic doesn't know about them and then tries to reconcile the database state with the only model it has, which is `Base`. 