### PR TITLE
Set general timeout on agent operations

### DIFF
--- a/logdetective/server/agent/agent.py
+++ b/logdetective/server/agent/agent.py
@@ -7,10 +7,13 @@ from beeai_framework.agents.requirement.requirements.conditional import (
 )
 from beeai_framework.backend.errors import ChatModelError
 from beeai_framework.cache import UnconstrainedCache
+from beeai_framework.errors import AbortError
 from beeai_framework.memory import UnconstrainedMemory
 from beeai_framework.tools.think import ThinkTool
 from beeai_framework.backend import ChatModel
 from beeai_framework.middleware.trajectory import GlobalTrajectoryMiddleware
+from beeai_framework.utils.cancellation import AbortSignal
+
 from litellm.exceptions import (
     Timeout as LiteLLMTimeout,
     RateLimitError as LiteLLMRateLimit
@@ -29,6 +32,7 @@ from logdetective.server.agent.tools import (
 from logdetective.server.models import APIResponse, BuildMetadata, AgentResponse
 from logdetective.server.exceptions import (
     LogDetectiveAgentResponseFailure,
+    LogDetectiveAgentTimeoutError,
     LogDetectiveInferenceTimeout,
     LogDetectiveInferenceError,
     LogDetectiveInferenceRateLimit,
@@ -165,7 +169,8 @@ async def analyze_artifacts(
             agent_input,
             max_retries_per_step=SERVER_CONFIG.inference.max_retries_per_step,
             total_max_retries=SERVER_CONFIG.inference.total_max_retries,
-            expected_output=AgentResponse
+            expected_output=AgentResponse,
+            signal=AbortSignal.timeout(SERVER_CONFIG.general.agent_timeout),
         ).middleware(middleware)
     except ChatModelError as exc:
         cause = exc.__cause__
@@ -174,6 +179,8 @@ async def analyze_artifacts(
         if isinstance(cause, LiteLLMRateLimit):
             raise LogDetectiveInferenceRateLimit(str(cause)) from exc
         raise LogDetectiveInferenceError(exc.message) from exc
+    except AbortError as exc:
+        raise LogDetectiveAgentTimeoutError(exc.message) from exc
 
     if not raw_output.output_structured:
         raise LogDetectiveAgentResponseFailure

--- a/logdetective/server/exceptions.py
+++ b/logdetective/server/exceptions.py
@@ -62,3 +62,8 @@ class LogDetectiveInferenceTimeout(LogDetectiveInferenceError):
 class LogDetectiveInferenceRateLimit(LogDetectiveInferenceError):
     """Inference service (temporarily) unavailable. Try again later."""
     http_status_code = 503
+
+
+class LogDetectiveAgentTimeoutError(LogDetectiveException):
+    """Agent didn't complete analysis on time"""
+    http_status_code = 504

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -371,6 +371,8 @@ class GeneralConfig(BaseModel):
     block_localhost_urls: bool = True
     generate_solution: bool = True
     delay_artifact_download: bool = False
+    # Timeout for execution of analysis in seconds
+    agent_timeout: int = 600
 
     @field_validator("max_artifact_size", mode="before")
     @classmethod

--- a/server/config.yml
+++ b/server/config.yml
@@ -90,3 +90,4 @@ general:
   # generate_solution: true
   # Enable lazy fetching of build artifacts
   # delay_artifact_download: true
+  agent_timeout: 600  # Timeout on agent execution


### PR DESCRIPTION
BeeAI framework supports timeouts on agent runs using signals. Specifically, the class `AbortSignal`[1] can be used to set a timeout, raising an `AbortError`.

[1] https://framework.beeai.dev/modules/middleware#runnable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable timeout for analysis execution, with a default limit of 10 minutes.
  * Analysis requests now stop automatically when the configured time limit is reached.

* **Bug Fixes**
  * Timeout failures now return a dedicated gateway-timeout error, providing clearer feedback when analysis cannot complete in time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->