### PR TITLE
Truncate, rather than split, snippets.

### DIFF
--- a/logdetective/constants.py
+++ b/logdetective/constants.py
@@ -29,3 +29,9 @@ PROMPT_PATH = os.environ.get(
 
 # Vector size of BAAI/bge-small-en-v1.5
 EMBEDDING_VECTOR_SIZE = 384
+
+# Marker for snippet truncation
+TRUNCATED = "<truncated>"
+
+# Minimum length of a snippet
+MINIMUM_SNIPPET_TRUNCATION_LEN = 100

--- a/logdetective/extractors.py
+++ b/logdetective/extractors.py
@@ -7,6 +7,7 @@ from drain3.template_miner import TemplateMiner
 from drain3.template_miner_config import TemplateMinerConfig
 from pydantic import ValidationError
 
+from logdetective.constants import TRUNCATED
 from logdetective.utils import get_chunks, filter_snippet_patterns
 from logdetective.models import SkipSnippets, CSGrepOutput
 
@@ -186,7 +187,7 @@ class PythonTracebackExtractor(Extractor):
         "During handling of the above exception, another exception occurred:",
         "The above exception was the direct cause of the following exception:",
     )
-    _TRUNCATE_STR = "\n...<truncated>...\n"
+    _TRUNCATE_STR = f"\n...{TRUNCATED}...\n"
 
     def __call__(self, log: str) -> list[Tuple[int, str]]:
         lines = log.splitlines()

--- a/logdetective/server/agent/tools.py
+++ b/logdetective/server/agent/tools.py
@@ -152,6 +152,7 @@ class DrainExtractorTool(ExtractorTool):
         "Use this tool at most once per artifact."
         "Extracts up to {max_clusters} snippets from a log file, using clustering Drain algorithm."
         "Maximum length of extracted snippet is {max_snippet_len}."
+        "Truncated snippets are marked with the `<truncated>` tag."
     )
     extractor: DrainExtractor
 
@@ -188,6 +189,7 @@ class CSGrepExtractorTool(ExtractorTool):
         "Extracts up to {max_clusters} snippets from a log file containing GCC traces, using csgrep tool."
         "Do not use on artifacts that don't contain traces from compiler."
         "Maximum length of extracted snippet is {max_snippet_len}."
+        "Truncated snippets are marked with the `<truncated>` tag."
     )
 
     extractor: CSGrepExtractor
@@ -226,6 +228,7 @@ class PythonTracebackExtractorTool(ExtractorTool):
         "Use on artifacts that contain Python output or test results. "
         "Do not use on artifacts that don't contain Python tracebacks. "
         "Maximum length of extracted snippet is {max_snippet_len}."
+        "Truncated snippets are marked with the `<truncated>` tag."
     )
     extractor: PythonTracebackExtractor
 

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -15,6 +15,7 @@ from logdetective.constants import (
     DEFAULT_TEMPERATURE,
     SYSTEM_ROLE_DEFAULT,
     DEFAULT_MAXIMUM_ARTIFACT_MIB,
+    MINIMUM_SNIPPET_TRUNCATION_LEN,
 )
 from logdetective.utils import check_csgrep, mib_to_bytes
 
@@ -240,7 +241,11 @@ class ExtractorConfig(BaseModel):
 
     max_clusters: int = 8
     verbose: bool = False
-    max_snippet_len: int = 2000
+    max_snippet_len: int = Field(
+        description="Maximum length of extracted snippets",
+        ge=MINIMUM_SNIPPET_TRUNCATION_LEN,
+        default=2000
+    )
     csgrep: bool = False
     csgrep_timeout: float = 1.0
     python_traceback: bool = False

--- a/logdetective/utils.py
+++ b/logdetective/utils.py
@@ -21,7 +21,7 @@ from llama_cpp import (
     CreateChatCompletionResponse,
     CreateChatCompletionStreamResponse,
 )
-from logdetective.constants import SNIPPET_DELIMITER
+from logdetective.constants import SNIPPET_DELIMITER, TRUNCATED, MINIMUM_SNIPPET_TRUNCATION_LEN
 from logdetective.models import PromptConfig, SkipSnippets
 from logdetective.prompts import PromptManager
 
