### PR TITLE
Fix volume path in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,7 +66,7 @@ services:
       context: .
       dockerfile: ./Containerfile.database
     volumes:
-      - database_data:/var/lib/postgresql/data
+      - database_data:/var/lib/pgsql/data
     ports:
       - "${POSTGRESQL_PORT:-5432}:${POSTGRESQL_PORT:-5432}"
     env_file: ./env_file


### PR DESCRIPTION
Wrong path to the volume caused DB non-persistence after postgres container is killed.
To make it work locally, this required me to remove the old volume. We might need to do the same in prod (probably during next rollout).

See https://github.com/sclorg/postgresql-container/blob/master/src/Dockerfile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the PostgreSQL data storage path to improve compatibility with the configured database environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->