### PR TITLE
Fix failing pytest and linter github actions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           python-version: '3.13'
       - name: Install krb5-dev
-        run: sudo apt-get install -y libkrb5-dev
+        run: sudo apt-get update && sudo apt-get install -y libkrb5-dev
       - name: Install tox
         run: pip install tox
       - name: Run pytest for base package

--- a/.github/workflows/tox-lint.yml
+++ b/.github/workflows/tox-lint.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           python-version: '3.13'
       - name: Install krb5-dev
-        run: sudo apt-get install -y libkrb5-dev
+        run: sudo apt-get update && sudo apt-get install -y libkrb5-dev
       - name: Install tox
         run: pip install tox
       - name: Run linters

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,9 @@ commands =
 [testenv:ruff]
 description = run ruff
 deps =
-    ruff>=0.9.0
+    # ruff 0.16.0 enables a much larger set of rules by default (413, up from 59),
+    # which would require a substantial rewrite, so for now we'll keep using 0.15
+    ruff>=0.9.0,<0.16.0
 commands =
     ruff check {posargs:./logdetective ./alembic/versions ./scripts/bumpver.py}
     # Ignore F401 (unused imports) and F811 (redefined names) in test files because of fixtures


### PR DESCRIPTION
Since Friday 2026-07-28, I noticed `Run Linters` and `Run Pytest` actions were failing in the `Install krb5-dev` step:

```
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/k/krb5/libgssrpc4t64_1.20.1-6ubuntu2.6_amd64.deb  404  Not Found [IP: 20.106.104.242 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/k/krb5/libkadm5clnt-mit12_1.20.1-6ubuntu2.6_amd64.deb  404  Not Found [IP: 20.106.104.242 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/k/krb5/libkdb5-10t64_1.20.1-6ubuntu2.6_amd64.deb  404  Not Found [IP: 20.106.104.242 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/k/krb5/libkadm5srv-mit12_1.20.1-6ubuntu2.6_amd64.deb  404  Not Found [IP: 20.106.104.242 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/k/krb5/krb5-multidev_1.20.1-6ubuntu2.6_amd64.deb  404  Not Found [IP: 20.106.104.242 80]
Fetched 43.8 kB in 1s (40.3 kB/s)
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/k/krb5/libkrb5-dev_1.20.1-6ubuntu2.6_amd64.deb  404  Not Found [IP: 20.106.104.242 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```