### PR TITLE
Lazy artifact download

### DIFF
--- a/logdetective/logdetective.py
+++ b/logdetective/logdetective.py
@@ -23,6 +23,7 @@ from logdetective.utils import (
     check_csgrep,
     mine_logs,
     mib_to_bytes,
+    sanitize_artifact,
 )
 from logdetective.remote_log import retrieve_log_content
 from logdetective.extractors import DrainExtractor, CSGrepExtractor
@@ -168,7 +169,7 @@ async def run():  # pylint: disable=too-many-statements,too-many-locals,too-many
             # file does not exist
             LOG.error(e)
             sys.exit(4)
-    log_summary = mine_logs(log=log, extractors=extractors)
+    log_summary = mine_logs(log=sanitize_artifact(log), extractors=extractors)
     LOG.info("Analyzing the text")
 
     log_summary = format_snippets(log_summary)

--- a/logdetective/logdetective.py
+++ b/logdetective/logdetective.py
@@ -22,7 +22,6 @@ from logdetective.utils import (
     load_skip_snippet_patterns,
     check_csgrep,
     mine_logs,
-    sanitize_artifact,
     mib_to_bytes,
 )
 from logdetective.remote_log import retrieve_log_content
@@ -169,7 +168,6 @@ async def run():  # pylint: disable=too-many-statements,too-many-locals,too-many
             # file does not exist
             LOG.error(e)
             sys.exit(4)
-    log = sanitize_artifact(log)
     log_summary = mine_logs(log=log, extractors=extractors)
     LOG.info("Analyzing the text")
 

--- a/logdetective/remote_log.py
+++ b/logdetective/remote_log.py
@@ -15,6 +15,7 @@ from logdetective.utils import (
     ContentSizeCheck,
     check_content_size,
     mib_to_bytes,
+    sanitize_artifact,
 )
 
 LOG = logging.getLogger("logdetective")
@@ -95,7 +96,8 @@ class RemoteLog:
             )
         try:
             async with self._http_session.get(self.url, raise_for_status=True) as response:
-                return await self._read_with_size_limit(response)
+                artifact = await self._read_with_size_limit(response)
+                return sanitize_artifact(artifact)
         except (aiohttp.ClientResponseError, aiohttp.ClientConnectorError) as ex:
             raise RemoteLogAccessError(f"We couldn't obtain the log from {self.url}") from ex
 

--- a/logdetective/server/agent/agent.py
+++ b/logdetective/server/agent/agent.py
@@ -17,6 +17,7 @@ from litellm.exceptions import (
 )
 from pydantic import ValidationError
 
+from logdetective.remote_log import RemoteLog
 from logdetective.server.config import PROMPT_CONFIG, SERVER_CONFIG, SKIP_SNIPPETS_CONFIG
 from logdetective.server.agent.tools import (
     ExtractorTool,
@@ -44,7 +45,7 @@ from logdetective.server.utils import inference_retry_backoff, inference_retry_g
     on_giveup=inference_retry_giveup,
 )
 async def analyze_artifacts(
-    artifacts: dict[str, str],
+    artifacts: dict[str, str | RemoteLog],
     chat_model: ChatModel,
     build_metadata: Optional[BuildMetadata] = None
 ) -> APIResponse:

--- a/logdetective/server/agent/tools.py
+++ b/logdetective/server/agent/tools.py
@@ -9,6 +9,7 @@ from beeai_framework.tools.types import ToolOutput, ToolRunOptions
 from pydantic import BaseModel, Field
 import yaml
 
+from logdetective.exceptions import RemoteLogError
 from logdetective.extractors import (
     Extractor,
     DrainExtractor,
@@ -16,6 +17,7 @@ from logdetective.extractors import (
     PythonTracebackExtractor,
 )
 from logdetective.models import SkipSnippets
+from logdetective.remote_log import RemoteLog
 from logdetective.server.models import ExtractorConfig, Snippet, AnalyzedSnippet
 
 ARTIFACT_NAME_DESC = "The exact name of the artifact you want to extract information from."
@@ -65,14 +67,14 @@ class ExtractorTool(Tool[ExtractorToolInput]):
     )
     description_template: str
     extractor: Extractor
