### PR TITLE
Render infra_status in agent start prompt

### DIFF
--- a/logdetective/prompts.py
+++ b/logdetective/prompts.py
@@ -7,6 +7,7 @@ from logdetective.models import PromptConfig
 
 class PromptManager:  # pylint: disable=too-many-instance-attributes
     """Manages prompts defined as jinja templates"""
+
     _tmp_env: Environment
 
     # Templates for system prompts
@@ -42,10 +43,16 @@ class PromptManager:  # pylint: disable=too-many-instance-attributes
         """Render message prompt from the template"""
         return self.default_message_template.render(snippets=snippets)
 
-    def agent_start_prompt(self, artifacts: list[str], commentary: Optional[str] = None) -> str:
+    def agent_start_prompt(
+        self,
+        artifacts: list[str],
+        commentary: Optional[str] = None,
+        infra_status: Optional[str] = None,
+    ) -> str:
         """Render agent start prompt"""
 
         return self._default_agent_start_prompt_template.render(
             artifacts=artifacts,
             commentary=commentary,
+            infra_status=infra_status,
         )

--- a/logdetective/prompts/agent_start_prompt.j2
+++ b/logdetective/prompts/agent_start_prompt.j2
@@ -14,3 +14,9 @@ such as environment.
 
 {{ commentary }}
 {% endif %}
+
+{% if infra_status %}
+Infrastructure status:
+
+{{ infra_status }}
+{% endif %}

--- a/logdetective/server/agent/agent.py
+++ b/logdetective/server/agent/agent.py
@@ -152,7 +152,11 @@ async def analyze_artifacts(
 
     # Names of build artifacts are inserted into the template.
     if build_metadata:
-        agent_input = PROMPT_CONFIG.agent_start_prompt(artifacts=list(artifacts.keys()), commentary=build_metadata.commentary)
+        agent_input = PROMPT_CONFIG.agent_start_prompt(
+            artifacts=list(artifacts.keys()),
+            commentary=build_metadata.commentary,
+            infra_status=build_metadata.infra_status
+        )
     else:
         agent_input = PROMPT_CONFIG.agent_start_prompt(artifacts=list(artifacts.keys()))
 

--- a/tests/base/test_prompts.py
+++ b/tests/base/test_prompts.py
@@ -63,3 +63,68 @@ def test_prompt_manager_agent_start_prompt_render_artifacts():
 
     for artifact in artifacts:
         assert artifact in agent_start_prompt
+
+
+def test_prompt_manager_agent_start_prompt_render_commentary():
+    """Test that prompt renders commentary if supplied"""
+
+    commentary = "COMMENT ABOUT BUILD"
+    artifacts = [
+        "build.log",
+    ]
+    prompt_manager = PromptManager(
+        os.path.join(os.path.dirname(logdetective.__file__), "prompts")
+    )
+
+    agent_start_prompt = prompt_manager.agent_start_prompt(
+        artifacts=artifacts, commentary=commentary
+    )
+
+    for artifact in artifacts:
+        assert artifact in agent_start_prompt
+
+    assert commentary in agent_start_prompt
+
+
+def test_prompt_manager_agent_start_prompt_render_infra_status():
+    """Test that prompt renders infra_status if supplied"""
+
+    infra_status = "INFRASTRUCTURE STATUS"
+    artifacts = [
+        "build.log",
+    ]
+    prompt_manager = PromptManager(
+        os.path.join(os.path.dirname(logdetective.__file__), "prompts")
+    )
+
+    agent_start_prompt = prompt_manager.agent_start_prompt(
+        artifacts=artifacts, infra_status=infra_status
+    )
+
+    for artifact in artifacts:
+        assert artifact in agent_start_prompt
+
+    assert infra_status in agent_start_prompt
+
+
+def test_prompt_manager_agent_start_prompt_render_supplementary():
+    """Test that prompt renders supplementary information if supplied"""
+
+    infra_status = "INFRASTRUCTURE STATUS"
+    commentary = "COMMENT ABOUT BUILD"
+    artifacts = [
+        "build.log",
+    ]
+    prompt_manager = PromptManager(
+        os.path.join(os.path.dirname(logdetective.__file__), "prompts")
+    )
+
+    agent_start_prompt = prompt_manager.agent_start_prompt(
+        artifacts=artifacts, infra_status=infra_status, commentary=commentary
+    )
+
+    for artifact in artifacts:
+        assert artifact in agent_start_prompt
+
+    assert infra_status in agent_start_prompt
+    assert commentary in agent_start_prompt


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added infrastructure status details to generated analysis prompts when available.
  * Prompts can now include infrastructure status alongside commentary and artifact information.

* **Tests**
  * Added coverage confirming prompts correctly include commentary, infrastructure status, and artifact details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->