### PR TITLE
Enable client side caching of tool calls and LLM responses

### DIFF
--- a/logdetective/server/agent/agent.py
+++ b/logdetective/server/agent/agent.py
@@ -5,6 +5,7 @@ from beeai_framework.agents.requirement.requirements.conditional import (
     ConditionalRequirement,
 )
 from beeai_framework.backend.errors import ChatModelError
+from beeai_framework.cache import UnconstrainedCache
 from beeai_framework.memory import UnconstrainedMemory
 from beeai_framework.tools.think import ThinkTool
 from beeai_framework.backend import ChatModel
@@ -50,6 +51,7 @@ async def analyze_artifacts(
         extractor_config=SERVER_CONFIG.extractor,
         available_artifacts=artifacts,
         skip_snippets=SKIP_SNIPPETS_CONFIG,
+        options={"cache": UnconstrainedCache()}
     )
     csgrep_extractor = None
     python_tb_extractor = None
@@ -78,6 +80,7 @@ async def analyze_artifacts(
             extractor_config=SERVER_CONFIG.extractor,
             available_artifacts=artifacts,
             skip_snippets=SKIP_SNIPPETS_CONFIG,
+            options={"cache": UnconstrainedCache()}
         )
         tools.append(csgrep_extractor)
         requirements.append(
@@ -93,6 +96,7 @@ async def analyze_artifacts(
             extractor_config=SERVER_CONFIG.extractor,
             available_artifacts=artifacts,
             skip_snippets=SKIP_SNIPPETS_CONFIG,
+            options={"cache": UnconstrainedCache()}
         )
         tools.append(python_tb_extractor)
         requirements.append(
@@ -107,7 +111,12 @@ async def analyze_artifacts(
     # max_invocations are set at 5. Most snippets are not informative, and annotating them
     # provides no benefit.
     extractors = [tool for tool in tools if isinstance(tool, ExtractorTool)]
-    tools.append(SnippetAnalysisTool(extractors=extractors))
+    tools.append(
+        SnippetAnalysisTool(
+            extractors=extractors,
+            options={"cache": UnconstrainedCache()}
+        )
+    )
     requirements.append(
         ConditionalRequirement(
             SnippetAnalysisTool,

--- a/logdetective/server/config.py
+++ b/logdetective/server/config.py
@@ -3,7 +3,7 @@ import logging
 import yaml
 from beeai_framework.backend import ChatModel
 from beeai_framework.backend.types import ChatModelParameters
-
+from beeai_framework.cache import SlidingCache
 from logdetective.utils import load_prompts, load_skip_snippet_patterns
 from logdetective.server.models import Config, InferenceConfig
 from logdetective.constants import PROMPT_PATH, PROMPT_CONF_PATH
@@ -63,6 +63,7 @@ def get_chat_model(inference_config: InferenceConfig) -> ChatModel:
             max_tokens=inference_config.max_tokens,
         ),
         tool_choice_support={"auto"},
+        cache=SlidingCache(inference_config.llm_call_cache_size),
         settings={
             **inference_config.provider_settings,
             "timeout": inference_config.api_timeout,

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -229,6 +229,8 @@ class InferenceConfig(BaseModel):  # pylint: disable=too-many-instance-attribute
     # Provider-specific settings passed to the beeai backend via the settings dict.
     # Keys are beeai internal setting names (e.g. api_key, base_url, vertex_project, ...).
     provider_settings: dict[str, str] = {}
+    # Harness cache settings
+    llm_call_cache_size: int = 35
 
 
 class ExtractorConfig(BaseModel):


### PR DESCRIPTION
With this modification we can cache both tool calls and LLM responses without having to change anything about our inference backend. The cache for LLM calls is set to hold 35 calls by default, this should be enough for most runs, while not excessively taxing memory. 

The tool calls cache is not constrained at all, since number of tool calls is extremely limited by constraints.