-    all_artifacts: dict[str, str]
+    all_artifacts: dict[str, str | RemoteLog]
 
     extracted_snippets: list[Snippet]
     _remaining_artifacts: set[str]
 
     def __init__(
         self,
-        all_artifacts: dict[str, str],
+        all_artifacts: dict[str, str | RemoteLog],
         schema: type[ExtractorToolInput] = ExtractorToolInput,
         options: dict[str, Any] | None = None,
     ) -> None:
@@ -100,9 +102,18 @@ class ExtractorTool(Tool[ExtractorToolInput]):
                 f"Requested artifact: {input.artifact_name} was already analyzed."
                 f"Only following artifacts are available: {self._remaining_artifacts}"
             )
-        self._remaining_artifacts.remove(input.artifact_name)
 
         artifact = self.all_artifacts[input.artifact_name]
+
+        # If the artifact isn't already in memory pull it
+        if isinstance(artifact, RemoteLog):
+            try:
+                artifact = await artifact.get_url_content()
+            except RemoteLogError as ex:
+                raise ToolError(f"Download of {input.artifact_name} failed.") from ex
+
+        self._remaining_artifacts.remove(input.artifact_name)
+
         raw_snippets = self.extractor(artifact)
         current_snippets = []
         for line_number, text in raw_snippets:
@@ -147,7 +158,7 @@ class DrainExtractorTool(ExtractorTool):
     def __init__(
         self,
         extractor_config: ExtractorConfig,
-        available_artifacts: dict[str, str],
+        available_artifacts: dict[str, str | RemoteLog],
         skip_snippets: Optional[SkipSnippets] = None,
         options: dict[str, Any] | None = None,
     ) -> None:
@@ -184,7 +195,7 @@ class CSGrepExtractorTool(ExtractorTool):
     def __init__(
         self,
         extractor_config: ExtractorConfig,
-        available_artifacts: dict[str, str],
+        available_artifacts: dict[str, str | RemoteLog],
         skip_snippets: Optional[SkipSnippets] = None,
         options: dict[str, Any] | None = None,
     ) -> None:
@@ -221,7 +232,7 @@ class PythonTracebackExtractorTool(ExtractorTool):
     def __init__(
         self,
         extractor_config: ExtractorConfig,
-        available_artifacts: dict[str, str],
+        available_artifacts: dict[str, str | RemoteLog],
         skip_snippets: Optional[SkipSnippets] = None,
         options: dict[str, Any] | None = None,
     ) -> None:

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -365,6 +365,7 @@ class GeneralConfig(BaseModel):
     max_artifact_size: int = mib_to_bytes(DEFAULT_MAXIMUM_ARTIFACT_MIB)
     block_localhost_urls: bool = True
     generate_solution: bool = True
+    delay_artifact_download: bool = False
 
     @field_validator("max_artifact_size", mode="before")
     @classmethod

--- a/logdetective/server/utils.py
+++ b/logdetective/server/utils.py
@@ -16,7 +16,6 @@ from logdetective.server.exceptions import LogDetectiveConnectionError
 from logdetective.remote_log import RemoteLog
 from logdetective.exceptions import RemoteLogError
 from logdetective.server.models import AnalysisRequest, ArtifactFile, RemoteArtifactFile
-from logdetective.utils import sanitize_artifact
 
 
 def connection_error_giveup(details: dict) -> None:
@@ -50,17 +49,15 @@ async def get_artifacts_from_payload(
     payload: AnalysisRequest,
     http_session: aiohttp.ClientSession,
     request_size: int,
-) -> dict[str, str]:
+) -> dict[str, str | RemoteLog]:
     """Retrieve artifact contents based on the type of artifact.
-    Sanitize all artifacts.
     Raise ValueError on unsupported element types."""
-    build_artifacts: dict[str, str] = {}
+    build_artifacts: dict[str, str | RemoteLog] = {}
 
     total_payload_size: int = request_size
 
     for artifact in payload.files:
         if isinstance(artifact, RemoteArtifactFile):
