### PR TITLE
Set version to 4.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "logdetective"
-version = "4.8.0"
+version = "4.9.0"
 description = "Analyze logs with a template miner and an LLM to discover errors and suggest solutions."
 authors = [
     { name="Jiri Podivin", email="jpodivin@gmail.com" }


### PR DESCRIPTION
Since we expanded packit dashboard display, and we would like to be able to turn on/off the solution exposure, we'll need to make a release.

I'd say the following changes warrant a `minor` bump.
- caching (although currently off),
- backoff retry for inference
- generate_solution flag and 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version 4.9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->