### PR TITLE
Limit thread usage by embedding model

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -93,6 +93,7 @@ services:
     env_file: ./env_file
     environment:
       - LOG_DIR=/var/log/logdetective
+      - USER_CONTRIBUTION_UPDATE_THREADS=4
     working_dir: /src
     volumes:
       - ./log:/var/log/logdetective:z

--- a/logdetective/server/config.py
+++ b/logdetective/server/config.py
@@ -75,7 +75,10 @@ def load_embedding_model(config: Config) -> TextEmbedding | None:
     """Load embedding model, if DB lookup is configured."""
     if config.general.annotation_lookup_tool:
         try:
-            return TextEmbedding(EMBEDDING_MODEL)
+            return TextEmbedding(
+                EMBEDDING_MODEL,
+                threads=config.general.embedding_model_threads,
+            )
         except Exception as exc:  # pylint: disable=broad-exception-caught
             LOG.exception("Embedding model load failed: %s", str(exc))
             return None

--- a/logdetective/server/models.py
+++ b/logdetective/server/models.py
@@ -6,6 +6,7 @@ from pydantic import (
     model_validator,
     field_validator,
     NonNegativeFloat,
+    PositiveInt,
     HttpUrl,
     ConfigDict,
 )
@@ -375,6 +376,10 @@ class GeneralConfig(BaseModel):
     agent_timeout: int = 600
     annotation_lookup_tool: bool = False
     max_annotations: int = 3
+    # Limits onnxruntime intra/inter-op threads per embedding model instance.
+    # Each gunicorn worker loads its own model, so with many workers this
+    # must stay low to avoid exhausting the process/thread limit.
+    embedding_model_threads: PositiveInt = 4
 
     @field_validator("max_artifact_size", mode="before")
     @classmethod

--- a/logdetective/server/user_contributions_update.py
+++ b/logdetective/server/user_contributions_update.py
@@ -74,6 +74,7 @@ DOWNLOAD_URL = "https://logdetective.com/download"
 MAX_ARCHIVE_AGE_DAYS = 90
 LOG_DIR = os.getenv("LOG_DIR", "/var/log/logdetective")
 LOG_FILE = os.path.join(LOG_DIR, "user_contributions_update.log")
+THREAD_COUNT = int(os.getenv("USER_CONTRIBUTION_UPDATE_THREADS", "4"))
 
 
 # pylint: disable=too-many-locals
@@ -250,7 +251,7 @@ async def run_update(url: str, dry_run: bool = False, reset: bool = False) -> No
     embedding_model = None
     if not dry_run:
         logger.info("Loading embedding model: %s", EMBEDDING_MODEL)
-        embedding_model = TextEmbedding(EMBEDDING_MODEL)
+        embedding_model = TextEmbedding(EMBEDDING_MODEL, threads=THREAD_COUNT)
 
     if reset:
         date_since = None

--- a/server/config.yml
+++ b/server/config.yml
@@ -95,3 +95,7 @@ general:
   # annotation_lookup_tool: true
   # Upper limit for returned similar annotated snippets
   # max_annotations: 3
+  # ONNXRuntime intra/inter-op thread count for the embedding model.
+  # A new model instance is loaded per gunicorn worker process, so keep this low (depending on how many cores/threads are available)
+  # to avoid exhausting the host's thread/process limit.
+  embedding_model_threads: 4


### PR DESCRIPTION
`threads` controls the relevant `{intra,inter}_op_num_threads` config
https://onnxruntime.ai/docs/performance/tune-performance/threading.html
https://github.com/qdrant/fastembed/blob/main/fastembed/common/onnx_model.py#L106-L108

With this change, there will be no way to get the default (None) behavior which starts onnx runtime on all available CPU cores (if no GPU can be found).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable setting for controlling the number of threads used by the embedding model.
  * The setting defaults to 4 threads and accepts only positive whole numbers.

* **Improvements**
  * Embedding model processing now consistently honors the configured thread count, helping administrators tune resource usage and performance.
  * Configuration documentation now explains thread usage and model loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->