### PR TITLE
Revert "Add LLM call cache configuration"

### DIFF
--- a/logdetective/server/config.py
+++ b/logdetective/server/config.py
@@ -3,7 +3,7 @@ import logging
 import yaml
 from beeai_framework.backend import ChatModel
 from beeai_framework.backend.types import ChatModelParameters
-from beeai_framework.cache import SlidingCache
+
 from logdetective.utils import load_prompts, load_skip_snippet_patterns
 from logdetective.server.models import Config, InferenceConfig
 from logdetective.constants import PROMPT_PATH, PROMPT_CONF_PATH
@@ -63,7 +63,6 @@ def get_chat_model(inference_config: InferenceConfig) -> ChatModel:
             max_tokens=inference_config.max_tokens,
         ),
         tool_choice_support={"auto"},
-        cache=SlidingCache(inference_config.llm_call_cache_size),
         settings={
             **inference_config.provider_settings,
             "timeout": inference_config.api_timeout,

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -229,8 +229,6 @@ class InferenceConfig(BaseModel):  # pylint: disable=too-many-instance-attribute
     # Provider-specific settings passed to the beeai backend via the settings dict.
     # Keys are beeai internal setting names (e.g. api_key, base_url, vertex_project, ...).
     provider_settings: dict[str, str] = {}
-    # Harness cache settings
-    llm_call_cache_size: int = 35
     # Retry settings for transient LLM API errors (timeouts, rate limits).
     # Uses exponential backoff. Set retry_max_tries to 1 to disable.
     retry_max_tries: int = 3


### PR DESCRIPTION
The sliding cache introduced an unexpected issue of delimiter leak inside of tool calls. For example:

```
   - Error: 1 validation error for AvailableTools
     item
     Field required [type=missing, input_value={'artifact_name': '|>builder-live.log.gz<|'}, input_type=dict]
     For further information visit https://errors.pydantic.dev/2.13/v/missing
```