-            LOG.info("Downloading artifact %s from %s", artifact.name, artifact.url)
             remaining_limit = (
                 SERVER_CONFIG.general.max_artifact_size - total_payload_size
             )
@@ -71,12 +68,26 @@ async def get_artifacts_from_payload(
             remote_log = RemoteLog(
                 str(artifact.url), http_session, limit_bytes=remaining_limit
             )
-            try:
-                log_text = await remote_log.get_url_content()
-            except RemoteLogError as ex:
-                raise HTTPException(status_code=ex.status_code, detail=f"{ex}") from ex
-            build_artifacts[artifact.name] = sanitize_artifact(log_text)
-            total_payload_size += remote_log.remote_log_size
+            if SERVER_CONFIG.general.delay_artifact_download:
+                LOG.info(
+                    "Delaying download of artifact %s from %s until requested",
+                    artifact.name,
+                    artifact.url
+                )
+                # Size is enforced per-file via limit_bytes when
+                # get_url_content() runs; total across deferred
+                # artifacts is accepted optimistically.
+                build_artifacts[artifact.name] = remote_log
+            else:
+                LOG.info("Downloading artifact %s from %s", artifact.name, artifact.url)
+                try:
+                    log_text = await remote_log.get_url_content()
+                except RemoteLogError as ex:
+                    raise HTTPException(
+                        status_code=ex.status_code, detail=f"{ex}"
+                    ) from ex
+                build_artifacts[artifact.name] = log_text
+                total_payload_size += remote_log.remote_log_size
 
         elif isinstance(artifact, ArtifactFile):
             LOG.info("Handling artifact %s as raw string", artifact.name)
@@ -84,7 +95,11 @@ async def get_artifacts_from_payload(
         else:
             raise ValueError(f"Invalid element type {type(artifact)}")
 
-    total_payload_len = sum(len(content) for _, content in build_artifacts.items())
+    total_payload_len = sum(
+        len(content)
+        for _, content in build_artifacts.items()
+        if isinstance(content, str)
+    )
     LOG.info(
         "Total artifact size from the obtained payload (in chars): %d "
         "Total payload size (in bytes): %d",

--- a/logdetective/server/utils.py
+++ b/logdetective/server/utils.py
@@ -10,6 +10,7 @@ from fastapi import Request, HTTPException
 from logdetective.utils import (
     ContentSizeCheck,
     check_content_size,
+    sanitize_artifact,
 )
 from logdetective.server.config import LOG, SERVER_CONFIG
 from logdetective.server.exceptions import LogDetectiveConnectionError
@@ -91,7 +92,7 @@ async def get_artifacts_from_payload(
 
         elif isinstance(artifact, ArtifactFile):
             LOG.info("Handling artifact %s as raw string", artifact.name)
-            build_artifacts[artifact.name] = artifact.content
+            build_artifacts[artifact.name] = sanitize_artifact(artifact.content)
         else:
             raise ValueError(f"Invalid element type {type(artifact)}")
 

--- a/server/config.yml
+++ b/server/config.yml
@@ -88,3 +88,5 @@ general:
   # If true, the API response will contain a solution,
   # if the agent is sure about the build failure root cause. (default=True)
   # generate_solution: true
+  # Enable lazy fetching of build artifacts
+  # delay_artifact_download: true

--- a/tests/server/agent/test_tools.py
+++ b/tests/server/agent/test_tools.py
@@ -1,11 +1,20 @@
+from enum import Enum
 from unittest.mock import AsyncMock, patch, MagicMock
 import pytest
 
 from beeai_framework.context import RunContext, RunInstance
 from beeai_framework.emitter import Emitter
+from beeai_framework.tools.errors import ToolError
+from logdetective.exceptions import (
+    RemoteLogAccessError,
+    RemoteLogRequestError,
+    RemoteLogTooLargeError,
+)
+from logdetective.remote_log import RemoteLog
 from logdetective.server.agent.tools import (
     DrainExtractorTool,
     ExtractorTool,
+    ExtractorToolInput,
     SnippetAnalysisTool,
     SnippetAnalysisToolInput,
     SnippetAnalysisToolOutput,
@@ -237,3 +246,128 @@ def test_snippet_analysis_output_is_empty():
         snippet=snippet_with_text, snippet_analysis="analysis"
     )
     assert not output_full.is_empty()
+
+
+@pytest.mark.asyncio
+async def test_extractor_tool_downloads_remote_log():
+    """When an artifact is a RemoteLog, _run fetches its content before extraction."""
+    source_file = "remote.log"
+    log_content = "ERROR: something went wrong\nTraceback follows"
+
+    mock_remote_log = AsyncMock(spec=RemoteLog)
+    mock_remote_log.get_url_content.return_value = log_content
+
+    tool = DrainExtractorTool(
+        ExtractorConfig(),
+        available_artifacts={source_file: mock_remote_log},
+    )
+
+    ArtifactName = Enum("ArtifactName", {source_file: source_file}, type=str)
+    input_data = ExtractorToolInput(artifact_name=ArtifactName(source_file))
+
+    result = await tool._run(
+        input=input_data,
+        context=RunContext(instance=MockRunInstance(), signal=None),
+        options=None,
+    )
+
+    mock_remote_log.get_url_content.assert_awaited_once()
+    assert result.source_artifact == source_file
+    assert source_file not in result.remaining_artifacts
+
+
+@pytest.mark.asyncio
+async def test_extractor_tool_uses_string_artifact_directly():
+    """When an artifact is a plain string, _run uses it without calling get_url_content."""
+    source_file = "local.log"
+    log_content = "INFO: build completed successfully"
+
+    tool = DrainExtractorTool(
+        ExtractorConfig(),
+        available_artifacts={source_file: log_content},
+    )
+
+    ArtifactName = Enum("ArtifactName", {source_file: source_file}, type=str)
+    input_data = ExtractorToolInput(artifact_name=ArtifactName(source_file))
+
+    result = await tool._run(
+        input=input_data,
+        context=RunContext(instance=MockRunInstance(), signal=None),
+        options=None,
+    )
+
+    assert result.source_artifact == source_file
+    assert source_file not in result.remaining_artifacts
+
+
+@pytest.mark.asyncio
+async def test_extractor_tool_mixed_artifacts():
+    """Tool handles a mix of string and RemoteLog artifacts across calls."""
+    string_file = "local.log"
+    remote_file = "remote.log"
+    string_content = "local log content"
+    remote_content = "remote log content"
+
+    mock_remote_log = AsyncMock(spec=RemoteLog)
+    mock_remote_log.get_url_content.return_value = remote_content
+
+    tool = DrainExtractorTool(
+        ExtractorConfig(),
+        available_artifacts={
+            string_file: string_content,
+            remote_file: mock_remote_log,
+        },
+    )
+
+    ArtifactName = Enum(
+        "ArtifactName",
+        {string_file: string_file, remote_file: remote_file},
+        type=str,
+    )
+
+    result_local = await tool._run(
+        input=ExtractorToolInput(artifact_name=ArtifactName(string_file)),
+        context=RunContext(instance=MockRunInstance(), signal=None),
+        options=None,
+    )
+    assert result_local.source_artifact == string_file
+    mock_remote_log.get_url_content.assert_not_awaited()
+
+    result_remote = await tool._run(
+        input=ExtractorToolInput(artifact_name=ArtifactName(remote_file)),
+        context=RunContext(instance=MockRunInstance(), signal=None),
+        options=None,
+    )
+    assert result_remote.source_artifact == remote_file
+    mock_remote_log.get_url_content.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("remote_error", [
+    RemoteLogAccessError("connection refused"),
+    RemoteLogRequestError("invalid URL"),
+    RemoteLogTooLargeError("exceeds limit"),
+])
+async def test_extractor_tool_remote_log_failure_raises_tool_error(remote_error):
+    """RemoteLogError from get_url_content is wrapped in ToolError."""
+    source_file = "failing.log"
+
+    mock_remote_log = AsyncMock(spec=RemoteLog)
+    mock_remote_log.get_url_content.side_effect = remote_error
+
+    tool = DrainExtractorTool(
+        ExtractorConfig(),
+        available_artifacts={source_file: mock_remote_log},
+    )
+
+    ArtifactName = Enum("ArtifactName", {source_file: source_file}, type=str)
+    input_data = ExtractorToolInput(artifact_name=ArtifactName(source_file))
+
+    with pytest.raises(ToolError, match=source_file) as exc_info:
+        await tool._run(
+            input=input_data,
+            context=RunContext(instance=MockRunInstance(), signal=None),
+            options=None,
+        )
+
+    assert exc_info.value.__cause__ is remote_error

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -147,35 +147,139 @@ async def test_get_log_from_payload_files_sanitization(
         assert any(i in sanitized for i in ["FFFF", "ffff", "copr-team"])
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "dirty_log, redacted_value",
+    [
+        ("RSA key 00112233AABBCCDD", "00112233AABBCCDD"),
+        ("pubkey-deadbeef-cafe0123", "deadbeef-cafe0123"),
+        ("Commited 2020 example@mail.com", "example@mail.com"),
+    ],
+)
+async def test_remote_log_get_url_content_sanitizes(dirty_log, redacted_value):
+    """RemoteLog.get_url_content returns sanitized content."""
+    url = "http://example.com/build.log"
+    mock_header = {"Content-Length": str(len(dirty_log))}
+    with aioresponses.aioresponses() as mock:
+        mock.head(url, status=200, headers=mock_header)
+        mock.get(url, status=200, body=dirty_log)
+        async with aiohttp.ClientSession() as http:
+            remote_log = RemoteLog(url, http)
+            result = await remote_log.get_url_content()
+
+    assert redacted_value not in result
+    assert result != dirty_log
+
+
 @pytest.mark.parametrize("request_size", [0, 10, 2000])
 @pytest.mark.asyncio
-async def test_get_log_from_payload_url_sanitization(request_size):
-    dirty_log = "This email should be sanitized: contact@someone.com"
+async def test_get_artifacts_delayed_download_stores_remote_log(
+    request_size, monkeypatch
+):
+    """When delay_artifact_download is True, remote artifacts are stored
+    as RemoteLog objects instead of downloaded strings."""
+    monkeypatch.setattr(SERVER_CONFIG.general, "delay_artifact_download", True)
+
     payload = AnalysisRequest(
         files=[
             RemoteArtifactFile(
-                name="mock_log.log", url=HttpUrl("http://path.to/file.log")
+                name="deferred.log", url=HttpUrl("http://path.to/deferred.log")
             )
         ]
     )
-    awaited_dirty_log = asyncio.Future()
-    awaited_dirty_log.set_result(dirty_log)
-    mock_remote_log = flexmock(RemoteLog)
 
     async with aiohttp.ClientSession() as session:
-        mock_remote_log.should_receive("__init__").with_args(
-            "http://path.to/file.log",
-            session,
-            limit_bytes=SERVER_CONFIG.general.max_artifact_size - request_size,
-        )
-        mock_remote_log.should_receive("get_url_content").and_return(awaited_dirty_log)
         artifacts = await get_artifacts_from_payload(
             payload, session, request_size=request_size
         )
 
     assert len(artifacts) == 1
-    assert "mock_log.log" in artifacts
+    assert "deferred.log" in artifacts
+    assert isinstance(artifacts["deferred.log"], RemoteLog)
 
-    assert artifacts["mock_log.log"] != dirty_log
-    assert "contact@someone.com" not in artifacts["mock_log.log"]
-    assert "copr-team@redhat.com" in artifacts["mock_log.log"]
+
+@pytest.mark.asyncio
+async def test_get_artifacts_delayed_download_mixed_types(monkeypatch):
+    """When delay_artifact_download is True, remote artifacts become RemoteLog
+    objects while inline ArtifactFile entries remain plain strings."""
+    monkeypatch.setattr(SERVER_CONFIG.general, "delay_artifact_download", True)
+
+    payload = AnalysisRequest(
+        files=[
+            RemoteArtifactFile(
+                name="remote.log", url=HttpUrl("http://path.to/remote.log")
+            ),
+            ArtifactFile(name="local.log", content=MOCK_LOG),
+        ]
+    )
+
+    async with aiohttp.ClientSession() as session:
+        artifacts = await get_artifacts_from_payload(
+            payload, session, request_size=0
+        )
+
+    assert isinstance(artifacts["remote.log"], RemoteLog)
+    assert isinstance(artifacts["local.log"], str)
+    assert artifacts["local.log"] == MOCK_LOG
+
+
+@pytest.mark.asyncio
+async def test_get_artifacts_delayed_download_no_http_call(monkeypatch):
+    """When delay_artifact_download is True, no HTTP requests are made
+    for remote artifacts during get_artifacts_from_payload."""
+    monkeypatch.setattr(SERVER_CONFIG.general, "delay_artifact_download", True)
+
+    payload = AnalysisRequest(
+        files=[
+            RemoteArtifactFile(
+                name="no_fetch.log", url=HttpUrl("http://path.to/no_fetch.log")
+            )
+        ]
+    )
+
+    async with aiohttp.ClientSession() as session:
+        mock_remote_log = flexmock(RemoteLog)
+        mock_remote_log.should_receive("get_url_content").never()
+
+        artifacts = await get_artifacts_from_payload(
+            payload, session, request_size=0
+        )
+
+    assert isinstance(artifacts["no_fetch.log"], RemoteLog)
+
+
+@pytest.mark.parametrize("request_size", [0, 10, 2000])
+@pytest.mark.asyncio
+async def test_get_artifacts_immediate_download_returns_string(
+    request_size, monkeypatch
+):
+    """When delay_artifact_download is False, remote artifacts are downloaded
+    immediately and stored as strings."""
+    monkeypatch.setattr(SERVER_CONFIG.general, "delay_artifact_download", False)
+
+    payload = AnalysisRequest(
+        files=[
+            RemoteArtifactFile(
+                name="immediate.log", url=HttpUrl("http://path.to/immediate.log")
+            )
+        ]
+    )
+
+    awaited_log = asyncio.Future()
+    awaited_log.set_result("downloaded content")
+    mock_remote_log = flexmock(RemoteLog)
+
+    async with aiohttp.ClientSession() as session:
+        mock_remote_log.should_receive("__init__").with_args(
+            "http://path.to/immediate.log",
+            session,
+            limit_bytes=SERVER_CONFIG.general.max_artifact_size - request_size,
+        )
+        mock_remote_log.should_receive("get_url_content").and_return(
+            awaited_log
+        ).once()
+        artifacts = await get_artifacts_from_payload(
+            payload, session, request_size=request_size
+        )
+
+    assert isinstance(artifacts["immediate.log"], str)

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -137,11 +137,9 @@ async def test_get_log_from_payload_files_sanitization(
 
     assert len(artifacts) == 1
     assert "test.log" in artifacts
-    assert artifacts[payload.files[0].name] == dirty_log
 
-    for text in artifacts.values():
-        sanitized = sanitize_artifact(text)
-
+    for sanitized in artifacts.values():
+        assert isinstance(sanitized, str)
         assert sanitized != dirty_log
         assert redacted_value not in sanitized
         assert any(i in sanitized for i in ["FFFF", "ffff", "copr-team"])


### PR DESCRIPTION
When the configuration option `delay_artifact_download` is set to `true` the artifacts will be downloaded only when requested. This will limit use of memory, as only one artifact will be loaded at any given time.

This will come at cost of latency in tool call response. However, artifacts are at most a few MB in size, so it shouldn't be an issue on any except the worst possible connections. And in those cases, the inference connection will be a much bigger problem.

The size check behavior changes somewhat. With eager fetch, the totals and partial sizes are still counted as before. With lazy, or delayed, fetch, only size of a single artifact is considered, as only a single artifact is loaded at any given time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional delayed downloading for remote log artifacts.
  * Remote and inline artifacts can now be processed together.
  * Remote content is sanitized when retrieved.
  * Added clearer handling and reporting of remote artifact download failures.

* **Configuration**
  * Added the `delay_artifact_download` setting, disabled by default.

* **Tests**
  * Added coverage for delayed downloads, mixed artifact types, sanitization, and download errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->