### PR TITLE
Annotation DB lookup tool for the agent

### DIFF
--- a/logdetective/server/agent/agent.py
+++ b/logdetective/server/agent/agent.py
@@ -21,14 +21,21 @@ from litellm.exceptions import (
 from pydantic import ValidationError
 
 from logdetective.remote_log import RemoteLog
-from logdetective.server.config import PROMPT_CONFIG, SERVER_CONFIG, SKIP_SNIPPETS_CONFIG
+from logdetective.server.config import (
+    PROMPT_CONFIG,
+    SERVER_CONFIG,
+    SKIP_SNIPPETS_CONFIG,
+    EMBEDDING_MODEL_INSTANCE,
+)
 from logdetective.server.agent.tools import (
     ExtractorTool,
     DrainExtractorTool,
     CSGrepExtractorTool,
     PythonTracebackExtractorTool,
     SnippetAnalysisTool,
+    AnnotatedSnippetLookupTool,
 )
+from logdetective.server.database.models.annotated_builds import AnnotatedSnippets
 from logdetective.server.models import APIResponse, BuildMetadata, AgentResponse
 from logdetective.server.exceptions import (
     LogDetectiveAgentResponseFailure,
@@ -121,6 +128,19 @@ async def analyze_artifacts(
                 max_invocations=len(artifacts),
             )
         )
+
+    if EMBEDDING_MODEL_INSTANCE and await AnnotatedSnippets.get_count() > 0:
+        snippet_lookup_tool = AnnotatedSnippetLookupTool(
+            options={"cache": UnconstrainedCache()},
+        )
+        tools.append(snippet_lookup_tool)
+        snippet_lookup_options = ConditionalRequirement(
+            AnnotatedSnippetLookupTool,
+            consecutive_allowed=True,
+            only_after=ExtractorTool,
+            max_invocations=5,
+        )
+        requirements.append(snippet_lookup_options)
 
     # Add snippet analysis tool, link all extractors and condition it to run after them
     # max_invocations are set at 5. Most snippets are not informative, and annotating them

--- a/logdetective/server/agent/tools.py
+++ b/logdetective/server/agent/tools.py
@@ -6,6 +6,7 @@ from beeai_framework.emitter.emitter import Emitter
 from beeai_framework.tools import Tool
 from beeai_framework.tools.errors import ToolInputValidationError, ToolError
 from beeai_framework.tools.types import ToolOutput, ToolRunOptions
+from fastembed import TextEmbedding
 from pydantic import BaseModel, Field
 import yaml
 
@@ -19,6 +20,8 @@ from logdetective.extractors import (
 from logdetective.models import SkipSnippets
 from logdetective.remote_log import RemoteLog
 from logdetective.server.models import ExtractorConfig, Snippet, AnalyzedSnippet
+from logdetective.server.config import EMBEDDING_MODEL_INSTANCE, SERVER_CONFIG
+from logdetective.server.database.models.annotated_builds import AnnotatedSnippets
 
 ARTIFACT_NAME_DESC = "The exact name of the artifact you want to extract information from."
 
@@ -349,3 +352,109 @@ class SnippetAnalysisTool(
     @property
     def input_schema(self) -> type[SnippetAnalysisToolInput]:
         return SnippetAnalysisToolInput
+
+
+class AnnotatedSnippetLookupToolInput(BaseModel):
+    snippet: str = Field(
+        description="Log snippet or key phrase to search for in annotated examples"
+    )
+    top_k: int = Field(
+        default=1,
+        le=SERVER_CONFIG.general.max_annotations,
+        ge=1,
+        description=(
+            "Number of similar annotated examples to retrieve "
+            f"(1 to {SERVER_CONFIG.general.max_annotations})."
+        ),
+    )
+
+
+class AnnotatedSnippetResult(BaseModel):
+    snippet_text: str
+    annotation: str
+    source_artifact_name: str
+    build_problem: str
+    build_solution: str
+
+
+class AnnotatedSnippetLookupToolOutput(ToolOutput, BaseModel):
+    results: list[AnnotatedSnippetResult]
+
+    def get_text_content(self) -> str:
+        return yaml.safe_dump(
+            self.model_dump(
+                exclude_defaults=True,
+                exclude_none=True,
+                exclude_computed_fields=True,
+                exclude_unset=True,
+                mode="json",
+            ),
+            allow_unicode=True,
+            default_flow_style=False,
+        )
+
+    def is_empty(self) -> bool:
+        return not self.results
+
+
+class AnnotatedSnippetLookupTool(
+    Tool[AnnotatedSnippetLookupToolInput, ToolRunOptions, AnnotatedSnippetLookupToolOutput]
+):
+    name: str = "annotated_snippet_lookup"
+    description: str = (
+        "Search the database of annotated log snippets for examples similar to a given "
+        "snippet or key phrase. Returns matching snippets with their annotations and the "
+        "associated build problem and solution. Use after extraction to look up known failures."
+    )
+
+    _embedding_model: TextEmbedding
+
+    def __init__(
+        self,
+        options: dict[str, Any] | None = None
+    ) -> None:
+        super().__init__(options)
+        self._embedding_model = EMBEDDING_MODEL_INSTANCE
+
+    def _create_emitter(self) -> Emitter:
+        return Emitter.root().child(
+            namespace=["tool", "annotated_snippet_lookup"], creator=self
+        )
+
+    async def _run(
+        self,
+        input: AnnotatedSnippetLookupToolInput,
+        options: ToolRunOptions | None,
+        context: RunContext,
+    ) -> AnnotatedSnippetLookupToolOutput:
+        if not input.snippet.strip():
+            return AnnotatedSnippetLookupToolOutput(results=[])
+
+        try:
+            embedding = list(self._embedding_model.embed([input.snippet]))[0].tolist()
+        except Exception as exc:
+            raise ToolError(f"Embedding creation failed: {exc}") from exc
+
+        try:
+            rows = await AnnotatedSnippets.get_by_snippet_embedding(
+                embedding,
+                top_k=input.top_k,
+            )
+        except Exception as exc:
+            raise ToolError(f"Database lookup failed: {exc}") from exc
+
+        results = [
+            AnnotatedSnippetResult(
+                snippet_text=row.text,
+                annotation=row.annotation,
+                source_artifact_name=row.source_artifact_name,
+                build_problem=row.source_build.problem,
+                build_solution=row.source_build.solution,
+            )
+            for row in rows
+        ]
+        return AnnotatedSnippetLookupToolOutput(results=results)
+
+    @property
+    def input_schema(self) -> type[AnnotatedSnippetLookupToolInput]:
+        return AnnotatedSnippetLookupToolInput

--- a/logdetective/server/config.py
+++ b/logdetective/server/config.py
@@ -3,10 +3,11 @@ import logging
 import yaml
 from beeai_framework.backend import ChatModel
 from beeai_framework.backend.types import ChatModelParameters
+from fastembed import TextEmbedding
 
 from logdetective.utils import load_prompts, load_skip_snippet_patterns
 from logdetective.server.models import Config, InferenceConfig
-from logdetective.constants import PROMPT_PATH, PROMPT_CONF_PATH
+from logdetective.constants import PROMPT_PATH, PROMPT_CONF_PATH, EMBEDDING_MODEL
 import logdetective
 
 
@@ -70,6 +71,17 @@ def get_chat_model(inference_config: InferenceConfig) -> ChatModel:
     )
 
 
+def load_embedding_model(config: Config) -> TextEmbedding | None:
+    """Load embedding model, if DB lookup is configured."""
+    if config.general.annotation_lookup_tool:
+        try:
+            return TextEmbedding(EMBEDDING_MODEL)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            LOG.exception("Embedding model load failed: %s", str(exc))
+            return None
+    return None
+
+
 SERVER_CONFIG_PATH = os.environ.get("LOGDETECTIVE_SERVER_CONF", None)
 
 # The default location for skip patterns is in the same directory
@@ -86,3 +98,5 @@ PROMPT_CONFIG = load_prompts(
 SKIP_SNIPPETS_CONFIG = load_skip_snippet_patterns(SERVER_SKIP_PATTERNS_PATH)
 
 LOG = get_log(SERVER_CONFIG)
+
+EMBEDDING_MODEL_INSTANCE = load_embedding_model(SERVER_CONFIG)

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -373,6 +373,8 @@ class GeneralConfig(BaseModel):
     delay_artifact_download: bool = False
     # Timeout for execution of analysis in seconds
     agent_timeout: int = 600
+    annotation_lookup_tool: bool = False
+    max_annotations: int = 3
 
     @field_validator("max_artifact_size", mode="before")
     @classmethod

--- a/server/config.yml
+++ b/server/config.yml
@@ -91,3 +91,7 @@ general:
   # Enable lazy fetching of build artifacts
   # delay_artifact_download: true
   agent_timeout: 600  # Timeout on agent execution
+  # Enable DB lookup of annotated snippets (requires populated annotated_snippets table)
+  # annotation_lookup_tool: true
+  # Upper limit for returned similar annotated snippets
+  # max_annotations: 3

--- a/tests/server/agent/test_agent.py
+++ b/tests/server/agent/test_agent.py
@@ -7,8 +7,13 @@ from beeai_framework.backend.errors import ChatModelError
 from litellm.exceptions import Timeout, RateLimitError
 
 from logdetective.server.agent.agent import analyze_artifacts
-from logdetective.server.agent.tools import DrainExtractorTool, CSGrepExtractorTool
-from logdetective.server.config import SERVER_CONFIG
+from logdetective.server.agent.tools import (
+    AnnotatedSnippetLookupTool,
+    DrainExtractorTool,
+    CSGrepExtractorTool,
+)
+from logdetective.server.config import SERVER_CONFIG, load_embedding_model
+from logdetective.server.database.models.annotated_builds import AnnotatedSnippets
 from logdetective.server.exceptions import (
     LogDetectiveInferenceError,
     LogDetectiveInferenceTimeout,
@@ -161,3 +166,46 @@ async def test_analyze_artifacts_solution_kept_when_enabled(mock_agent_setup):
             response = await analyze_artifacts(mock_artifacts, mock_chat_model)
             assert response.solution is not None
             assert response.solution.text == "Mock solution"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("config_option", "snippet_count", "expecting_lookup_tool"),
+    [
+        (True, 10, True),
+        (False, 10, False),
+        (True, 0, False),
+    ],
+    ids=("everything-set-up", "config-option-off", "db-not-populated"),
+)
+async def test_analyze_artifacts_lookup_tool_included(
+    mock_agent_setup,
+    config_option: bool,
+    snippet_count: int,
+    expecting_lookup_tool: bool,
+):
+    """AnnotatedSnippetLookupTool is enabled only if the flag is on and the table has data."""
+    mock_artifacts, mock_chat_model, mock_agent_output = mock_agent_setup
+    with patch("logdetective.server.agent.agent.RequirementAgent") as MockAgent:
+        mock_run_instance = MagicMock()
+        mock_run_instance.middleware = AsyncMock(return_value=mock_agent_output)
+        MockAgent.return_value.run.return_value = mock_run_instance
+
+        with (
+            patch.object(SERVER_CONFIG.general, "annotation_lookup_tool", config_option),
+            patch.object(SERVER_CONFIG.general, "max_annotations", 3),
+            patch("logdetective.server.config.TextEmbedding", MagicMock()),
+            patch.object(
+                AnnotatedSnippets, "get_count", new_callable=AsyncMock, return_value=snippet_count
+            ),
+        ):
+            model_instance = load_embedding_model(SERVER_CONFIG)
+            with patch(
+                "logdetective.server.agent.agent.EMBEDDING_MODEL_INSTANCE", model_instance
+            ):
+                await analyze_artifacts(mock_artifacts, mock_chat_model)
+
+        _, kwargs = MockAgent.call_args
+        tools = kwargs.get("tools", [])
+        is_tool_included = any(isinstance(t, AnnotatedSnippetLookupTool) for t in tools)
+        assert is_tool_included == expecting_lookup_tool

--- a/tests/server/agent/test_tools.py
+++ b/tests/server/agent/test_tools.py
@@ -1,10 +1,11 @@
 from enum import Enum
 from unittest.mock import AsyncMock, patch, MagicMock
+import numpy as np
 import pytest
 
 from beeai_framework.context import RunContext, RunInstance
 from beeai_framework.emitter import Emitter
-from beeai_framework.tools.errors import ToolError
+from beeai_framework.tools.errors import ToolError, ToolInputValidationError
 from logdetective.exceptions import (
     RemoteLogAccessError,
     RemoteLogRequestError,
@@ -12,6 +13,8 @@ from logdetective.exceptions import (
 )
 from logdetective.remote_log import RemoteLog
 from logdetective.server.agent.tools import (
+    AnnotatedSnippetLookupTool,
+    AnnotatedSnippetLookupToolInput,
     DrainExtractorTool,
     ExtractorTool,
     ExtractorToolInput,
@@ -19,7 +22,11 @@ from logdetective.server.agent.tools import (
     SnippetAnalysisToolInput,
     SnippetAnalysisToolOutput,
 )
+from logdetective.constants import EMBEDDING_VECTOR_SIZE
+from logdetective.server.database.models.annotated_builds import AnnotatedBuilds, AnnotatedSnippets
 from logdetective.server.models import ExtractorConfig, Snippet, AnalyzedSnippet
+
+ZERO_EMBEDDING = np.zeros(EMBEDDING_VECTOR_SIZE, dtype=np.float32)
 
 
 class MockRunInstance(RunInstance):
@@ -63,7 +70,6 @@ async def test_snippet_analysis_tool_init():
 @pytest.mark.asyncio
 async def test_snippet_analysis_nonexistent_source_file():
     """ToolInputValidationError when source_file is not in any extractor's available_artifacts."""
-    from beeai_framework.tools.errors import ToolInputValidationError
 
     source_file = "build.log"
     extractors: list[ExtractorTool] = [
@@ -86,7 +92,6 @@ async def test_snippet_analysis_nonexistent_source_file():
 @pytest.mark.asyncio
 async def test_snippet_analysis_wrong_line_number():
     """ToolError when source_file exists but no snippet matches the line_number."""
-    from beeai_framework.tools.errors import ToolError
 
     source_file = "build.log"
     artifact_content = "extracted text"
@@ -170,7 +175,6 @@ async def test_snippet_analysis_multiple_extractors():
 @pytest.mark.asyncio
 async def test_snippet_analysis_already_analyzed():
     """ToolInputValidationError when attempting to analyze a snippet that was already analyzed."""
-    from beeai_framework.tools.errors import ToolInputValidationError
 
     source_file = "build.log"
     artifact_content = "extracted text"
@@ -201,7 +205,6 @@ async def test_snippet_analysis_already_analyzed():
 @pytest.mark.asyncio
 async def test_snippet_analysis_no_extracted_snippets():
     """ToolError when source_file is valid but no snippets have been extracted yet."""
-    from beeai_framework.tools.errors import ToolError
 
     source_file = "build.log"
     extractors: list[ExtractorTool] = [
@@ -371,3 +374,95 @@ async def test_extractor_tool_remote_log_failure_raises_tool_error(remote_error)
         )
 
     assert exc_info.value.__cause__ is remote_error
+
+
+@pytest.mark.asyncio
+async def test_annotated_snippet_lookup_success():
+    """Returns populated results when DB returns matching rows."""
+
+    mock_build = MagicMock(spec=AnnotatedBuilds)
+    mock_build.problem = "missing dependency"
+    mock_build.solution = "install the package"
+
+    mock_row = MagicMock(spec=AnnotatedSnippets)
+    mock_row.text = "error: cannot find -lssl"
+    mock_row.annotation = "linker error due to missing openssl"
+    mock_row.source_artifact_name = "build.log"
+    mock_row.source_build = mock_build
+
+    mock_embedding = MagicMock()
+    mock_embedding.tolist.return_value = ZERO_EMBEDDING
+
+    with patch.object(
+        AnnotatedSnippets,
+        "get_by_snippet_embedding",
+        new_callable=AsyncMock,
+        return_value=[mock_row]
+    ), patch(
+        "logdetective.server.agent.tools.EMBEDDING_MODEL_INSTANCE"
+    ) as mock_embed_model:
+        mock_embed_model.embed.return_value = [mock_embedding]
+        tool = AnnotatedSnippetLookupTool()
+        result = await tool._run(
+            input=AnnotatedSnippetLookupToolInput(snippet="linker error", top_k=1),
+            context=RunContext(instance=MockRunInstance(), signal=None),
+            options=None,
+        )
+
+    assert not result.is_empty()
+    assert len(result.results) == 1
+    r = result.results[0]
+    assert r.snippet_text == "error: cannot find -lssl"
+    assert r.annotation == "linker error due to missing openssl"
+    assert r.source_artifact_name == "build.log"
+    assert r.build_problem == "missing dependency"
+    assert r.build_solution == "install the package"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("embed_side_effect", "db_effect", "expected_err"),
+    [
+        (RuntimeError("model load failed"), None, "Embedding creation failed"),
+        (None, RuntimeError("connection refused"), "Database lookup failed"),
+        (None, None, None),
+    ],
+    ids=("embedding-model-failure", "database-lookup-failure", "empty-list-returned")
+)
+async def test_annotated_snippet_lookup_fail(
+    embed_side_effect: RuntimeError | None,
+    db_effect: RuntimeError | None,
+    expected_err: str | None,
+) -> None:
+    """Test various annotated_snippet_lookup tool call fail cases."""
+
+    mock_embedding = MagicMock()
+    mock_embedding.tolist.return_value = ZERO_EMBEDDING
+
+    with patch.object(
+        AnnotatedSnippets,
+        "get_by_snippet_embedding",
+        new_callable=AsyncMock,
+        side_effect=db_effect,
+        return_value=[],
+    ), patch(
+        "logdetective.server.agent.tools.EMBEDDING_MODEL_INSTANCE"
+    ) as mock_embed_model:
+        mock_embed_model.embed.side_effect = embed_side_effect
+        mock_embed_model.embed.return_value = [mock_embedding]
+        tool = AnnotatedSnippetLookupTool()
+        if expected_err:
+            with pytest.raises(ToolError, match=expected_err):
+                await tool._run(
+                    input=AnnotatedSnippetLookupToolInput(snippet="some snippet", top_k=1),
+                    context=RunContext(instance=MockRunInstance(), signal=None),
+                    options=None,
+                )
+        else:
+            tool_output = await tool._run(
+                input=AnnotatedSnippetLookupToolInput(snippet="nothing here", top_k=1),
+                context=RunContext(instance=MockRunInstance(), signal=None),
+                options=None,
+            )
+            assert tool_output.is_empty()
+            assert tool_output.results == []


### PR DESCRIPTION
We made the script for populating the database with user contributions from website. We fixed the database persistence issues. Now it is time to actually provide the data to the agent.

DB lookup tool is controlled using 2 general options in `server/config.yml`: 
- `annotation_lookup_tool` - flag for enabling the tool, false by default
- `top_k_annotations` - how many best-match snippets are returned by the DB (default: 2, more would probably be wasteful, needs testing and fine-tuning)

I still need to thoroughly live-test (maybe adjust the tool description) the tool before merging, but we can already start the review process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional annotated-snippet lookup using semantic search.
  * Search results can include matching text, annotations, source artifacts, build problems, and solutions.
  * Added configuration options to enable lookup and control the number of results returned.
* **Bug Fixes**
  * Added handling for empty searches and reporting of embedding or lookup failures.
* **Tests**
  * Added coverage for successful searches, empty results, configuration behavior, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->