### PR TITLE
Add sync profile to compose files

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -27,6 +27,8 @@ services:
     extends:
       file: docker-compose.yaml
       service: user-contributions-update
+    profiles:
+      - sync
 
 volumes:
   database_data:

--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -103,6 +103,8 @@ services:
     extends:
       file: docker-compose.yaml
       service: user-contributions-update
+    profiles:
+      - sync
 
 volumes:
   database_data:


### PR DESCRIPTION
I was only testing with `podman-compose up`. If `-f` is used, the profile information about the `user-contributions-update` is not passed to the `-dev` or `-prod` configurations, this is why compose didn't work in prod. Tested from scratch with `-dev` (removed volume, no migrations).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added the user contributions update service to the `sync` Compose profile for development and production environments.
  * The service can now be managed consistently with other synchronization services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->