### PR TITLE
Set configurable exponential backoff on agentic analysis

### DIFF
--- a/logdetective/server/agent/agent.py
+++ b/logdetective/server/agent/agent.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+import backoff
 from beeai_framework.agents.requirement import RequirementAgent
 from beeai_framework.agents.requirement.requirements.conditional import (
     ConditionalRequirement,
@@ -31,8 +32,17 @@ from logdetective.server.exceptions import (
     LogDetectiveInferenceError,
     LogDetectiveInferenceRateLimit,
 )
+from logdetective.server.utils import inference_retry_backoff, inference_retry_giveup
 
 
+@backoff.on_exception(
+    backoff.expo,
+    (LogDetectiveInferenceTimeout, LogDetectiveInferenceRateLimit),
+    max_tries=SERVER_CONFIG.inference.retry_max_tries,
+    max_time=SERVER_CONFIG.inference.retry_max_time,
+    on_backoff=inference_retry_backoff,
+    on_giveup=inference_retry_giveup,
+)
 async def analyze_artifacts(
     artifacts: dict[str, str],
     chat_model: ChatModel,

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -231,6 +231,10 @@ class InferenceConfig(BaseModel):  # pylint: disable=too-many-instance-attribute
     provider_settings: dict[str, str] = {}
     # Harness cache settings
     llm_call_cache_size: int = 35
+    # Retry settings for transient LLM API errors (timeouts, rate limits).
+    # Uses exponential backoff. Set retry_max_tries to 1 to disable.
+    retry_max_tries: int = 3
+    retry_max_time: int = 120
 
 
 class ExtractorConfig(BaseModel):

--- a/logdetective/server/utils.py
+++ b/logdetective/server/utils.py
@@ -25,6 +25,27 @@ def connection_error_giveup(details: dict) -> None:
     raise LogDetectiveConnectionError() from details["exception"]
 
 
+def inference_retry_backoff(details: dict) -> None:
+    """Log when an LLM inference call is being retried."""
+    LOG.warning(
+        "LLM inference retry %d after %s (%.1fs elapsed): %s",
+        details["tries"],
+        type(details["exception"]).__name__,
+        details["elapsed"],
+        details["exception"],
+    )
+
+
+def inference_retry_giveup(details: dict) -> None:
+    """Log when all LLM inference retries are exhausted."""
+    LOG.error(
+        "LLM inference failed after %d retries (%.1fs elapsed): %s",
+        details["tries"],
+        details["elapsed"],
+        details["exception"],
+    )
+
+
 async def get_artifacts_from_payload(
     payload: AnalysisRequest,
     http_session: aiohttp.ClientSession,

--- a/server/config.yml
+++ b/server/config.yml
@@ -32,6 +32,10 @@ inference:
   # increase when working with smaller models
   total_max_retries: 10
   max_retries_per_step: 3
+  # Retry settings for transient LLM API errors (timeouts, rate limits).
+  # Uses exponential backoff. Set retry_max_tries to 1 to disable.
+  # retry_max_tries: 3     # Maximum number of retry attempts
+  # retry_max_time: 120    # Maximum total backoff time in seconds
 extractor:
   max_clusters: 25
   verbose: false

--- a/tests/server/agent/test_agent.py
+++ b/tests/server/agent/test_agent.py
@@ -109,13 +109,14 @@ async def test_analyze_artifacts_inference_errors(mock_agent_setup, cause, expec
     mock_error.__cause__ = cause
 
     with patch("logdetective.server.agent.agent.RequirementAgent") as MockAgent:
-        mock_run_instance = MagicMock()
-        mock_run_instance.middleware = AsyncMock(
-            side_effect=mock_error
-        )
-        MockAgent.return_value.run.return_value = mock_run_instance
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            mock_run_instance = MagicMock()
+            mock_run_instance.middleware = AsyncMock(
+                side_effect=mock_error
+            )
+            MockAgent.return_value.run.return_value = mock_run_instance
 
-        with pytest.raises(LogDetectiveInferenceError) as exc_info:
-            await analyze_artifacts(mock_artifacts, mock_chat_model)
+            with pytest.raises(LogDetectiveInferenceError) as exc_info:
+                await analyze_artifacts(mock_artifacts, mock_chat_model)
 
     assert isinstance(exc_info.value, expected_exc)

--- a/tests/server/test_inference_retry.py
+++ b/tests/server/test_inference_retry.py
@@ -1,0 +1,176 @@
+"""Tests for LLM inference retry-with-backoff behavior."""
+
+import pytest
+import backoff
+
+from logdetective.server.exceptions import (
+    LogDetectiveInferenceError,
+    LogDetectiveInferenceTimeout,
+    LogDetectiveInferenceRateLimit,
+)
+from logdetective.server.models import InferenceConfig
+from logdetective.server.utils import inference_retry_backoff, inference_retry_giveup
+
+
+@pytest.mark.asyncio
+async def test_retry_on_timeout_succeeds():
+    """Transient timeout on first call, success on second."""
+    call_count = 0
+
+    @backoff.on_exception(
+        backoff.expo,
+        (LogDetectiveInferenceTimeout, LogDetectiveInferenceRateLimit),
+        max_tries=3,
+        max_time=60,
+        on_backoff=inference_retry_backoff,
+        on_giveup=inference_retry_giveup,
+    )
+    async def retryable():
+        nonlocal call_count
+        call_count += 1
+        if call_count < 2:
+            raise LogDetectiveInferenceTimeout("temporary timeout")
+        return "ok"
+
+    result = await retryable()
+    assert result == "ok"
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_on_rate_limit_succeeds():
+    """Transient rate limit on first call, success on second."""
+    call_count = 0
+
+    @backoff.on_exception(
+        backoff.expo,
+        (LogDetectiveInferenceTimeout, LogDetectiveInferenceRateLimit),
+        max_tries=3,
+        max_time=60,
+        on_backoff=inference_retry_backoff,
+        on_giveup=inference_retry_giveup,
+    )
+    async def retryable():
+        nonlocal call_count
+        call_count += 1
+        if call_count < 2:
+            raise LogDetectiveInferenceRateLimit("rate limited")
+        return "ok"
+
+    result = await retryable()
+    assert result == "ok"
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_no_retry_on_permanent_error():
+    """LogDetectiveInferenceError propagates immediately without retry."""
+    call_count = 0
+
+    @backoff.on_exception(
+        backoff.expo,
+        (LogDetectiveInferenceTimeout, LogDetectiveInferenceRateLimit),
+        max_tries=3,
+        max_time=60,
+        on_backoff=inference_retry_backoff,
+        on_giveup=inference_retry_giveup,
+    )
+    async def retryable():
+        nonlocal call_count
+        call_count += 1
+        raise LogDetectiveInferenceError("permanent error")
+
+    with pytest.raises(LogDetectiveInferenceError, match="permanent error"):
+        await retryable()
+    assert call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_exhaustion_raises():
+    """All retries exhausted — exception propagates."""
+    call_count = 0
+
+    @backoff.on_exception(
+        backoff.expo,
+        (LogDetectiveInferenceTimeout, LogDetectiveInferenceRateLimit),
+        max_tries=3,
+        max_time=60,
+        on_backoff=inference_retry_backoff,
+        on_giveup=inference_retry_giveup,
+    )
+    async def retryable():
+        nonlocal call_count
+        call_count += 1
+        raise LogDetectiveInferenceTimeout("still timing out")
+
+    with pytest.raises(LogDetectiveInferenceTimeout, match="still timing out"):
+        await retryable()
+    assert call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_backoff_handler_called():
+    """inference_retry_backoff is called when a retry occurs."""
+    backoff_calls = []
+    call_count = 0
+
+    def tracking_backoff(details):
+        backoff_calls.append(details)
+        inference_retry_backoff(details)
+
+    @backoff.on_exception(
+        backoff.expo,
+        (LogDetectiveInferenceTimeout,),
+        max_tries=2,
+        max_time=60,
+        on_backoff=tracking_backoff,
+    )
+    async def retryable():
+        nonlocal call_count
+        call_count += 1
+        if call_count < 2:
+            raise LogDetectiveInferenceTimeout("timeout")
+        return "ok"
+
+    await retryable()
+    assert len(backoff_calls) == 1
+    assert backoff_calls[0]["tries"] == 1
+
+
+@pytest.mark.asyncio
+async def test_giveup_handler_called():
+    """inference_retry_giveup is called when retries are exhausted."""
+    giveup_calls = []
+
+    def tracking_giveup(details):
+        giveup_calls.append(details)
+        inference_retry_giveup(details)
+
+    @backoff.on_exception(
+        backoff.expo,
+        (LogDetectiveInferenceTimeout,),
+        max_tries=2,
+        max_time=60,
+        on_giveup=tracking_giveup,
+    )
+    async def retryable():
+        raise LogDetectiveInferenceTimeout("timeout")
+
+    with pytest.raises(LogDetectiveInferenceTimeout):
+        await retryable()
+    assert len(giveup_calls) == 1
+    assert giveup_calls[0]["tries"] == 2
+
+
+def test_config_defaults():
+    """InferenceConfig has correct default retry values."""
+    config = InferenceConfig()
+    assert config.retry_max_tries == 3
+    assert config.retry_max_time == 120
+
+
+def test_config_custom_values():
+    """InferenceConfig accepts custom retry values."""
+    config = InferenceConfig(retry_max_tries=5, retry_max_time=300)
+    assert config.retry_max_tries == 5
+    assert config.retry_max_time == 300


### PR DESCRIPTION
The backoff covers exceptions caused by LLM backend not responding on time.

While this approach doesn't cover all possible causes of failed agent runs, it will help us deal more gracefully with the most common cause.

Alternative would be turning our API fully asynchronous, much like we do for koji, and implementing a task queue. But that would break all existing integrations and require a major release.

Assisted-by: Claude