### PR TITLE
Unify how mocking is done in Log Detective tests

### DIFF
--- a/.github/workflows/python-diff-lint.yml
+++ b/.github/workflows/python-diff-lint.yml
@@ -28,7 +28,6 @@ jobs:
             python3-fastapi
             python3-gitlab
             python3-sqlalchemy
-            python3-flexmock
             python3-alembic
           linter_tags: |
             pylint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ For CUDA GPU acceleration, uncomment the device lines in `docker-compose-dev.yam
 
 - Split into `tests/base` (utilities used in both CLI and server) and `tests/server`.
 - Async tests use `@pytest.mark.asyncio` decorator
-- Mocking: `unittest.mock` or `flexmock` for object mocking/patching, `aioresponses` for async HTTP
+- Mocking: `unittest.mock` for object mocking/patching, `aioresponses` for async HTTP
 - Some test data fixtures (related to gitlab) live in `tests/server/data/` as YAML files
 
 # Package layout

--- a/poetry.lock
+++ b/poetry.lock
@@ -1167,19 +1167,6 @@ files = [
 ]
 
 [[package]]
-name = "flexmock"
-version = "0.12.2"
-description = "flexmock is a testing library for Python that makes it easy to create mocks, stubs and fakes."
-optional = true
-python-versions = "<4.0.0,>=3.8.0"
-groups = ["main"]
-markers = "extra == \"testing\""
-files = [
-    {file = "flexmock-0.12.2-py3-none-any.whl", hash = "sha256:46c5c125548af8f8906f3199efaca6d35cfee0a7ddc77cd8135f69376c3b3e23"},
-    {file = "flexmock-0.12.2.tar.gz", hash = "sha256:435c661c3b35477575eb9150428a1cfd7c62cb992aa7887567c3357aebc9aca1"},
-]
-
-[[package]]
 name = "frozenlist"
 version = "1.8.0"
 description = "A list-like structure which implements collections.abc.MutableSequence"
@@ -2113,7 +2100,7 @@ description = "brain-dead simple config-ini parsing"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"server-testing\" or extra == \"testing\""
+markers = "extra == \"testing\""
 files = [
     {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
     {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
@@ -3187,7 +3174,7 @@ description = "plugin and hook calling mechanisms for python"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"server-testing\" or extra == \"testing\""
+markers = "extra == \"testing\""
 files = [
     {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
     {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
@@ -3710,7 +3697,7 @@ description = "pytest: simple powerful testing with Python"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"server-testing\" or extra == \"testing\""
+markers = "extra == \"testing\""
 files = [
     {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
     {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
@@ -3767,25 +3754,6 @@ pytest = ">=7"
 
 [package.extras]
 testing = ["process-tests", "pytest-xdist", "virtualenv"]
-
-[[package]]
-name = "pytest-mock"
-version = "3.15.1"
-description = "Thin-wrapper around the mock package for easier use with pytest"
-optional = true
-python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"server-testing\" or extra == \"testing\""
-files = [
-    {file = "pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d"},
-    {file = "pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f"},
-]
-
-[package.dependencies]
-pytest = ">=6.2.5"
-
-[package.extras]
-dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
 name = "python-dateutil"
@@ -5108,10 +5076,10 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 
 [extras]
 server = ["alembic", "asyncpg", "fastapi", "fastembed", "google-cloud-aiplatform", "gunicorn", "httpx", "koji", "pgvector", "python-gitlab", "sentry-sdk", "sqlalchemy", "starlette", "tenacity", "uvicorn"]
-server-testing = ["alembic", "asyncpg", "fastapi", "fastembed", "google-cloud-aiplatform", "gunicorn", "httpx", "koji", "pgvector", "pytest-mock", "python-gitlab", "responses", "sentry-sdk", "sqlalchemy", "starlette", "tenacity", "uvicorn"]
-testing = ["aioresponses", "asciidoc", "flexmock", "pytest", "pytest-asyncio", "pytest-cov", "pytest-mock"]
+server-testing = ["alembic", "asyncpg", "fastapi", "fastembed", "google-cloud-aiplatform", "gunicorn", "httpx", "koji", "pgvector", "python-gitlab", "responses", "sentry-sdk", "sqlalchemy", "starlette", "tenacity", "uvicorn"]
+testing = ["aioresponses", "asciidoc", "pytest", "pytest-asyncio", "pytest-cov"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "c9f85f4b73acf0e0e33712aac660fd66016de7c980e0cf2ade7e81fc40a190ff"
+content-hash = "e0c383ce5ad46bd72355b999bb79f67a810dedeeb47f475c16be307c40b75089"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,16 +92,13 @@ server-testing = [
     "fastembed>=0.8.0",
     "pgvector>=0.4.2",
     "google-cloud-aiplatform>=1.158.0",
-    "pytest-mock",
     "responses",
 ]
 testing = [
     "pytest",
     "pytest-asyncio",
     "aioresponses",
-    "flexmock",
     "pytest-cov",
-    "pytest-mock",
     "asciidoc>=10.2.1,<11.0.0",
 ]
 

--- a/tests/base/base.fmf
+++ b/tests/base/base.fmf
@@ -1,6 +1,5 @@
 require:
 - python3-pytest
-- python3-flexmock
 - python3-pytest-asyncio
 - python3-aioresponses
 - python3-responses

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -1,4 +1,4 @@
-from unittest import mock
+from unittest.mock import patch, mock_open
 
 import aiohttp
 import aioresponses
@@ -230,7 +230,7 @@ def test_load_skip_snippet_patterns_no_path():
 def test_load_skip_snippet_patterns_empty_file():
     """Test behavior for case when the file exists but is empty."""
 
-    with mock.patch("logdetective.utils.open", mock.mock_open(read_data=b"")):
+    with patch("logdetective.utils.open", mock_open(read_data=b"")):
         result = load_skip_snippet_patterns("/valid/but/empty.toml")
 
     assert result is None
@@ -239,9 +239,9 @@ def test_load_skip_snippet_patterns_empty_file():
 def test_load_skip_snippet_patterns_only_comments():
     """Test behavior for case when the file is functionally empty (only comments)."""
 
-    with mock.patch(
+    with patch(
         "logdetective.utils.open",
-        mock.mock_open(read_data=b"# commented out stuff\n# no patterns here\n"),
+        mock_open(read_data=b"# commented out stuff\n# no patterns here\n"),
     ):
         result = load_skip_snippet_patterns("/valid/but/empty.toml")
 
@@ -253,8 +253,8 @@ def test_load_skip_snippet_patterns_correct_path():
     All patterns must be parsed successfully and match
     those from original source."""
 
-    with mock.patch(
-        "logdetective.utils.open", mock.mock_open(read_data=_to_toml(test_filter_patterns))
+    with patch(
+        "logdetective.utils.open", mock_open(read_data=_to_toml(test_filter_patterns))
     ):
         prompts_config = load_skip_snippet_patterns("/valid/filters.toml")
 
@@ -267,8 +267,8 @@ def test_load_skip_snippet_patterns_invalid_syntax():
 
     test_skip_snippet_data = b"[bad_regex]\npattern = '$**.^.*'\n"
 
-    with mock.patch(
-        "logdetective.utils.open", mock.mock_open(read_data=test_skip_snippet_data)
+    with patch(
+        "logdetective.utils.open", mock_open(read_data=test_skip_snippet_data)
     ):
         with pytest.raises(ValueError, match="Invalid pattern"):
             load_skip_snippet_patterns("/valid/filters.toml")
@@ -279,8 +279,8 @@ def test_load_skip_snippet_patterns_missing_pattern_key():
 
     test_skip_snippet_data = b"[bad_entry]\nnot_pattern = 'just_a_string'\n"
 
-    with mock.patch(
-        "logdetective.utils.open", mock.mock_open(read_data=test_skip_snippet_data)
+    with patch(
+        "logdetective.utils.open", mock_open(read_data=test_skip_snippet_data)
     ):
         with pytest.raises(ValueError, match="must be a mapping"):
             load_skip_snippet_patterns("/valid/filters.toml")

--- a/tests/server/server.fmf
+++ b/tests/server/server.fmf
@@ -1,6 +1,5 @@
 require:
 - python3-pytest
-- python3-flexmock
 - python3-pytest-asyncio
 - python3-aioresponses
 - python3-responses

--- a/tests/server/test_helpers.py
+++ b/tests/server/test_helpers.py
@@ -1,16 +1,15 @@
 import datetime
 import io
 from itertools import cycle, count
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
+from types import SimpleNamespace
 from typing import Optional, AsyncGenerator
 import zipfile
-from unittest.mock import AsyncMock
+from unittest.mock import MagicMock, AsyncMock, patch
 
 import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
-from flexmock import flexmock
-from pytest_mock import MockerFixture
 
 from openai.types.chat.chat_completion import Choice, ChatCompletion
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
@@ -91,7 +90,10 @@ class DatabaseFactory:  # pylint: disable=too-few-public-methods
             self.get_pg_test_url(), connect_args={"command_timeout": 10}, pool_pre_ping=True
         )
         self.SessionFactory = async_sessionmaker(autoflush=True, bind=self.engine)
-        flexmock(base, engine=self.engine, SessionFactory=self.SessionFactory)
+        self._engine_patch = patch.object(base, "engine", self.engine)
+        self._session_patch = patch.object(base, "SessionFactory", self.SessionFactory)
+        self._engine_patch.start()
+        self._session_patch.start()
 
     @asynccontextmanager
     async def make_new_db(self):
@@ -100,7 +102,11 @@ class DatabaseFactory:  # pylint: disable=too-few-public-methods
                 await conn.run_sync(Base.metadata.create_all)
             yield self.SessionFactory
         finally:
-            await destroy()
+            try:
+                await destroy()
+            finally:
+                self._engine_patch.stop()
+                self._session_patch.stop()
 
 
 class PopulateDatabase:  # pylint: disable=too-few-public-methods
@@ -286,13 +292,13 @@ def build_log_request(request):
 
 @pytest.fixture
 def build_log_url():
-    return {"payload": flexmock(url="https://example.com/logs/123", files=None)}
+    return {"payload": SimpleNamespace(url="https://example.com/logs/123", files=None)}
 
 
 @pytest.fixture
 def build_log_two_files():
     return {
-        "payload": flexmock(
+        "payload": SimpleNamespace(
             url=None,
             files=[
                 ArtifactFile(name="builder-live.log", content=MOCK_LOG),
@@ -305,7 +311,7 @@ def build_log_two_files():
 @pytest.fixture
 def build_log_one_file():
     return {
-        "payload": flexmock(
+        "payload": SimpleNamespace(
             url=None,
             files=[
                 ArtifactFile(name="build.log", content=MOCK_LOG)
@@ -315,19 +321,18 @@ def build_log_one_file():
 
 
 @pytest.fixture
-def mock_AnalyzeRequestMetrics(mocker: MockerFixture):
-    mock_create = mocker.patch(
-        "logdetective.server.database.models.AnalyzeRequestMetrics.create",
-        new_callable=AsyncMock,
-        return_value=1,
-    )
-
-    mock_update = mocker.patch(
-        "logdetective.server.database.models.AnalyzeRequestMetrics.update",
-        new_callable=AsyncMock,
-    )
-
-    return {"mock_create": mock_create, "mock_update": mock_update}
+def mock_AnalyzeRequestMetrics():
+    with (
+        patch(
+            "logdetective.server.database.models.AnalyzeRequestMetrics.create",
+            new_callable=AsyncMock,
+            return_value=1,
+        ) as mock_create, patch(
+            "logdetective.server.database.models.AnalyzeRequestMetrics.update",
+            new_callable=AsyncMock,
+        ) as mock_update,
+    ):
+        yield {"mock_create": mock_create, "mock_update": mock_update}
 
 
 class MockGitlabJob:
@@ -356,7 +361,8 @@ def create_zip_archive(files_to_add: dict[str, str]) -> bytes:
     return zip_buffer.read()
 
 
-def mock_artifact_download(mocker: MockerFixture, zip_content: bytes):
+@contextmanager
+def mock_artifact_download(zip_content: bytes):
     """Mocks the asyncio.to_thread call that simulates the artifact download."""
 
     async def mock_side_effect(func, *args, **kwargs):
@@ -364,7 +370,8 @@ def mock_artifact_download(mocker: MockerFixture, zip_content: bytes):
         if action and callable(action):
             action(zip_content)
 
-    mocker.patch("asyncio.to_thread", side_effect=mock_side_effect)
+    with patch("asyncio.to_thread", side_effect=mock_side_effect) as mock_to_thread:
+        yield mock_to_thread
 
 
 @pytest.fixture
@@ -387,13 +394,11 @@ def mock_job() -> MockGitlabJob:
     return MockGitlabJob(project_id=42, job_id=101)
 
 
-def create_mock_koji_session(
-    mocker, task_id, method, arch="x86_64", list_task_output=True
-):
+def create_mock_koji_session(task_id, method, arch="x86_64", list_task_output=True):
     """Mock koji session. Returns responses to `getTaskOutput`, `listTaskOutput`
     and `downloadTaskOutput` methods. If `list_task_output` is set to `False`
     will instead return `None` for the `listTaskOutput`."""
-    mock_session = mocker.Mock()
+    mock_session = MagicMock()
 
     mock_session.getTaskInfo.return_value = {
         "id": task_id,
@@ -423,16 +428,16 @@ def create_mock_koji_session(
     return mock_session
 
 
-def create_mock_client_response(mocker, content_length: int | None = None):
+def create_mock_client_response(content_length: int | None = None):
     """Creates a mock aiohttp.ClientSession that can be awaited."""
     # This is the mock response object that head() will eventually return.
-    mock_response = mocker.Mock()
+    mock_response = MagicMock()
     mock_response.headers = {}
     if content_length:
         mock_response.headers["content-length"] = str(content_length)
 
     # This is the mock for the session object itself.
-    mock_session = mocker.MagicMock()
+    mock_session = MagicMock()
     # We configure its `head` method to be an async function (coroutine)
     # that returns our mock response.
     mock_session.head = AsyncMock(return_value=mock_response)
@@ -464,6 +469,5 @@ def mock_config():
             },
         }
     )
-    flexmock(gitlab).should_receive("SERVER_CONFIG").and_return(server_config)
-
-    return {"server_config": server_config}
+    with patch.object(gitlab, "SERVER_CONFIG", server_config):
+        yield {"server_config": server_config}

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -1,5 +1,6 @@
-from pathlib import Path
 import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import aiohttp
 import aioresponses
@@ -7,7 +8,6 @@ import pytest
 from pydantic import HttpUrl
 
 import gitlab
-from flexmock import flexmock
 
 from logdetective.server.config import SERVER_CONFIG
 from logdetective.remote_log import RemoteLog
@@ -235,13 +235,12 @@ async def test_get_artifacts_delayed_download_no_http_call(monkeypatch):
         ]
     )
 
-    async with aiohttp.ClientSession() as session:
-        mock_remote_log = flexmock(RemoteLog)
-        mock_remote_log.should_receive("get_url_content").never()
-
-        artifacts = await get_artifacts_from_payload(
-            payload, session, request_size=0
-        )
+    with patch.object(RemoteLog, "get_url_content", new_callable=AsyncMock) as mock_get_content:
+        async with aiohttp.ClientSession() as session:
+            artifacts = await get_artifacts_from_payload(
+                payload, session, request_size=0
+            )
+            mock_get_content.assert_not_called()
 
     assert isinstance(artifacts["no_fetch.log"], RemoteLog)
 
@@ -263,21 +262,21 @@ async def test_get_artifacts_immediate_download_returns_string(
         ]
     )
 
-    awaited_log = asyncio.Future()
-    awaited_log.set_result("downloaded content")
-    mock_remote_log = flexmock(RemoteLog)
+    with (
+        patch.object(RemoteLog, "__init__", return_value=None) as mock_init,
+        patch.object(
+            RemoteLog, "get_url_content", new_callable=AsyncMock, return_value="downloaded content"
+        ) as mock_url_content,
+    ):
+        async with aiohttp.ClientSession() as session:
+            artifacts = await get_artifacts_from_payload(
+                payload, session, request_size=request_size
+            )
+            mock_init.assert_called_with(
+                "http://path.to/immediate.log",
+                session,
+                limit_bytes=SERVER_CONFIG.general.max_artifact_size - request_size,
+            )
+            mock_url_content.assert_called_once()
 
-    async with aiohttp.ClientSession() as session:
-        mock_remote_log.should_receive("__init__").with_args(
-            "http://path.to/immediate.log",
-            session,
-            limit_bytes=SERVER_CONFIG.general.max_artifact_size - request_size,
-        )
-        mock_remote_log.should_receive("get_url_content").and_return(
-            awaited_log
-        ).once()
-        artifacts = await get_artifacts_from_payload(
-            payload, session, request_size=request_size
-        )
-
-    assert isinstance(artifacts["immediate.log"], str)
+        assert isinstance(artifacts["immediate.log"], str)

--- a/tests/server/test_server_gitlab.py
+++ b/tests/server/test_server_gitlab.py
@@ -1,6 +1,6 @@
 import os
 import io
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import MagicMock, AsyncMock, patch
 import zipfile
 import pytest
 import pytest_asyncio
@@ -9,7 +9,6 @@ import responses
 import aioresponses
 from gitlab import Gitlab
 from packaging.version import Version
-from pytest_mock import MockerFixture
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 from beeai_framework.backend import ChatModel
@@ -252,17 +251,18 @@ async def mock_job_hook():
 
 
 @pytest.fixture
-def mock_analysis(mocker, request):
+def mock_analysis(request):
     """Fixture to mock analyze_artifacts directly at the server level."""
     message = getattr(request, "param", "This is a mock message")
     mock_response = APIResponse(
         explanation=Explanation(text=message),
         snippets=[]
     )
-    return mocker.patch(
+    with patch(
         "logdetective.server.gitlab.analyze_artifacts",
         AsyncMock(return_value=mock_response)
-    )
+    ) as mock:
+        yield mock
 
 
 @pytest.mark.parametrize(
@@ -274,7 +274,6 @@ def mock_analysis(mocker, request):
 )
 @pytest.mark.asyncio
 async def test_process_gitlab_job_event(
-    mocker,
     mock_config,
     mock_job_hook,
     mock_analysis,
@@ -288,7 +287,7 @@ async def test_process_gitlab_job_event(
             url="https://gitlab.com/",
         )
         mock_http_session = create_mock_client_response(
-            mocker, content_length=gitlab_cfg.max_artifact_size
+            content_length=gitlab_cfg.max_artifact_size
         )
 
         # We need a chat model for the process_gitlab_job_event
@@ -342,7 +341,7 @@ async def test_is_eligible_package(mock_config):
 # To test this, comment out the @pytest.mark.skip decorator
 @pytest.mark.skip(reason="Requires real network access and a valid token")
 @pytest.mark.asyncio
-async def test_regression_unknown_arch_logs(mocker: MockerFixture):
+async def test_regression_unknown_arch_logs():
     gl_token = os.environ.get("LD_GITLAB_TOKEN", None)
     data = {
         "name": "Live Network Test Instance",
@@ -359,7 +358,7 @@ async def test_regression_unknown_arch_logs(mocker: MockerFixture):
 
     project = gitlab_connection.projects.get(23665037)
     job = project.jobs.get(10226618670)
-    mock_session = mocker.Mock()
+    mock_session = AsyncMock()
     url, _ = await retrieve_and_preprocess_koji_logs(
         gitlab_cfg=gitlab_cfg, job=job, http_session=mock_session
     )
@@ -370,9 +369,7 @@ async def test_regression_unknown_arch_logs(mocker: MockerFixture):
 
 
 @pytest.mark.asyncio
-async def test_fallback_to_task_failed_log_if_no_match(
-    mocker: MockerFixture, gitlab_cfg, mock_job
-):
+async def test_fallback_to_task_failed_log_if_no_match(gitlab_cfg, mock_job):
     """
     Tests that if task_failed.log doesn't mention a specific log,
     it returns the task_failed.log itself.
@@ -380,16 +377,15 @@ async def test_fallback_to_task_failed_log_if_no_match(
     log_content = "A generic failure occurred. Check Koji for details."
     files = {"kojilogs/x86_64-build/task_failed.log": log_content}
     zip_content = create_zip_archive(files)
-    mock_artifact_download(mocker, zip_content)
-    mocker.patch(
-        "logdetective.server.gitlab.check_artifacts_file_size", return_value=True
-    )
 
-    mock_session = mocker.AsyncMock()
-
-    log_url, log_text = await retrieve_and_preprocess_koji_logs(
-        gitlab_cfg=gitlab_cfg, job=mock_job, http_session=mock_session
-    )
+    with (
+        mock_artifact_download(zip_content),
+        patch("logdetective.server.gitlab.check_artifacts_file_size", return_value=True),
+    ):
+        mock_session = AsyncMock()
+        log_url, log_text = await retrieve_and_preprocess_koji_logs(
+            gitlab_cfg=gitlab_cfg, job=mock_job, http_session=mock_session
+        )
 
     assert "artifacts/kojilogs/x86_64-build/task_failed.log" in log_url
     assert log_text == log_content
@@ -397,56 +393,49 @@ async def test_fallback_to_task_failed_log_if_no_match(
 
 
 @pytest.mark.asyncio
-async def test_raises_file_not_found_on_no_failures(
-    mocker: MockerFixture, gitlab_cfg, mock_job
-):
+async def test_raises_file_not_found_on_no_failures(gitlab_cfg, mock_job):
     """
     Tests that FileNotFoundError is raised if no task_failed.log is found.
     """
     files = {"kojilogs/x86_64-build/build.log": "This build was successful."}
     zip_content = create_zip_archive(files)
-    mock_artifact_download(mocker, zip_content)
-    mocker.patch(
-        "logdetective.server.gitlab.check_artifacts_file_size", return_value=True
-    )
-
-    mock_session = mocker.AsyncMock()
-
-    with pytest.raises(
-        FileNotFoundError, match="Could not detect failed architecture."
+    with (
+        mock_artifact_download(zip_content),
+        patch("logdetective.server.gitlab.check_artifacts_file_size", return_value=True),
     ):
-        await retrieve_and_preprocess_koji_logs(
-            gitlab_cfg=gitlab_cfg, job=mock_job, http_session=mock_session
-        )
+        mock_session = AsyncMock()
+        with pytest.raises(
+            FileNotFoundError, match="Could not detect failed architecture."
+        ):
+            await retrieve_and_preprocess_koji_logs(
+                gitlab_cfg=gitlab_cfg, job=mock_job, http_session=mock_session
+            )
 
 
 @pytest.mark.asyncio
-async def test_raises_logs_too_large_error(mocker: MockerFixture, gitlab_cfg, mock_job):
+async def test_raises_logs_too_large_error(gitlab_cfg, mock_job):
     """
     Tests that LogsTooLargeError is raised if check_artifacts_file_size returns False.
     """
-    mocker.patch(
-        "logdetective.server.gitlab.check_artifacts_file_size", return_value=False
-    )
-    mock_to_thread = mocker.patch("asyncio.to_thread")
-    mock_session = mocker.AsyncMock()
+    with (
+        patch("logdetective.server.gitlab.check_artifacts_file_size", return_value=False),
+        patch("asyncio.to_thread") as mock_to_thread,
+    ):
+        mock_session = AsyncMock()
+        with pytest.raises(LogsTooLargeError):
+            await retrieve_and_preprocess_koji_logs(
+                gitlab_cfg=gitlab_cfg, job=mock_job, http_session=mock_session
+            )
 
-    with pytest.raises(LogsTooLargeError):
-        await retrieve_and_preprocess_koji_logs(
-            gitlab_cfg=gitlab_cfg, job=mock_job, http_session=mock_session
-        )
-
-    # Ensure we didn't attempt to download the file
-    mock_to_thread.assert_not_called()
+        # Ensure we didn't attempt to download the file
+        mock_to_thread.assert_not_called()
 
 
 @pytest.mark.parametrize(
     "limit", (512, 1024 + 2), ids=("single-file-size", "cumulative-size")
 )
 @pytest.mark.asyncio
-async def test_raises_logs_too_large_error_decompression(
-    mocker: MockerFixture, gitlab_cfg, mock_job, limit,
-):
+async def test_raises_logs_too_large_error_decompression(gitlab_cfg, mock_job, limit):
     """
     Tests that LogsTooLargeError is raised if the archive is small, but the decompressed content
     is too big, either one file by itself, or multiple files accumulate over the limit.
@@ -457,26 +446,24 @@ async def test_raises_logs_too_large_error_decompression(
         "kojilogs/noarch-build/x86_64-build/build.log": "A" * 1024,
     }
     zip_content = create_zip_archive(files)
-    mock_artifact_download(mocker, zip_content)
-    mocker.patch(
-        "logdetective.server.gitlab.check_artifacts_file_size", return_value=True
-    )
-    gitlab_cfg.max_artifact_size = limit
-
-    mock_session = mocker.AsyncMock()
-
-    with pytest.raises(LogsTooLargeError, match="exceeds the limit"):
-        await retrieve_and_preprocess_koji_logs(
-            gitlab_cfg=gitlab_cfg, job=mock_job, http_session=mock_session
-        )
+    with (
+        mock_artifact_download(zip_content),
+        patch("logdetective.server.gitlab.check_artifacts_file_size", return_value=True),
+    ):
+        gitlab_cfg.max_artifact_size = limit
+        mock_session = AsyncMock()
+        with pytest.raises(LogsTooLargeError, match="exceeds the limit"):
+            await retrieve_and_preprocess_koji_logs(
+                gitlab_cfg=gitlab_cfg, job=mock_job, http_session=mock_session
+            )
 
 
 @pytest.mark.asyncio
-async def test_check_artifacts_file_size(mocker: MockerFixture, gitlab_cfg, mock_job):
+async def test_check_artifacts_file_size(gitlab_cfg, mock_job):
     """Test check_artifacts_file_size in case the file doesn't exceed the limit."""
     # Test case where artifact size is within the limit
     mock_session_ok = create_mock_client_response(
-        mocker, content_length=gitlab_cfg.max_artifact_size
+        content_length=gitlab_cfg.max_artifact_size
     )
 
     result_ok = await check_artifacts_file_size(
@@ -487,12 +474,10 @@ async def test_check_artifacts_file_size(mocker: MockerFixture, gitlab_cfg, mock
 
 
 @pytest.mark.asyncio
-async def test_check_artifacts_file_size_too_large(
-    mocker: MockerFixture, gitlab_cfg, mock_job
-):
+async def test_check_artifacts_file_size_too_large(gitlab_cfg, mock_job):
     """Test check_artifacts_file_size in case the file exceeds the limit."""
     mock_session_large = create_mock_client_response(
-        mocker, content_length=gitlab_cfg.max_artifact_size + 1
+        content_length=gitlab_cfg.max_artifact_size + 1
     )
 
     result_large = await check_artifacts_file_size(
@@ -502,12 +487,10 @@ async def test_check_artifacts_file_size_too_large(
 
 
 @pytest.mark.asyncio
-async def test_check_artifacts_file_no_content_length(
-    mocker: MockerFixture, gitlab_cfg, mock_job
-):
+async def test_check_artifacts_file_no_content_length(gitlab_cfg, mock_job):
     """Test check_artifacts_file_size evaluates to `False`
     if no content-length header is provided."""
-    mock_session_large = create_mock_client_response(mocker)
+    mock_session_large = create_mock_client_response()
 
     result_large = await check_artifacts_file_size(
         gitlab_cfg=gitlab_cfg, job=mock_job, http_session=mock_session_large
@@ -516,17 +499,15 @@ async def test_check_artifacts_file_no_content_length(
 
 
 @pytest.mark.asyncio
-async def test_check_artifacts_file_size_handles_http_error(
-    mocker: MockerFixture, gitlab_cfg, mock_job
-):
+async def test_check_artifacts_file_size_handles_http_error(gitlab_cfg, mock_job):
     """Test that check_artifacts_file_size raises an HTTPException if the HEAD
     request fails.
     """
-    mock_session = create_mock_client_response(mocker, 4096)
+    mock_session = create_mock_client_response(content_length=4096)
     # Configure the mock to raise a ClientResponseError, which is what aiohttp does on 4xx/5xx
     mock_session.head.side_effect = aiohttp.ClientResponseError(
-        request_info=mocker.Mock(),
-        history=mocker.Mock(),
+        request_info=MagicMock(),
+        history=MagicMock(),
         status=404,
         message="Not Found",
     )
@@ -540,7 +521,7 @@ async def test_check_artifacts_file_size_handles_http_error(
 
 
 @pytest.mark.asyncio
-async def test_architecture_prioritization(mocker: MockerFixture, gitlab_cfg, mock_job):
+async def test_architecture_prioritization(gitlab_cfg, mock_job):
     """Test that the correct architecture is chosen when multiple have failed.
     x86_64 should be preferred over aarch64.
     """
@@ -552,22 +533,21 @@ async def test_architecture_prioritization(mocker: MockerFixture, gitlab_cfg, mo
         "kojilogs/aarch64-build/x86_64-build/root.log": "x86_64 failure",
     }
     zip_content = create_zip_archive(files)
-    mock_artifact_download(mocker, zip_content)
-    mocker.patch(
-        "logdetective.server.gitlab.check_artifacts_file_size", return_value=True
-    )
-    mock_session = mocker.AsyncMock()
-
-    log_url, log_text = await retrieve_and_preprocess_koji_logs(
-        gitlab_cfg=gitlab_cfg, job=mock_job, http_session=mock_session
-    )
+    with (
+        mock_artifact_download(zip_content),
+        patch("logdetective.server.gitlab.check_artifacts_file_size", return_value=True),
+    ):
+        mock_session = AsyncMock()
+        log_url, log_text = await retrieve_and_preprocess_koji_logs(
+            gitlab_cfg=gitlab_cfg, job=mock_job, http_session=mock_session
+        )
 
     assert "x86_64-build/root.log" in log_url
     assert log_text == "x86_64 failure"
 
 
 @pytest.mark.asyncio
-async def test_toplevel_failure_fallback(mocker: MockerFixture, gitlab_cfg, mock_job):
+async def test_toplevel_failure_fallback(gitlab_cfg, mock_job):
     """Test that a top-level failure is handled correctly when no specific
     architecture has failed.
     """
@@ -576,24 +556,21 @@ async def test_toplevel_failure_fallback(mocker: MockerFixture, gitlab_cfg, mock
         "kojilogs/noarch-build/x86_64-build/build.log": "this one didn't fail",
     }
     zip_content = create_zip_archive(files)
-    mock_artifact_download(mocker, zip_content)
-    mocker.patch(
-        "logdetective.server.gitlab.check_artifacts_file_size", return_value=True
-    )
-    mock_session = mocker.AsyncMock()
-
-    log_url, log_text = await retrieve_and_preprocess_koji_logs(
-        gitlab_cfg=gitlab_cfg, job=mock_job, http_session=mock_session
-    )
+    with (
+        mock_artifact_download(zip_content),
+        patch("logdetective.server.gitlab.check_artifacts_file_size", return_value=True),
+    ):
+        mock_session = AsyncMock()
+        log_url, log_text = await retrieve_and_preprocess_koji_logs(
+            gitlab_cfg=gitlab_cfg, job=mock_job, http_session=mock_session
+        )
 
     assert "kojilogs/noarch-build/task_failed.log" in log_url
     assert log_text == "Target build already exists"
 
 
 @pytest.mark.asyncio
-async def test_unrecognized_architecture_handling(
-    mocker: MockerFixture, gitlab_cfg, mock_job
-):
+async def test_unrecognized_architecture_handling(gitlab_cfg, mock_job):
     """Test that if only unrecognized architectures have failed, one is
     chosen alphabetically.
     """
@@ -605,15 +582,14 @@ async def test_unrecognized_architecture_handling(
         "kojilogs/noarch-build/b-arch-build/build.log": "b-arch failure",
     }
     zip_content = create_zip_archive(files)
-    mock_artifact_download(mocker, zip_content)
-    mocker.patch(
-        "logdetective.server.gitlab.check_artifacts_file_size", return_value=True
-    )
-    mock_session = mocker.AsyncMock()
-
-    log_url, log_text = await retrieve_and_preprocess_koji_logs(
-        gitlab_cfg=gitlab_cfg, job=mock_job, http_session=mock_session
-    )
+    with (
+        mock_artifact_download(zip_content),
+        patch("logdetective.server.gitlab.check_artifacts_file_size", return_value=True),
+    ):
+        mock_session = AsyncMock()
+        log_url, log_text = await retrieve_and_preprocess_koji_logs(
+            gitlab_cfg=gitlab_cfg, job=mock_job, http_session=mock_session
+        )
 
     # Should pick 'a-arch' as it comes first alphabetically
     assert "a-arch-build/build.log" in log_url

--- a/tests/server/test_server_koji.py
+++ b/tests/server/test_server_koji.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 import koji
 import pytest
 from beeai_framework.backend import ChatModel
@@ -23,9 +23,9 @@ from tests.server.test_helpers import (
 
 @pytest.mark.parametrize("arch", ARCHES)
 @pytest.mark.asyncio
-async def test_koji_get_failed_subtask_info(mocker, arch):
+async def test_koji_get_failed_subtask_info(arch):
     # Mock the Koji session
-    mock_session = mocker.Mock()
+    mock_session = MagicMock()
 
     # Mock the parent task info
     mock_session.getTaskInfo.return_value = {
@@ -67,11 +67,11 @@ async def test_koji_get_failed_subtask_info(mocker, arch):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("method", SIMPLE_METHODS)
 @pytest.mark.parametrize("taskid,arch", SUBTASK_ARCHES)
-async def test_koji_get_failed_subtask_info_arches(mocker, taskid, arch, method):
+async def test_koji_get_failed_subtask_info_arches(taskid, arch, method):
     """Test retrieval of substasks for tasks of type `buildArch` or `buildSRPMFromSCM`.
     These should be returned directly, without going trough architectures."""
     # Mock the Koji session
-    mock_session = mocker.Mock()
+    mock_session = MagicMock()
 
     mock_session.getTaskInfo.return_value = {
         "state": koji.TASK_STATES["FAILED"],
@@ -95,9 +95,9 @@ async def test_koji_get_failed_subtask_info_arches(mocker, taskid, arch, method)
 
 @pytest.mark.parametrize("method", SIMPLE_METHODS)
 @pytest.mark.asyncio
-async def test_koji_get_failed_subtask_from_canceledtask(mocker, method):
+async def test_koji_get_failed_subtask_from_canceledtask(method):
     # Mock the Koji session
-    mock_session = mocker.Mock()
+    mock_session = MagicMock()
 
     # Mock the parent task info
     mock_session.getTaskInfo.return_value = {
@@ -143,11 +143,11 @@ async def test_koji_get_failed_subtask_from_canceledtask(mocker, method):
 
 @pytest.mark.parametrize("method", SIMPLE_METHODS)
 @pytest.mark.asyncio
-async def test_koji_get_failed_log_from_task(mocker, method):
+async def test_koji_get_failed_log_from_task(method):
     task_id = EXAMPLE_TASK_ID
 
     # Mock the Koji session
-    mock_session = create_mock_koji_session(mocker, task_id, method)
+    mock_session = create_mock_koji_session(task_id, method)
 
     # Test getting log from a failed task
     log_file, log_contents = await get_failed_log_from_task(
@@ -167,12 +167,12 @@ async def test_koji_get_failed_log_from_task(mocker, method):
 
 @pytest.mark.parametrize("method", SIMPLE_METHODS)
 @pytest.mark.asyncio
-async def test_koji_get_failed_log_from_task_logs_too_large(mocker, method):
+async def test_koji_get_failed_log_from_task_logs_too_large(method):
     """Test that attempt to download log larger than a limit raises an exception."""
     task_id = EXAMPLE_TASK_ID
 
     # Mock the Koji session
-    mock_session = create_mock_koji_session(mocker, task_id, method)
+    mock_session = create_mock_koji_session(task_id, method)
 
     # Test getting a log that is too large
     with pytest.raises(LogsTooLargeError):
@@ -187,14 +187,12 @@ async def test_koji_get_failed_log_from_task_logs_too_large(mocker, method):
 
 @pytest.mark.parametrize("method", SIMPLE_METHODS)
 @pytest.mark.asyncio
-async def test_koji_get_failed_log_from_task_log_missing(mocker, method):
+async def test_koji_get_failed_log_from_task_log_missing(method):
     """Test that attempt to download log larger than a limit raises an exception."""
     task_id = EXAMPLE_TASK_ID
 
     # Mock the Koji session
-    mock_session = create_mock_koji_session(
-        mocker, task_id, method, list_task_output=False
-    )
+    mock_session = create_mock_koji_session(task_id, method, list_task_output=False)
 
     # Test getting a log that is too large
     with pytest.raises(LogsMissingError):
@@ -208,17 +206,18 @@ async def test_koji_get_failed_log_from_task_log_missing(mocker, method):
 
 
 @pytest.fixture
-def mock_analysis(mocker, request):
+def mock_analysis(request):
     """Fixture to mock analyze_artifacts directly at the server level."""
     message = getattr(request, "param", "This is a mock message")
     mock_response = APIResponse(
         explanation=Explanation(text=message),
         snippets=None
     )
-    return mocker.patch(
+    with patch(
         "logdetective.server.server.analyze_artifacts",
         AsyncMock(return_value=mock_response)
-    )
+    ) as mock:
+        yield mock
 
 
 @pytest.mark.parametrize(
@@ -226,11 +225,11 @@ def mock_analysis(mocker, request):
 )
 @pytest.mark.parametrize("method", SIMPLE_METHODS)
 @pytest.mark.asyncio
-async def test_koji_analyze_koji_task(mocker, method, mock_analysis):
+async def test_koji_analyze_koji_task(method, mock_analysis):
     async with DatabaseFactory().make_new_db() as _:
         # Mock the KojiInstanceConfig
-        mock_koji_instance_config = mocker.Mock()
-        mock_koji_conn = create_mock_koji_session(mocker, EXAMPLE_TASK_ID, method)
+        mock_koji_instance_config = MagicMock()
+        mock_koji_conn = create_mock_koji_session(EXAMPLE_TASK_ID, method)
         mock_koji_instance_config.get_connection.return_value = mock_koji_conn
         mock_koji_instance_config.max_artifact_size = mib_to_bytes(1)
         mock_koji_instance_config.name = "fedora"

--- a/tests/server/test_server_metric.py
+++ b/tests/server/test_server_metric.py
@@ -1,11 +1,10 @@
 import datetime
 from typing import Callable
+from types import SimpleNamespace
 
 import pytest
 import aiohttp
 import aioresponses
-
-from flexmock import flexmock
 
 from logdetective.server.database.models import AnalyzeRequestMetrics, EndpointType
 from logdetective.server.models import Explanation, TimePeriod, MetricTimeSeries
@@ -38,10 +37,10 @@ from tests.server.test_helpers import (
 @pytest.mark.parametrize(
     "response",
     [
-        flexmock(
+        SimpleNamespace(
             explanation=Explanation(text="abc")
         ),
-        flexmock(),  # mimic StreamResponse
+        SimpleNamespace(),  # mimic StreamResponse
     ],
 )
 @pytest.mark.asyncio

--- a/tests/server/test_server_models.py
+++ b/tests/server/test_server_models.py
@@ -1,9 +1,10 @@
 import datetime
-import pytest
-from pytest_mock import MockerFixture
-import yaml
+from unittest.mock import patch
 
+import pytest
+import yaml
 from pydantic import ValidationError
+
 from logdetective.server.models import (
     TimePeriod,
     Config,
@@ -11,8 +12,6 @@ from logdetective.server.models import (
     ArtifactFile,
     AnalysisRequest,
 )
-from logdetective.constants import DEFAULT_MAXIMUM_ARTIFACT_MIB
-from logdetective.utils import mib_to_bytes
 
 
 def test_TimePeriod():
@@ -60,19 +59,18 @@ def test_default_initialization_and_configuration():
     assert not config.python_traceback
 
 
-def test_initialization_with_custom_data(mocker: MockerFixture):
+def test_initialization_with_custom_data():
     """Tests that ExtractorConfig correctly uses custom values from a provided
     data dictionary and instantiates all relevant extractors.
     """
-    mocker.patch("logdetective.server.models.check_csgrep", return_value=True)
-
     custom_data = {
         "max_clusters": 15,
         "verbose": True,
         "max_snippet_len": 500,
         "csgrep": True,
     }
-    config = ExtractorConfig.model_validate(custom_data)
+    with patch("logdetective.server.models.check_csgrep", return_value=True):
+        config = ExtractorConfig.model_validate(custom_data)
 
     assert config.max_clusters == 15
     assert config.verbose is True


### PR DESCRIPTION
Three different libraries were used -> `pytest-mock`, `flexmock`, `unittest.mock`
Even though IMO `unittest.mock` has somewhat cumbersome syntax (due to indentation of `patch` context), it was used the most across the codebase and is a part of python standard library, so the other two dependencies can be removed.

NOTE: This change does not depend on anything, but I wonder if maybe we should rebase it on the `ld_v5` branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized test mocking on Python’s built-in `unittest.mock` tools.
  * Removed reliance on legacy mocking utilities and related test fixtures.
  * Updated test helpers and configurations to use context-managed mocks.

* **Documentation**
  * Updated testing guidance to reflect the supported mocking approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->