### PR TITLE
Remove mention of build from docstring

### DIFF
--- a/logdetective/server/agent/tools.py
+++ b/logdetective/server/agent/tools.py
@@ -93,7 +93,7 @@ class ExtractorTool(Tool[ExtractorToolInput]):
         options: ToolRunOptions | None,
         context: RunContext,
     ) -> ExtractorToolOutput:
-        """Extract snippets from selected build artifact."""
+        """Extract snippets from selected artifact."""
 
         if input.artifact_name not in self.all_artifacts:
             raise ToolInputValidationError(


### PR DESCRIPTION
The only mention of build in tools that don't explicitly require it was this one docstring. Agent would never read it, so it wouldn't have impact, but just for the sake of clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the extractor tool’s documentation to refer to the selected artifact.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->