@@ -92,6 +92,8 @@ def get_chunks(
     """Split log into chunks according to heuristic
     based on whitespace and backslash presence.
     """
+    if max_chunk_len < MINIMUM_SNIPPET_TRUNCATION_LEN:
+        raise ValueError(f"Snippets must be at least {MINIMUM_SNIPPET_TRUNCATION_LEN} chars long")
     lines = text.splitlines()
 
     # Chunk we will be yielding
@@ -108,18 +110,20 @@ def get_chunks(
             original_line = i
             chunk = line
         else:
-            chunk += "\n" + line
+            # If the chunk was truncated, we'll start building a new one
+            if not chunk:
+                original_line = i
+                chunk = line
+            else:
+                chunk += "\n" + line
         if len(chunk) > max_chunk_len:
-            # If the chunk is too long, keep splitting into smaller chunks
-            # until we reach manageable size
-            while len(chunk) > max_chunk_len:
-                remainder = chunk[max_chunk_len:]
-                chunk = chunk[:max_chunk_len]
-                yield (original_line, chunk)
-                chunk = remainder
-
+            # If the chunk is too long, truncate and add <truncated> tag
+            chunk = chunk[:max(max_chunk_len - len(TRUNCATED), 0)] + TRUNCATED
+            yield (original_line, chunk)
+            chunk = ""
     # if we still have some text left over
-    yield (original_line, chunk)
+    if chunk:
+        yield (original_line, chunk)
 
 
 def initialize_model(

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -15,7 +15,7 @@ from logdetective.utils import (
     get_chunks,
     mib_to_bytes,
 )
-from logdetective.constants import DEFAULT_MAXIMUM_ARTIFACT_MIB, PROMPT_PATH
+from logdetective.constants import DEFAULT_MAXIMUM_ARTIFACT_MIB, PROMPT_PATH, TRUNCATED
 from logdetective.remote_log import RemoteLog
 from logdetective.exceptions import (
     RemoteLogAccessError,
@@ -274,18 +274,58 @@ def test_load_skip_snippet_patterns_invalid_syntax():
             load_skip_snippet_patterns("/there/is/nothing/to/read.yml")
 
 
-@pytest.mark.parametrize("max_chunk_len", [10, 20, 100])
+@pytest.mark.parametrize("max_chunk_len", [100, 120, 150])
 def test_get_chunks_max_length(simple_log, max_chunk_len):
-    """Test that maximum length of chunks is properly enforced
-    and that no text is lost"""
+    """Test that maximum length of chunks is properly enforced"""
     log = "".join(simple_log)
     chunks = list(get_chunks(log, max_chunk_len=max_chunk_len))
-    reconstructed_text = ""
+
+    # Number of chunks must be <= number of original lines
+    assert len(chunks) <= len(simple_log)
+
+    # All chunks must obey contraints and exist in the original text
     for c in chunks:
         assert len(c[1]) <= max_chunk_len
-        assert c[1] in log
-        reconstructed_text += c[1]
+        assert c[1][:-len(TRUNCATED)] in log
 
-    for _, line in enumerate(simple_log):
-        if len(line) > 0:
-            assert line.strip() in reconstructed_text
+    # All chunks must have unique lines
+    lines = set(c[0] for c in chunks)
+    assert len(lines) == len(chunks)
+
+    # Last chunk must not be empty
+    assert len(chunks[-1][1]) > 0
+
+
+@pytest.mark.parametrize("max_chunk_len", [20, 50, 70])
+def test_get_chunks_raises_on_too_short(simple_log, max_chunk_len):
+
+    log = "".join(simple_log)
+    with pytest.raises(ValueError):
+        list(get_chunks(log, max_chunk_len=max_chunk_len))
+
+
+def test_empty_log_creates_no_chunks():
+    log = ""
+    chunks = list(get_chunks(log))
+
+    assert len(chunks) == 0
+
+
+def test_leading_whitespace_chunks(simple_log):
+
+    log = " ".join(simple_log)
+
+    chunks = list(get_chunks(log))
+
+    # Number of chunks must be <= number of original lines
+    assert len(chunks) <= len(simple_log)
+
+    for chunk in chunks[1:]:
+        assert chunk[1].startswith(" ")
+
+    # All chunks must have unique lines
+    lines = set(c[0] for c in chunks)
+    assert len(lines) == len(chunks)
+
+    # Last chunk must not be empty
+    assert len(chunks[-1][1]) > 0


### PR DESCRIPTION
We used to split snippets that were over given length into multiple sub-snippets. But this posed certain issues when working with SnippetAnalysisTool. Multiple snippets technically occupied the same line and could be analyzed only once.
At the same time, the agent could get confused.

Instead, we are going to truncate, much like in the python traceback extractor. This does mean that in certain limit cases, when the length of the truncation marker is greater than the maximum snippet length, we would effectively replace snippets entirely with truncation. To prevent that, a constraint will be set on the parameter in the config model, and raise an exception if utility function is called with an unreasonable argument value.

I've also expanded the tests, so that we verify the chunk generator behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Long log snippets are now clearly marked with a `<truncated>` tag.
  * Extractor tool guidance now explains how truncated snippets are identified.
* **Improvements**
  * Snippet length settings now include clearer descriptions and enforce a minimum length.
  * Oversized snippets are truncated consistently instead of being split repeatedly.
* **Bug Fixes**
  * Invalid snippet length configurations now return a clear validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->