### PR TITLE
Fix test server gitlab warnings

### DIFF
--- a/logdetective/server/gitlab.py
+++ b/logdetective/server/gitlab.py
@@ -341,7 +341,7 @@ async def check_artifacts_file_size(
             raise_for_status=True,
         )
     except aiohttp.ClientResponseError as ex:
-        if ex.code == 404:
+        if ex.status == 404:
             raise LogDetectiveArtifactsMissingError(
                 f"Requested artifacts from job {job.id} in project "
                 f"{job.project_id} are not available."

--- a/tests/server/test_helpers.py
+++ b/tests/server/test_helpers.py
@@ -359,14 +359,10 @@ def create_zip_archive(files_to_add: dict[str, str]) -> bytes:
 def mock_artifact_download(mocker: MockerFixture, zip_content: bytes):
     """Mocks the asyncio.to_thread call that simulates the artifact download."""
 
-    async def dummy_coro():
-        pass
-
-    def mock_side_effect(func, *args, **kwargs):
+    async def mock_side_effect(func, *args, **kwargs):
         action = kwargs.get("action")
         if action and callable(action):
             action(zip_content)
-        return dummy_coro()
 
     mocker.patch("asyncio.to_thread", side_effect=mock_side_effect)
 


### PR DESCRIPTION
```
tests/server/test_server_gitlab.py::test_fallback_to_task_failed_log_if_no_match
tests/server/test_server_gitlab.py::test_raises_file_not_found_on_no_failures
tests/server/test_server_gitlab.py::test_architecture_prioritization
tests/server/test_server_gitlab.py::test_toplevel_failure_fallback
tests/server/test_server_gitlab.py::test_unrecognized_architecture_handling
  logdetective/logdetective/server/gitlab.py:224: RuntimeWarning: coroutine 'mock_artifact_download.<locals>.dummy_coro' was never awaited
    await asyncio.to_thread(job.artifacts, streamed=True, action=tempfile.write)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/server/test_server_gitlab.py::test_check_artifacts_file_size_handles_http_error
  logdetective/logdetective/server/gitlab.py:344: DeprecationWarning: code property is deprecated, use status instead
    if ex.code == 404:
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing GitLab artifacts, ensuring HTTP 404 responses are detected correctly.
  - Prevented errors when checking artifact availability, resulting in more reliable artifact-related operations.

- **Tests**
  - Updated automated test helpers to accurately simulate asynchronous artifact responses and callback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->