### PR TITLE
Set version to 4.10.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "logdetective"
-version = "4.10.1"
+version = "4.10.2"
 description = "Analyze logs with a template miner and an LLM to discover errors and suggest solutions."
 authors = [
     { name="Jiri Podivin", email="jpodivin@gmail.com" }


### PR DESCRIPTION
I think we should have at least one last release before we move to v5. This is mainly because I wanted to deploy the fix of thread-creating issues with ONNX.

Changes since 4.10.1 warranted only a patch release, we have only fixed bugs and resolved some security issues.