### PR TITLE
Import ChatModelParameters directly from the types module

### DIFF
--- a/logdetective/server/config.py
+++ b/logdetective/server/config.py
@@ -2,7 +2,7 @@ import os
 import logging
 import yaml
 from beeai_framework.backend import ChatModel
-from beeai_framework.backend.chat import ChatModelParameters
+from beeai_framework.backend.types import ChatModelParameters
 
 from logdetective.utils import load_prompts, load_skip_snippet_patterns
 from logdetective.server.models import Config, InferenceConfig


### PR DESCRIPTION
The original import was indirect.  Importing it from types is a better option.