### PR TITLE
Add config flag for solution presence

### DIFF
--- a/logdetective/server/agent/agent.py
+++ b/logdetective/server/agent/agent.py
@@ -191,4 +191,6 @@ async def analyze_artifacts(
         no_issue_found=structured_output.no_issue_found,
         snippets=all_snippets,
     )
+    if not SERVER_CONFIG.general.generate_solution:
+        response.solution = None
     return response

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -364,6 +364,7 @@ class GeneralConfig(BaseModel):
     # max_artifact_size in config.yml is in MiBs, here (GeneralConfig class) is in bytes
     max_artifact_size: int = mib_to_bytes(DEFAULT_MAXIMUM_ARTIFACT_MIB)
     block_localhost_urls: bool = True
+    generate_solution: bool = True
 
     @field_validator("max_artifact_size", mode="before")
     @classmethod

--- a/server/config.yml
+++ b/server/config.yml
@@ -85,3 +85,6 @@ general:
   # default = 1 hour. Emoji feedback is collected only if `gitlab` config
   # contains some valid configuration entry.
   # collect_emojis_interval: 3600
+  # If true, the API response will contain a solution,
+  # if the agent is sure about the build failure root cause. (default=True)
+  # generate_solution: true

--- a/tests/server/agent/test_agent.py
+++ b/tests/server/agent/test_agent.py
@@ -14,7 +14,7 @@ from logdetective.server.exceptions import (
     LogDetectiveInferenceTimeout,
     LogDetectiveInferenceRateLimit,
 )
-from logdetective.server.models import AgentResponse, Explanation
+from logdetective.server.models import AgentResponse, Explanation, Solution
 
 
 @pytest.fixture
@@ -120,3 +120,44 @@ async def test_analyze_artifacts_inference_errors(mock_agent_setup, cause, expec
                 await analyze_artifacts(mock_artifacts, mock_chat_model)
 
     assert isinstance(exc_info.value, expected_exc)
+
+
+@pytest.mark.asyncio
+async def test_analyze_artifacts_solution_stripped_when_disabled(mock_agent_setup):
+    """Test that solution is None when generate_solution is False."""
+    mock_artifacts, mock_chat_model, mock_agent_output = mock_agent_setup
+    mock_agent_output.output_structured = AgentResponse(
+        explanation=Explanation(text="Mock explanation"),
+        solution=Solution(text="Mock solution"),
+    )
+
+    mock_run_chain = MagicMock()
+    mock_run_chain.middleware = AsyncMock(return_value=mock_agent_output)
+
+    with patch("logdetective.server.agent.agent.RequirementAgent") as MockAgent:
+        MockAgent.return_value.run.return_value = mock_run_chain
+
+        with patch.object(SERVER_CONFIG.general, "generate_solution", False):
+            response = await analyze_artifacts(mock_artifacts, mock_chat_model)
+            assert response.solution is None
+
+
+@pytest.mark.asyncio
+async def test_analyze_artifacts_solution_kept_when_enabled(mock_agent_setup):
+    """Test that solution is preserved when generate_solution is True."""
+    mock_artifacts, mock_chat_model, mock_agent_output = mock_agent_setup
+    mock_agent_output.output_structured = AgentResponse(
+        explanation=Explanation(text="Mock explanation"),
+        solution=Solution(text="Mock solution"),
+    )
+
+    mock_run_chain = MagicMock()
+    mock_run_chain.middleware = AsyncMock(return_value=mock_agent_output)
+
+    with patch("logdetective.server.agent.agent.RequirementAgent") as MockAgent:
+        MockAgent.return_value.run.return_value = mock_run_chain
+
+        with patch.object(SERVER_CONFIG.general, "generate_solution", True):
+            response = await analyze_artifacts(mock_artifacts, mock_chat_model)
+            assert response.solution is not None
+            assert response.solution.text == "Mock solution"


### PR DESCRIPTION
Solution is an experimental feature and it might not be desirable to have it present in the response, so we want a fast way of disabling its presence in the response.
The dependant services are:
- packit-dashboard (which are also linked log detective jobs from koji CI),
- and possibly logdetective website (although the website does not access solution or show it).

This behavior is affected by the `generate_solution` flag inside the general config in `config.yml`.
- default behavior is "true", i.e. show solution (string),
- overriding with "false" means the field is None.

It should be sufficient to just change the flag and restart the server container.
Tested on a local compose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `generate_solution` configuration option to control whether solution content is included in API responses.
  * Solutions are included by default, and are suppressed when the option is disabled.
* **Documentation**
  * Updated configuration guidance describing the new `generate_solution` setting (default: enabled).
* **Tests**
  * Added tests confirming the response omits the solution when disabled and includes it when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->